### PR TITLE
do not decode package names from classpath

### DIFF
--- a/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
+++ b/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
@@ -51,8 +51,7 @@ object ClasspathLoaders {
         if (lastSep == -1) (nme.EmptyPackageName, termName(NameTransformer.decode(name)))
         else
           import scala.language.unsafeNulls
-          val pre = name.substring(0, lastSep)
-          val packageName = pre.split('.').map(NameTransformer.decode).mkString(".")
+          val packageName = name.substring(0, lastSep) // Do not decode package names
           val simpleName = NameTransformer.decode(name.substring(lastSep + 1))
           (termName(packageName), termName(simpleName))
       }

--- a/jvm/src/test/scala/SymbolSuite.scala
+++ b/jvm/src/test/scala/SymbolSuite.scala
@@ -9,7 +9,6 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
 
   val empty_class = name"empty_class".singleton
   val simple_trees = name"simple_trees".singleton
-  val symbolic_>> = name"symbolic_>>".singleton
   val `simple_trees.nested` = simple_trees / name"nested"
 
   def getUnpicklingContext(path: TopLevelDeclPath): FileContext =
@@ -64,12 +63,11 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
     )
   }
 
-  test("basic-symbol-structure-symbolic-names".ignore) {
-    // TODO: this test is inconsistent as long as https://github.com/lampepfl/dotty/issues/14448 is unresolved.
-    val symbolicClassInSymbollicPackage = symbolic_>> / tname"#::" // these will be encoded in the class path
-    val ctx = getUnpicklingContext(symbolicClassInSymbollicPackage)
-    assertContainsDeclaration(ctx, symbolicClassInSymbollicPackage)
-    assertContainsExactly(ctx, symbolic_>>, Set(symbolic_>> / tname"#::", symbolic_>> / tname"#::" / name"<init>"))
+  test("fail-on-symbolic-package:it-should-be-missing") {
+    intercept[MissingTopLevelDecl] {
+      getUnpicklingContext(name"symbolic_>>" / tname"#::") // this will fail, we can't find a symbolic package
+    }
+    val ctx = getUnpicklingContext(name"symbolic_$$greater$$greater" / tname"#::") // can only find encoded version
   }
 
   test("basic-symbol-structure-nested") {


### PR DESCRIPTION
we will not do anything in dotty compiler to special case symbolic package names, so error when user tries to find a symbolic package name.