### PR TITLE
Resolve type and term references to symbols

### DIFF
--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -3,11 +3,20 @@ package tastyquery.ast
 import scala.collection.mutable
 import tastyquery.ast.Names.*
 import dotty.tools.tasty.TastyFormat.NameTags
-import tastyquery.ast.Trees.{Tree, EmptyTree}
+import tastyquery.ast.Trees.{EmptyTree, Tree}
 
 object Symbols {
-  class SymbolLookupException(name: Name)
-      extends RuntimeException(s"Could not find symbol for name ${name.toDebugString}")
+  class SymbolLookupException(val name: Name, explanation: String = "")
+      extends RuntimeException(
+        SymbolLookupException.addExplanation(s"Could not find symbol for name ${name.toDebugString}", explanation)
+      )
+
+  object SymbolLookupException {
+    def unapply(e: SymbolLookupException): Option[Name] = Some(e.name)
+
+    def addExplanation(msg: String, explanation: String): String =
+      if (explanation.isEmpty) msg else s"$msg: $explanation"
+  }
 
   val NoSymbol = new RegularSymbol(Names.EmptyTermName, null)
 

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -1,14 +1,22 @@
 package tastyquery.ast
 
 import scala.collection.mutable
-import tastyquery.ast.Names._
-
+import tastyquery.ast.Names.*
 import dotty.tools.tasty.TastyFormat.NameTags
+import tastyquery.ast.Trees.{Tree, EmptyTree}
 
 object Symbols {
   val NoSymbol = new RegularSymbol(Names.EmptyTermName, null)
 
   abstract class Symbol private[Symbols] (val name: Name, val owner: Symbol) {
+    protected var myTree: Tree = EmptyTree
+    // overridden in package symbol
+    def withTree(t: Tree): this.type = {
+      myTree = t
+      this
+    }
+    final def tree: Tree = myTree
+
     override def toString: String = s"symbol[$name]"
     def toDebugString = toString
   }
@@ -57,6 +65,10 @@ object Symbols {
 
     private def getPackageDecl(packageName: TermName): Option[PackageClassSymbol] =
       getDecl(packageName).map(_.asInstanceOf[PackageClassSymbol])
+
+    override def withTree(t: Tree): PackageClassSymbol.this.type = throw new UnsupportedOperationException(
+      s"Multiple trees correspond to one package, a single tree cannot be assigned"
+    )
   }
 
   abstract class SymbolFactory[T <: Symbol] {

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -6,6 +6,9 @@ import dotty.tools.tasty.TastyFormat.NameTags
 import tastyquery.ast.Trees.{Tree, EmptyTree}
 
 object Symbols {
+  class SymbolLookupException(name: Name)
+      extends RuntimeException(s"Could not find symbol for name ${name.toDebugString}")
+
   val NoSymbol = new RegularSymbol(Names.EmptyTermName, null)
 
   abstract class Symbol private[Symbols] (val name: Name, val owner: Symbol) {

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -2,13 +2,20 @@ package tastyquery.ast
 
 import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names.{Name, TermName, TypeName}
-import tastyquery.ast.Types.{Type, TypeBounds}
+import tastyquery.ast.Types.{NoType, Type, TypeBounds}
 import tastyquery.ast.TypeTrees.*
 import tastyquery.ast.Symbols.{ClassSymbol, NoSymbol, PackageClassSymbol, RegularSymbol, Symbol}
 
 object Trees {
 
-  abstract class Tree
+  abstract class Tree {
+    protected var myType: Type = NoType
+
+    protected def calculateType(): Type = throw UnsupportedOperationException(s"Can't calculate type of $this")
+    final def tpe: Type =
+      if (myType == NoType) calculateType()
+      myType
+  }
 
   trait DefTree(val symbol: Symbol)
 
@@ -70,7 +77,9 @@ object Trees {
   /** mods val name: tpt = rhs */
   case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: RegularSymbol)
       extends Tree
-      with DefTree(symbol)
+      with DefTree(symbol) {
+    override protected def calculateType(): Type = tpt.toType
+  }
 
   type ParamsClause = List[ValDef] | List[TypeParam]
 

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -12,9 +12,10 @@ object Trees {
     protected var myType: Type = NoType
 
     protected def calculateType(): Type = throw UnsupportedOperationException(s"Can't calculate type of $this")
-    final def tpe: Type =
-      if (myType == NoType) calculateType()
+    final def tpe: Type = {
+      if (myType == NoType) myType = calculateType()
       myType
+    }
   }
 
   trait DefTree(val symbol: Symbol)

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -7,11 +7,16 @@ import tastyquery.ast.TypeTrees.*
 import tastyquery.ast.Symbols.{ClassSymbol, NoSymbol, PackageClassSymbol, RegularSymbol, Symbol}
 
 object Trees {
+  class TypeComputationError(val tree: Tree) extends RuntimeException(s"Could not compute type of $tree")
+
+  object TypeComputationError {
+    def unapply(e: TypeComputationError): Option[Tree] = Some(e.tree)
+  }
 
   abstract class Tree {
     protected var myType: Type = NoType
 
-    protected def calculateType(): Type = throw UnsupportedOperationException(s"Can't calculate type of $this")
+    protected def calculateType(): Type = throw new TypeComputationError(this)
     final def tpe: Type = {
       if (myType == NoType) myType = calculateType()
       myType

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -3,16 +3,30 @@ package tastyquery.ast
 import tastyquery.ast.Names.{EmptyTermName, EmptyTypeName, TypeName}
 import tastyquery.ast.Symbols.RegularSymbol
 import tastyquery.ast.Trees.{DefTree, Tree, TypeParam}
-import tastyquery.ast.Types.{Type, TypeBounds}
+import tastyquery.ast.Types.{NoType, Type, TypeBounds}
 
 object TypeTrees {
-  abstract class TypeTree
+  abstract class TypeTree {
+    protected var tpe: Type = NoType
+
+    protected def calculateType(): Type = throw UnsupportedOperationException(s"Can't convert $this to type")
+    final def toType: Type = {
+      if (tpe == NoType) tpe = calculateType()
+      tpe
+    }
+    final def withType(typ: Type): this.type = {
+      tpe = typ
+      this
+    }
+  }
 
   case class TypeIdent(name: TypeName) extends TypeTree
 
   object EmptyTypeIdent extends TypeIdent(EmptyTypeName)
 
-  case class TypeWrapper(tp: Type) extends TypeTree
+  case class TypeWrapper(tp: Type) extends TypeTree {
+    override protected def calculateType(): Type = tp
+  }
 
   /** ref.type */
   case class SingletonTypeTree(ref: Tree) extends TypeTree

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -6,10 +6,16 @@ import tastyquery.ast.Trees.{DefTree, Tree, TypeParam}
 import tastyquery.ast.Types.{NoType, Type, TypeBounds}
 
 object TypeTrees {
+  class TypeTreeToTypeError(val typeTree: TypeTree) extends RuntimeException(s"Could not convert $typeTree to type")
+
+  object TypeTreeToTypeError {
+    def unapply(e: TypeTreeToTypeError): Option[TypeTree] = Some(e.typeTree)
+  }
+
   abstract class TypeTree {
     protected var tpe: Type = NoType
 
-    protected def calculateType(): Type = throw UnsupportedOperationException(s"Can't convert $this to type")
+    protected def calculateType(): Type = throw new TypeTreeToTypeError(this)
     final def toType: Type = {
       if (tpe == NoType) tpe = calculateType()
       tpe

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -1,5 +1,6 @@
 package tastyquery.ast
 
+import tastyquery.Contexts.BaseContext
 import tastyquery.ast.Constants.Constant
 import tastyquery.ast.Names.{Name, TermName, TypeName}
 import tastyquery.ast.Symbols.Symbol
@@ -20,7 +21,7 @@ object Types {
   abstract class TypeProxy extends Type {
 
     /** The type to which this proxy forwards operations. */
-    def underlying: Type
+    def underlying(using BaseContext): Type
   }
 
   /** Non-proxy types */
@@ -103,7 +104,7 @@ object Types {
 
     override protected def designator_=(d: Designator): Unit = myDesignator = d
 
-    override def underlying: Type = ???
+    override def underlying(using ctx: BaseContext): Type = ???
 
     override def isOverloaded: Boolean = ???
 
@@ -131,7 +132,7 @@ object Types {
 
     override protected def designator_=(d: Designator): Unit = myDesignator = d
 
-    override def underlying: Type = ???
+    override def underlying(using BaseContext): Type = ???
   }
 
   case object NoPrefix extends Type
@@ -140,43 +141,43 @@ object Types {
   class PackageTypeRef(packageName: Name) extends TypeRef(NoPrefix, packageName)
 
   case class ThisType(tref: TypeRef) extends TypeProxy with SingletonType {
-    override def underlying: Type = ???
+    override def underlying(using BaseContext): Type = ???
   }
 
   /** A constant type with single `value`. */
   case class ConstantType(value: Constant) extends TypeProxy with SingletonType {
-    override def underlying: Type = ???
+    override def underlying(using BaseContext): Type = ???
   }
 
   /** A type application `C[T_1, ..., T_n]`
     * Typebounds for wildcard application: C[_], C[?]
     */
   case class AppliedType(tycon: Type, args: List[Type | TypeBounds]) extends TypeProxy with ValueType {
-    override def underlying: Type = tycon
+    override def underlying(using BaseContext): Type = tycon
   }
 
   /** A by-name parameter type of the form `=> T`, or the type of a method with no parameter list. */
   case class ExprType(resType: Type) extends TypeProxy with MethodicType {
-    override def underlying: Type = resType
+    override def underlying(using BaseContext): Type = resType
   }
 
   case class TypeLambda(params: List[TypeParam], resultTypeCtor: TypeLambda => Type) extends TypeProxy with TermType {
     val resultType = resultTypeCtor(this)
 
-    override def underlying: Type = ???
+    override def underlying(using BaseContext): Type = ???
 
     override def toString: String = s"TypeLambda($params, $resultType)"
   }
 
   case class TypeParamRef(binder: TypeLambda, num: Int) extends TypeProxy with ValueType {
-    override def underlying: Type = ???
+    override def underlying(using BaseContext): Type = ???
 
     override def toString: String = binder.params(num).name.toString
   }
 
   /** typ @ annot */
   case class AnnotatedType(typ: Type, annotation: Tree) extends TypeProxy with ValueType {
-    override def underlying: Type = typ
+    override def underlying(using BaseContext): Type = typ
   }
 
   /** A refined type parent { refinement }
@@ -185,7 +186,7 @@ object Types {
     *  @param refinedInfo The info of the refinement declaration
     */
   case class RefinedType(parent: Type, refinedName: Name, refinedInfo: TypeBounds) extends TypeProxy with ValueType {
-    override def underlying: Type = parent
+    override def underlying(using BaseContext): Type = parent
   }
 
   trait TypeBounds(low: Type, high: Type)
@@ -193,7 +194,7 @@ object Types {
   case class RealTypeBounds(low: Type, high: Type) extends TypeBounds(low, high)
 
   case class TypeAlias(alias: Type) extends TypeProxy with TypeBounds(alias, alias) {
-    override def underlying: Type = alias
+    override def underlying(using BaseContext): Type = alias
   }
 
   // ----- Ground Types -------------------------------------------------

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -128,7 +128,10 @@ object Types {
 
     override protected def designator_=(d: Designator): Unit = myDesignator = d
 
-    override def underlying(using ctx: BaseContext): Type = ???
+    override def underlying(using ctx: BaseContext): Type = {
+      val termSymbol = resolveToSymbol
+      termSymbol.tree.tpe
+    }
 
     override def isOverloaded: Boolean = ???
 

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -237,4 +237,6 @@ object Types {
   case class OrType(first: Type, second: Type) extends GroundType with ValueType
 
   case class AndType(first: Type, second: Type) extends GroundType with ValueType
+
+  case object NoType extends GroundType
 }

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -195,8 +195,20 @@ object Types {
     def underlyingRef: TermRef = this
   }
 
-  class PackageRef(val packageName: TermName) extends TermRef(NoPrefix, packageName) {
+  class PackageRef(val packageName: TermName) extends NamedType with SingletonType {
     var packageSymbol: PackageClassSymbol = null
+
+    override def designator: Designator =
+      if (packageSymbol == null) packageName else packageSymbol
+
+    override protected def designator_=(d: Designator): Unit = throw UnsupportedOperationException(
+      s"Can't assign designator of a package"
+    )
+
+    override def underlying(using BaseContext): Type = ???
+
+    // TODO: root package?
+    override val prefix: Type = NoType
 
     override def isStandard: Boolean = {
       def isStandard(name: TermName): Boolean =

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -1,10 +1,11 @@
 package tastyquery.ast
 
+import dotty.tools.tasty.TastyFormat.NameTags
 import tastyquery.Contexts.BaseContext
 import tastyquery.ast.Constants.Constant
-import tastyquery.ast.Names.{Name, TermName, TypeName}
-import tastyquery.ast.Symbols._
-import tastyquery.ast.Trees.{Tree, TypeParam}
+import tastyquery.ast.Names.{Name, QualifiedName, SimpleName, TermName, TypeName}
+import tastyquery.ast.Symbols.*
+import tastyquery.ast.Trees.{EmptyTree, Tree, TypeParam}
 
 object Types {
   type Designator = Symbol | Name
@@ -51,6 +52,8 @@ object Types {
 
   trait Symbolic {
     def resolveToSymbol(using BaseContext): Symbol
+
+    private[Types] def isStandard: Boolean
   }
 
   // ----- Type Proxies -------------------------------------------------
@@ -86,6 +89,34 @@ object Types {
       case sym: Symbol => sym.name
     }
 
+    /** This is a temprorary hack to create symbols for standard types and objects, because Java classes and
+      * Scala 2 standard library don't have .tasty files.
+      */
+    // overridden in package references
+    private[Types] def createStandardSymbol(name: Name)(using ctx: BaseContext): Symbol = {
+      val prefixSym = prefix.asInstanceOf[Symbolic] match {
+        case t: TermRef =>
+          val refType = t.underlying
+          if (!refType.isInstanceOf[Symbolic])
+            throw new ReferenceResolutionError(
+              t,
+              s"only references to terms, whose type is a combination of typeref, termref and thistype, are supported. Got type $refType"
+            )
+          refType.asInstanceOf[Symbolic].resolveToSymbol
+        case other => other.resolveToSymbol
+      }
+      val newSymbol = name match {
+        case tn: TypeName   => ClassSymbolFactory.createSymbol(name, prefixSym)
+        case sn: SimpleName => RegularSymbolFactory.createSymbol(name, prefixSym)
+        case _              => throw new SymbolLookupException(name, "unexpected name format")
+      }
+      prefixSym.asInstanceOf[DeclaringSymbol].addDecl(newSymbol)
+
+      newSymbol
+    }
+
+    override def isStandard: Boolean = prefix.asInstanceOf[Symbolic].isStandard
+
     // overridden in package references
     override def resolveToSymbol(using BaseContext): Symbol = {
       if (!designator.isInstanceOf[Symbol]) {
@@ -108,7 +139,7 @@ object Types {
         }
         designator = {
           val symOption = prefixSym.asInstanceOf[DeclaringSymbol].getDecl(name)
-          symOption.getOrElse(throw new SymbolLookupException(name))
+          symOption.getOrElse(if (isStandard) createStandardSymbol(name) else throw new SymbolLookupException(name))
         }
       }
       designator.asInstanceOf[Symbol]
@@ -165,12 +196,30 @@ object Types {
   }
 
   class PackageRef(val packageName: TermName) extends TermRef(NoPrefix, packageName) {
+    var packageSymbol: PackageClassSymbol = null
+
+    override def isStandard: Boolean = {
+      def isStandard(name: TermName): Boolean =
+        name match {
+          case QualifiedName(NameTags.QUALIFIED, prefix, _) => isStandard(prefix)
+          case SimpleName(name)                             => name == "java" || name == "scala"
+          case _ => throw IllegalArgumentException(s"Unexpected package name: $packageName")
+        }
+      isStandard(packageName)
+    }
+
+    override def createStandardSymbol(name: Name)(using ctx: BaseContext): Symbol =
+      ctx.createPackageSymbolIfNew(name.asInstanceOf[TermName], ctx.defn.RootPackage)
+
     override def resolveToSymbol(using ctx: BaseContext): PackageClassSymbol = {
-      val symOption = ctx.defn.RootPackage.findPackageSymbol(packageName)
-      if (symOption.isEmpty) {
-        throw new SymbolLookupException(packageName)
-      } else
-        symOption.get
+      if (packageSymbol == null) {
+        val symOption = ctx.defn.RootPackage.findPackageSymbol(packageName)
+        packageSymbol = symOption.getOrElse(
+          if (isStandard) ctx.createPackageSymbolIfNew(packageName, ctx.defn.RootPackage)
+          else throw new SymbolLookupException(packageName)
+        )
+      }
+      packageSymbol
     }
 
     override def toString: String = s"PackageRef($packageName)"
@@ -197,6 +246,11 @@ object Types {
   class PackageTypeRef(packageName: TermName) extends TypeRef(NoPrefix, packageName) {
     private val packageRef = PackageRef(packageName)
 
+    override def isStandard: Boolean = packageRef.isStandard
+
+    override private[Types] def createStandardSymbol(name: Name)(using BaseContext) =
+      packageRef.createStandardSymbol(name)
+
     override def resolveToSymbol(using BaseContext): Symbol = packageRef.resolveToSymbol
   }
 
@@ -204,6 +258,8 @@ object Types {
     override def underlying(using BaseContext): Type = ???
 
     override def resolveToSymbol(using BaseContext): Symbol = tref.resolveToSymbol
+
+    override private[Types] def isStandard = tref.isStandard
   }
 
   /** A constant type with single `value`. */

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -776,8 +776,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       reader.readByte()
       val typeName = readName.toTypeName
       val typ = readType
-      // TODO: assign type
-      TypeIdent(typeName)
+      TypeIdent(typeName).withType(typ)
     case SINGLETONtpt =>
       reader.readByte()
       SingletonTypeTree(readTerm)


### PR DESCRIPTION
This PR introduces resolution of TermRef and TypeRef to their corresponding symbols.

In addition, this PR creates "standard" (`java.*` and `scala.*`) symbols in case they are not found. This is a temporary replacement for reading standard library.