### PR TITLE
upgrade scalafmt to 3.1.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,11 +1,12 @@
-version = "2.7.5"
-runner.dialect = dotty
+version = "3.1.2"
+runner.dialect = scala3
 maxColumn = 120
 align.preset = most
 align.multiline = false
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-docstrings = JavaDoc
+docstrings.style = Asterisk
+docstrings.wrap = no
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
 danglingParentheses.preset = true


### PR DESCRIPTION
updates the `docstrings` settings to keep same behaviour in the newer scalafmt