### PR TITLE
create top level classes before reading tasty

### DIFF
--- a/jvm/src/main/scala/Main.scala
+++ b/jvm/src/main/scala/Main.scala
@@ -15,7 +15,7 @@ object Main {
         val reader = new ProjectReader
         val cpElems = ClasspathLoaders.splitClasspath(cp)
         val classpath = ClasspathLoaders.read(cpElems, Set(ClasspathLoaders.FileKind.Tasty))
-        given BaseContext = Contexts.empty(classpath)
+        given BaseContext = Contexts.init(classpath)
         reader.read(classes*)
       case _ =>
         println("""Usage:

--- a/jvm/src/test/scala/tastyquery/BaseUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/BaseUnpicklingSuite.scala
@@ -41,7 +41,7 @@ abstract class BaseUnpicklingSuite(withClasses: Boolean, withStdLib: Boolean) ex
       extends Exception(s"Missing top-level declaration ${path.fullClassName}, perhaps it is not on the classpath?")
 
   private def findTopLevelClass(path: TopLevelDeclPath): (BaseContext, ClassSymbol) = {
-    val base: BaseContext = Contexts.empty(testClasspath)
+    val base: BaseContext = Contexts.init(testClasspath)
     val classRoot = base.getClassIfDefined(path.fullClassName) match
       case Some(cls) => cls
       case _         => throw MissingTopLevelDecl(path)

--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1,3 +1,5 @@
+package tastyquery
+
 import tastyquery.Contexts
 import tastyquery.ast.Constants.{ClazzTag, Constant, IntTag, NullTag}
 import tastyquery.ast.Names.*
@@ -7,8 +9,6 @@ import tastyquery.ast.TypeTrees.*
 import tastyquery.ast.Types.*
 import tastyquery.reader.TastyUnpickler
 import dotty.tools.tasty.TastyFormat.NameTags
-
-import java.nio.file.{Files, Paths}
 
 class ReadTreeSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false) {
   import BaseUnpicklingSuite.Decls.*

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -201,6 +201,6 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
       // package in tasty - the owners of the classroot do not match
       forceTopLevel(`symbolic_$greater$greater.#::`)
 
-    runTest(using Contexts.empty(testClasspath))
+    runTest(using Contexts.init(testClasspath))
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -4,12 +4,14 @@ import dotty.tools.tasty.TastyBuffer.Addr
 import dotty.tools.tasty.TastyFormat.NameTags
 import tastyquery.ast.Names.*
 import tastyquery.ast.Symbols.*
-import tastyquery.ast.Types.Binders
+import tastyquery.ast.Types.{Type, Symbolic, Binders, PackageRef, TypeRef}
 
 import scala.collection.mutable
 import scala.collection.mutable.HashMap
 import tastyquery.reader.classfiles.Classpaths
 import tastyquery.reader.classfiles.Classpaths.Classpath
+import scala.util.Try
+import scala.util.control.NonFatal
 
 object Contexts {
 
@@ -18,6 +20,12 @@ object Contexts {
   transparent inline def baseCtx(using baseCtx: BaseContext): BaseContext = baseCtx
   transparent inline def clsCtx(using clsCtx: ClassContext): ClassContext = clsCtx
   transparent inline def defn(using baseCtx: BaseContext): baseCtx.defn.type = baseCtx.defn
+
+  object permissions:
+    opaque type InitAll = Unit
+
+    private[Contexts] inline def withInitAllPrivelege[T](inline op: InitAll ?=> T): T =
+      op(using ())
 
   def empty: BaseContext =
     new BaseContext(new Definitions(), Classpaths.Classpath.Empty.loader)
@@ -33,31 +41,70 @@ object Contexts {
   def empty(classpath: Classpath): BaseContext =
     new BaseContext(new Definitions(), classpath.loader)
 
+  private[Contexts] def moduleClassRoot(classRoot: ClassSymbol): ClassSymbol = {
+    val pkg = classRoot.enclosingDecl
+    ClassSymbolFactory.castSymbol(pkg.getDecl(classRoot.name.toTypeName.toObjectName).get)
+  }
+
+  private[Contexts] def moduleRoot(classRoot: ClassSymbol): RegularSymbol = {
+    val pkg = classRoot.enclosingDecl
+    RegularSymbolFactory.castSymbol(pkg.getDecl(classRoot.name.toTermName).get)
+  }
+
+  private[tastyquery] def initialisedRoot(classRoot: ClassSymbol): Boolean =
+    classRoot.initialised || moduleClassRoot(classRoot).initialised
+
   /** BaseContext is used throughout unpickling an entire project. */
   class BaseContext private[Contexts] (val defn: Definitions, val classloader: Classpaths.Loader) {
-    def withFile(filename: String): FileContext =
-      new FileContext(defn, defn.RootPackage, filename, classloader)
 
-    def withRoot(root: ClassSymbol)(using classloader.LoadRoot): ClassContext =
+    private inline given thisCtx: this.type = this
+
+    def withFile(root: ClassSymbol, filename: String)(using Classpaths.permissions.LoadRoot): FileContext =
+      new FileContext(defn, root, filename, classloader)
+
+    def withRoot(root: ClassSymbol)(using Classpaths.permissions.LoadRoot): ClassContext =
       new ClassContext(defn, classloader, root)
 
-    def createClassSymbolIfNew(name: Name, owner: DeclaringSymbol): ClassSymbol =
-      owner.getDecl(name) match {
+    def getClassIfDefined(fullClassName: String): Option[ClassSymbol] =
+      def packageAndClass(fullClassName: String): TypeRef = {
+        val lastSep = fullClassName.lastIndexOf('.')
+        if (lastSep == -1) TypeRef(PackageRef(nme.EmptyPackageName), typeName(fullClassName))
+        else {
+          import scala.language.unsafeNulls
+          val packageName = fullClassName.substring(0, lastSep)
+          val className = typeName(fullClassName.substring(lastSep + 1))
+          TypeRef(PackageRef(classloader.toPackageName(packageName)), className)
+        }
+      }
+      val typeRef = packageAndClass(fullClassName)
+      permissions.withInitAllPrivelege(classloader.initPackages())
+      val symOpt =
+        try Some(typeRef.resolveToSymbol)
+        catch
+          case NonFatal(e) =>
+            println(s"[error] Cannot resolve class $fullClassName: $e")
+            None
+      symOpt match
+        case Some(cls: ClassSymbol) => Some(cls)
+        case _                      => None
+
+    def createClassSymbol(name: Name, owner: DeclaringSymbol): ClassSymbol =
+      owner.getDecl(name) match
         case None =>
           val cls = ClassSymbolFactory.createSymbol(name, owner)
           owner.addDecl(cls)
           cls
-        case Some(clazz) => ClassSymbolFactory.castSymbol(clazz)
-      }
+        case some =>
+          throw ExistingDefinitionException(owner, name)
 
-    def createSymbolIfNew(name: Name, owner: DeclaringSymbol): RegularSymbol =
-      owner.getDecl(name) match {
+    def createSymbol(name: Name, owner: DeclaringSymbol): RegularSymbol =
+      owner.getDecl(name) match
         case None =>
           val sym = RegularSymbolFactory.createSymbol(name, owner)
           owner.addDecl(sym)
           sym
-        case Some(sym) => RegularSymbolFactory.castSymbol(sym)
-      }
+        case some =>
+          throw ExistingDefinitionException(owner, name)
 
     def createPackageSymbolIfNew(name: TermName, owner: PackageClassSymbol): PackageClassSymbol = {
       def create(): PackageClassSymbol = {
@@ -96,24 +143,18 @@ object Contexts {
 
     def classRoot: ClassSymbol = owner
 
-    def moduleClassRoot: ClassSymbol = {
-      val pkg = classRoot.enclosingDecl
-      pkg.getDecl(classRoot.name.toTypeName.toObjectName).get.asInstanceOf[ClassSymbol]
-    }
+    def moduleClassRoot: ClassSymbol = Contexts.moduleClassRoot(classRoot)
 
-    def moduleRoot: RegularSymbol = {
-      val pkg = classRoot.enclosingDecl
-      pkg.getDecl(classRoot.name.toTermName).get.asInstanceOf[RegularSymbol]
-    }
+    def moduleRoot: RegularSymbol = Contexts.moduleRoot(classRoot)
 
-    def createSymbolIfNew[T <: Symbol](name: Name, factory: SymbolFactory[T], addToDecls: Boolean = false): T =
-      owner.getDecl(name) match {
-        case Some(sym) => factory.castSymbol(sym)
-        case _ =>
+    def createSymbol[T <: Symbol](name: Name, factory: SymbolFactory[T], addToDecls: Boolean = false): T =
+      owner.getDecl(name) match
+        case None =>
           val sym = factory.createSymbol(name, owner)
           if (addToDecls) owner.addDecl(sym)
           sym
-      }
+        case some =>
+          throw ExistingDefinitionException(owner, name)
 
   }
 
@@ -141,19 +182,25 @@ object Contexts {
     */
   class FileContext private[Contexts] (
     override val defn: Definitions,
+    val classRoot: ClassSymbol,
     val owner: Symbol,
     private val fileLocalInfo: FileLocalInfo,
     override val classloader: Classpaths.Loader
   ) extends BaseContext(defn, classloader) { base =>
-    def this(defn: Definitions, owner: Symbol, filename: String, classloader: Classpaths.Loader) =
-      this(defn, owner, new FileLocalInfo(filename), classloader)
+
+    private[Contexts] def this(
+      defn: Definitions,
+      classRoot: ClassSymbol,
+      filename: String,
+      classloader: Classpaths.Loader
+    ) = this(defn, classRoot, defn.RootPackage, new FileLocalInfo(filename), classloader)
 
     def withEnclosingBinders(addr: Addr, b: Binders): FileContext =
-      new FileContext(defn, owner, fileLocalInfo.addEnclosingBinders(addr, b), classloader)
+      new FileContext(defn, classRoot, owner, fileLocalInfo.addEnclosingBinders(addr, b), classloader)
 
     def withOwner(newOwner: Symbol): FileContext =
       if (newOwner == owner) this
-      else new FileContext(defn, newOwner, fileLocalInfo, classloader)
+      else new FileContext(defn, classRoot, newOwner, fileLocalInfo, classloader)
 
     def getFile: String = fileLocalInfo.filename
 
@@ -161,27 +208,46 @@ object Contexts {
 
     def hasSymbolAt(addr: Addr): Boolean = fileLocalInfo.localSymbols.contains(addr)
 
-    private def registerSym(addr: Addr, sym: Symbol, addToDecls: Boolean): Unit = {
+    private def registerSym[T <: Symbol](addr: Addr, sym: T, addToDecls: Boolean): T =
       fileLocalInfo.localSymbols(addr) = sym
       if addToDecls then
         owner match
           case owner: DeclaringSymbol => owner.addDecl(sym)
           case _ => throw IllegalArgumentException(s"can not add $sym to decls of non-declaring symbol $owner")
-    }
+      sym
 
-    /** Creates a new symbol at @addr with @name. The symbol is added to the owner's declarations if both
-      * 1) @addToDecls is true.
-      *    Example: true for valdef and defdef, false for parameters and type parameters
-      * 2) the owner is a declaring symbol.
-      *    Example: a method is added to the declarations of its class, but a nested method is not added
-      *    to declarations of its owner method.
+    /** Creates a new symbol at @addr with @name. If `addToDecls` is true, the symbol is added to the owner's
+      * declarations: this requires that the owner is a `DeclaringSymbol`, or else throws.
+      *
+      * @note `addToDecls` should be `true` for ValDef and DefDef, `false` for parameters and type parameters.
+      * @note A method is added to the declarations of its class, but a nested method should not added
+      *    to declarations of the outer method.
       */
-    def createSymbolIfNew[T <: Symbol](addr: Addr, name: Name, factory: SymbolFactory[T], addToDecls: Boolean): T = {
-      if (!hasSymbolAt(addr)) {
-        registerSym(addr, factory.createSymbol(name, owner), addToDecls)
-      }
-      fileLocalInfo.localSymbols(addr).asInstanceOf[T]
-    }
+    def createSymbol[T <: Symbol](addr: Addr, name: Name, factory: SymbolFactory[T], addToDecls: Boolean): T =
+
+      extension (s: ClassSymbol)
+        def isModuleClassRoot: Boolean = s.name.toTermName match
+          case SuffixedName(NameTags.OBJECTCLASS, module) => module == classRoot.name.toTermName
+          case _                                          => false
+
+      extension (s: RegularSymbol)
+        def isModuleRoot: Boolean =
+          s.name == classRoot.name.toTermName
+
+      def mkSymbol(name: Name, owner: Symbol): T =
+        if owner == classRoot.enclosingDecl then
+          owner.lookup(name) match
+            case Some(sym) =>
+              (factory, sym) match
+                case (ClassSymbolFactory, `classRoot`)                               => classRoot
+                case (ClassSymbolFactory, sym: ClassSymbol) if sym.isModuleClassRoot => sym
+                case (RegularSymbolFactory, sym: RegularSymbol) if sym.isModuleRoot  => sym
+                case _ => throw ExistingDefinitionException(owner, name, explanation = s"existing symbol: $sym")
+            case _ => factory.createSymbol(name, owner)
+        else factory.createSymbol(name, owner)
+
+      if !hasSymbolAt(addr) then registerSym(addr, mkSymbol(name, owner), addToDecls)
+      else throw ExistingDefinitionException(owner, name)
 
     def createPackageSymbolIfNew(name: TermName): PackageClassSymbol = owner match {
       case owner: PackageClassSymbol => base.createPackageSymbolIfNew(name, owner)

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -214,7 +214,12 @@ object Names {
       extends DerivedName(underlying) {
     override def toString: String = tag match {
       case NameTags.BODYRETAINER => ???
-      case NameTags.OBJECTCLASS  => s"$underlying$$"
+      case NameTags.OBJECTCLASS  => underlying.toString
+    }
+
+    override def toDebugString: String = tag match {
+      case NameTags.BODYRETAINER => ???
+      case NameTags.OBJECTCLASS  => s"$underlying[$$]"
     }
   }
 
@@ -245,8 +250,14 @@ object Names {
 
     override def toString: String = toTermName.toString
 
-    override def toDebugString: String = s"$toString/T"
+    override def toDebugString: String = s"${toTermName.toDebugString}/T"
 
-    def toObjectName: TypeName = SuffixedName(NameTags.OBJECTCLASS, toTermName).toTypeName
+    def wrapsObjectName: Boolean = toTermName match
+      case SuffixedName(NameTags.OBJECTCLASS, _) => true
+      case _                                     => false
+
+    def toObjectName: TypeName =
+      if wrapsObjectName then this
+      else SuffixedName(NameTags.OBJECTCLASS, toTermName).toTypeName
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -7,6 +7,12 @@ import tastyquery.ast.Trees.{EmptyTree, Tree}
 import tastyquery.ast.Types.*
 
 object Symbols {
+
+  class ExistingDefinitionException(val scope: Symbol, val name: Name, explanation: String = "")
+      extends Exception(
+        SymbolLookupException.addExplanation(s"$scope has already defined ${name.toDebugString}", explanation)
+      )
+
   class SymbolLookupException(val name: Name, explanation: String = "")
       extends RuntimeException(
         SymbolLookupException.addExplanation(s"Could not find symbol for name ${name.toDebugString}", explanation)
@@ -34,21 +40,29 @@ object Symbols {
 
     final def outer: Symbol = rawowner match {
       case owner: Symbol => owner
-      case null          => assert(false, s"cannot access outer, $this was not declared within any scope")
+      case null          => assert(false, s"cannot access outer, ${this.name} was not declared within any scope")
     }
 
     final def enclosingDecl: DeclaringSymbol = rawowner match {
       case owner: DeclaringSymbol => owner
-      case _: Symbol | null       => assert(false, s"cannot access owner, $this is a local symbol or has no owner")
+      case _: Symbol | null =>
+        assert(false, s"cannot access owner, ${this.name} is local or not declared within any scope")
     }
 
+    final def exists: Boolean = this ne NoSymbol
+
     final def isClass: Boolean = this.isInstanceOf[ClassSymbol]
+    final def isPackage: Boolean = this.isInstanceOf[PackageClassSymbol]
+
+    final def lookup(name: Name): Option[Symbol] = this match
+      case scope: DeclaringSymbol => scope.getDecl(name)
+      case _                      => None
 
     override def toString: String = {
       val kind = this match
         case _: PackageClassSymbol => "package "
-        case _: ClassSymbol        => "class "
-        case _                     => ""
+        case _: ClassSymbol        => if name.toTypeName.wrapsObjectName then "object class " else "class "
+        case _                     => if exists && outer.isPackage then "object " else ""
       s"symbol[$kind$name]"
     }
     def toDebugString = toString
@@ -63,23 +77,30 @@ object Symbols {
   abstract class DeclaringSymbol(override val name: Name, rawowner: Symbol | Null) extends Symbol(name, rawowner) {
     /* A map from the name of a declaration directly inside this symbol to the corresponding symbol
      * The qualifiers on the name are not dropped. For instance, the package names are always fully qualified. */
-    protected val myDeclarations: mutable.HashMap[Name, mutable.HashSet[Symbol]] =
+    private val myDeclarations: mutable.HashMap[Name, mutable.HashSet[Symbol]] =
       mutable.HashMap[Name, mutable.HashSet[Symbol]]()
 
-    def addDecl(decl: Symbol): Unit = myDeclarations.getOrElseUpdate(decl.name, new mutable.HashSet) += decl
-    def getDecl(name: Name): Option[Symbol] = name match {
+    private[tastyquery] final def addDecl(decl: Symbol): Unit =
+      myDeclarations.getOrElseUpdate(decl.name, new mutable.HashSet) += decl
+
+    private[tastyquery] final def getDecl(name: Name): Option[Symbol] = name match {
       case overloaded: SignedName => resolveOverloaded(overloaded)
       case name =>
-        myDeclarations.get(name).collect {
-          case set if set.sizeIs == 1 => set.head
-        }
+        myDeclarations.get(name) match
+          case Some(decls) =>
+            if decls.sizeIs == 1 then Some(decls.head)
+            else if decls.sizeIs > 1 then
+              throw SymbolLookupException(name, s"unexpected overloads: ${decls.mkString(", ")}")
+            else None
+          case _ => None
     }
-    def resolveOverloaded(name: SignedName): Option[Symbol] =
+
+    final def resolveOverloaded(name: SignedName): Option[Symbol] =
       getDecl(name.underlying) // TODO: look at signature to filter overloads
 
-    def declarations: List[Symbol] = myDeclarations.values.toList.flatten
+    final def declarations: List[Symbol] = myDeclarations.values.toList.flatten
 
-    override def toDebugString: String =
+    final override def toDebugString: String =
       s"${super.toString} with declarations [${myDeclarations.keys.map(_.toDebugString).mkString(", ")}]"
   }
 

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -247,12 +247,7 @@ object Types {
       val local = packageSymbol
       if (local == null) {
         def searchPkg = defn.RootPackage.findPackageSymbol(packageName)
-        def slowSearchPkg = {
-          baseCtx.classloader.initPackages()
-          searchPkg
-        }
-        val symOption = searchPkg
-        val resolved = symOption.orElse(slowSearchPkg).getOrElse(throw new SymbolLookupException(packageName))
+        val resolved = searchPkg.getOrElse(throw new SymbolLookupException(packageName))
         packageSymbol = resolved
         resolved
       } else local

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -53,7 +53,14 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
         val end = reader.readEnd()
         val pid = readPotentiallyShared({
           assert(reader.readByte() == TERMREFpkg, posErrorMsg)
-          ctx.createPackageSymbolIfNew(readName)
+          val pkg = ctx.createPackageSymbolIfNew(readName)
+          if pkg != defn.EmptyPackage then
+            // can happen for symbolic packages
+            assert(
+              ctx.classRoot.enclosingDecls.exists(_ == pkg),
+              s"unexpected package ${pkg.name} in owners of top level class ${ctx.classRoot.fullName}"
+            )
+          pkg
         })
         reader.until(end)(createSymbols()(using ctx.withOwner(pid)))
       case TYPEDEF =>

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -23,16 +23,18 @@ case object CaseDefFactory extends AbstractCaseDefFactory[CaseDef]
 case object TypeCaseDefFactory extends AbstractCaseDefFactory[TypeCaseDef]
 
 class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
-  def unpickle(using FileContext): List[Tree] = {
-    @tailrec def read(acc: ListBuffer[Tree]): List[Tree] = {
-      acc += readTopLevelStat
-      if (!reader.isAtEnd) read(acc) else acc.toList
-    }
 
-    val symbolFork = fork
-    while (!symbolFork.reader.isAtEnd) symbolFork.createSymbols
+  def unpickle(using FileContext): List[Tree] =
+    @tailrec
+    def read(acc: ListBuffer[Tree]): List[Tree] =
+      acc += readTopLevelStat
+      if !reader.isAtEnd then read(acc) else acc.toList
+
+    fork.enterSymbols()
     read(new ListBuffer[Tree])
-  }
+
+  private def enterSymbols()(using FileContext): Unit =
+    while !reader.isAtEnd do createSymbols()
 
   /* This method walks a TASTy file and creates all symbols in it.
    *
@@ -42,7 +44,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
    * The alternative is to create a symbol when we encounter a forward reference, but it is hard to
    * keep track of the owner in this case.
    * */
-  def createSymbols(using FileContext): Unit = {
+  private def createSymbols()(using FileContext): Unit = {
     val start = reader.currentAddr
     val tag = reader.readByte()
     tag match {
@@ -53,51 +55,48 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
           assert(reader.readByte() == TERMREFpkg, posErrorMsg)
           ctx.createPackageSymbolIfNew(readName)
         })
-        reader.until(end)(createSymbols(using ctx.withOwner(pid)))
+        reader.until(end)(createSymbols()(using ctx.withOwner(pid)))
       case TYPEDEF =>
         val end = reader.readEnd()
         val name = readName.toTypeName
         val tag = reader.nextByte
-        val newOwner = if tag == TEMPLATE then {
-          ctx.createSymbolIfNew(start, name, ClassSymbolFactory, addToDecls = ctx.owner.isClass)
-        } else {
-          ctx.createSymbolIfNew(start, name, RegularSymbolFactory, addToDecls = ctx.owner.isClass)
-        }
-        reader.until(end)(createSymbols(using ctx.withOwner(newOwner)))
+        val factory = if tag == TEMPLATE then ClassSymbolFactory else RegularSymbolFactory
+        val newOwner = ctx.createSymbol(start, name, factory, addToDecls = ctx.owner.isClass)
+        reader.until(end)(createSymbols()(using ctx.withOwner(newOwner)))
         if tag == TEMPLATE then newOwner.asInstanceOf[ClassSymbol].initialised = true
       case DEFDEF | VALDEF | PARAM | TYPEPARAM =>
         val end = reader.readEnd()
         val name = if (tag == TYPEPARAM) readName.toTypeName else readName
         val addToDecls = tag != TYPEPARAM && ctx.owner.isClass
         val newSymbol =
-          ctx.createSymbolIfNew(start, name, RegularSymbolFactory, addToDecls)
-        reader.until(end)(createSymbols(using ctx.withOwner(newSymbol)))
+          ctx.createSymbol(start, name, RegularSymbolFactory, addToDecls)
+        reader.until(end)(createSymbols()(using ctx.withOwner(newSymbol)))
       case BIND =>
         val end = reader.readEnd()
         var name: Name = readName
         if (tagFollowShared == TYPEBOUNDS) name = name.toTypeName
-        ctx.createSymbolIfNew(start, name, RegularSymbolFactory, addToDecls = false)
+        ctx.createSymbol(start, name, RegularSymbolFactory, addToDecls = false)
         // bind is never an owner
-        reader.until(end)(createSymbols)
+        reader.until(end)(createSymbols())
 
       // ---------- tags with potentially nested symbols --------------------------------
-      case tag if firstASTTreeTag <= tag && tag < firstNatASTTreeTag => createSymbols
+      case tag if firstASTTreeTag <= tag && tag < firstNatASTTreeTag => createSymbols()
       case tag if firstNatASTTreeTag <= tag && tag < firstLengthTreeTag =>
         reader.readNat()
-        createSymbols
+        createSymbols()
       case TEMPLATE | APPLY | TYPEAPPLY | SUPER | TYPED | ASSIGN | BLOCK | INLINED | LAMBDA | IF | MATCH | TRY | WHILE |
           REPEATED | ALTERNATIVE | UNAPPLY | REFINEDtpt | APPLIEDtpt | LAMBDAtpt | TYPEBOUNDStpt | ANNOTATEDtpt |
           MATCHtpt | CASEDEF =>
         val end = reader.readEnd()
-        reader.until(end)(createSymbols)
+        reader.until(end)(createSymbols())
       case SELECTin =>
         val end = reader.readEnd()
         readName
-        reader.until(end)(createSymbols)
+        reader.until(end)(createSymbols())
       case RETURN | SELECTouter =>
         val end = reader.readEnd()
         reader.readNat()
-        reader.until(end)(createSymbols)
+        reader.until(end)(createSymbols())
 
       // ---------- no nested symbols ---------------------------------------------------
       case _ => skipTree(tag)
@@ -210,13 +209,13 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val name = readName.toTypeName
       val typedef: Class | TypeMember = if (reader.nextByte == TEMPLATE) {
         val classSymbol = ctx.getSymbol(start, ClassSymbolFactory)
-        createSymbolTree(s => Class(name, readTemplate(using ctx.withOwner(s)), s), classSymbol)
+        Class(name, readTemplate(using ctx.withOwner(classSymbol)), classSymbol).definesTreeOf(classSymbol)
       } else {
         val symbol = ctx.getSymbol(start, RegularSymbolFactory)
         if (tagFollowShared == TYPEBOUNDS)
-          createSymbolTree(s => TypeMember(name, readTypeBounds(using ctx.withOwner(s)), s), symbol)
+          TypeMember(name, readTypeBounds(using ctx.withOwner(symbol)), symbol).definesTreeOf(symbol)
         else
-          createSymbolTree(s => TypeMember(name, readTypeTree(using ctx.withOwner(s)), s), symbol)
+          TypeMember(name, readTypeTree(using ctx.withOwner(symbol)), symbol).definesTreeOf(symbol)
       }
       // TODO: read modifiers
       skipModifiers(end)
@@ -291,7 +290,7 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val name = readName.toTypeName
       val bounds = readTypeParamType(using ctx.withOwner(paramSymbol))
       skipModifiers(end)
-      createSymbolTree(symbol => TypeParam(name, bounds, symbol), paramSymbol)
+      TypeParam(name, bounds, paramSymbol).definesTreeOf(paramSymbol)
     }
     var acc = new ListBuffer[TypeParam]()
     while (reader.nextByte == TYPEPARAM) {
@@ -405,20 +404,22 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
     skipModifiers(end)
     tag match {
       case VALDEF | PARAM =>
-        createSymbolTree(s => ValDef(name, tpt, rhs, s), symbol)
+        ValDef(name, tpt, rhs, symbol).definesTreeOf(symbol)
       case DEFDEF =>
-        createSymbolTree(s => DefDef(name, params, tpt, rhs, s), symbol)
+        DefDef(name, params, tpt, rhs, symbol).definesTreeOf(symbol)
     }
   }
 
   def readTerms(end: Addr)(using FileContext): List[Tree] =
     reader.until(end)(readTerm)
 
-  def createSymbolTree[S <: Symbol, T <: Tree](createTree: S => T, symbol: S): T = {
-    val tree = createTree(symbol)
-    symbol.withTree(tree)
-    tree
-  }
+  extension [T <: Tree](tree: T)
+    /** Adds `tree` to the `symbol`, returning the tree.
+      * @todo remove and assign tree to symbol in ctor of tree
+      */
+    inline def definesTreeOf[S <: Symbol](symbol: S): T =
+      symbol.withTree(tree)
+      tree
 
   def readTerm(using FileContext): Tree = reader.nextByte match {
     case IDENT =>
@@ -524,7 +525,8 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
       val typ = readType
       val term = readTerm
       skipModifiers(end)
-      createSymbolTree(bindSymbol => Bind(name, term, bindSymbol), ctx.getSymbol(start, RegularSymbolFactory))
+      val symbol = ctx.getSymbol(start, RegularSymbolFactory)
+      Bind(name, term, symbol).definesTreeOf(symbol)
     case ALTERNATIVE =>
       reader.readByte()
       val end = reader.readEnd()

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Classpaths.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Classpaths.scala
@@ -2,14 +2,23 @@ package tastyquery.reader.classfiles
 
 import tastyquery.ast.Names.SimpleName
 import scala.reflect.NameTransformer
-import tastyquery.Contexts.{BaseContext, baseCtx, defn}
+import tastyquery.Contexts
+import tastyquery.Contexts.{BaseContext, baseCtx, ctx, defn}
 import scala.collection.mutable
 import tastyquery.ast.Names.{TermName, nme, termName, str}
 import tastyquery.ast.Symbols.PackageClassSymbol
 import tastyquery.ast.Symbols.ClassSymbol
 import tastyquery.ast.Symbols.DeclaringSymbol
+import tastyquery.reader.TastyUnpickler
+
+import ClassfileParser.ClassKind
+import tastyquery.Contexts.ClassContext
+import tastyquery.Contexts.FileContext
+import tastyquery.ast.Trees.Tree
 
 object Classpaths {
+
+  class MissingTopLevelTasty(cls: ClassSymbol) extends Exception(s"Missing TASTy for $cls")
 
   /** Contains class data and tasty data. `name` is a Scala identifier */
   case class PackageData(name: SimpleName, classes: IArray[ClassData], tastys: IArray[TastyData])
@@ -20,16 +29,23 @@ object Classpaths {
   /** Contains tasty bytes. `simpleName` is a Scala identifier */
   case class TastyData(simpleName: SimpleName, debugPath: String, bytes: IArray[Byte])
 
-  def enterRoot(root: ClassData, owner: DeclaringSymbol)(using BaseContext): ClassSymbol = {
-    val clsName = root.simpleName.toTypeName
+  object permissions {
+
+    /** sentinel value, it proves that `baseCtx.withRoot` can only be called from `scanClass` */
+    opaque type LoadRoot = Unit
+    private[Classpaths] inline def withLoadRootPrivelege[T](inline op: LoadRoot ?=> T): T = op(using ())
+  }
+
+  def enterRoot(root: SimpleName, owner: DeclaringSymbol)(using BaseContext): ClassSymbol = {
+    val clsName = root.toTypeName
     val objclassName = clsName.toObjectName
-    val objName = root.simpleName
+    val objName = root
 
     locally {
-      baseCtx.createSymbolIfNew(objName, owner)
-      baseCtx.createClassSymbolIfNew(objclassName, owner)
+      baseCtx.createSymbol(objName, owner)
+      baseCtx.createClassSymbol(objclassName, owner)
     }
-    baseCtx.createClassSymbolIfNew(clsName, owner)
+    baseCtx.createClassSymbol(clsName, owner)
   }
 
   sealed abstract class Classpath protected (val packages: IArray[PackageData]) {
@@ -46,93 +62,144 @@ object Classpaths {
 
   class Loader(val classpath: Classpath) { loader =>
 
+    private enum Entry:
+      case ClassAndTasty(classData: ClassData, tastyData: TastyData)
+      case TastyOnly(tastyData: TastyData)
+      case ClassOnly(classData: ClassData)
+
     private var searched = false
-    private var index: Map[PackageClassSymbol, IArray[ClassData]] = Map.empty
-    private var uninitialised: Map[ClassSymbol, ClassData] = Map.empty
+    private var packages: Map[PackageClassSymbol, PackageData] = compiletime.uninitialized
+    private var lookup: Map[ClassSymbol, Entry] = Map.empty
+    private var topLevelTastys: Map[ClassSymbol, List[Tree]] = Map.empty
 
-    /** sentinel value, it proves that `baseCtx.withRoot` can only be called from `scanClass` */
-    opaque type LoadRoot = Null
-    protected final given loadRoot: LoadRoot = null
+    // TODO: do not use fully qualified name for storing packages in decls
+    private val packageNameCache = mutable.HashMap.empty[TermName, TermName]
 
-    def lookupTasty(fullClassName: String): Option[TastyData] =
-      def packageAndClass(fullClassName: String): (SimpleName, SimpleName) = {
-        val lastSep = fullClassName.lastIndexOf('.')
-        if (lastSep == -1) (nme.EmptyPackageName, termName(fullClassName))
-        else {
-          import scala.language.unsafeNulls
-          val packageName = termName(fullClassName.substring(0, lastSep))
-          val className = termName(fullClassName.substring(lastSep + 1))
-          (packageName, className)
-        }
-      }
-      val (pkg, cls) = packageAndClass(fullClassName)
-      classpath.packages.find(_.name == pkg) match {
-        case Some(pkg) => pkg.tastys.find(_.simpleName == cls)
-        case _         => None
-      }
+    def toPackageName(dotSeparated: String): TermName =
+      def cached(name: TermName): TermName =
+        packageNameCache.getOrElseUpdate(name, name)
 
-    def scanClass(cls: ClassSymbol)(using baseCtx: BaseContext): Unit =
-      uninitialised.get(cls) match {
-        case Some(classRoot) =>
-          uninitialised -= cls
-          if !cls.initialised then // may have been initialised by TASTy
-            ClassfileParser.loadInfo(classRoot)(using baseCtx.withRoot(cls)).toTry.get
-            cls.initialised = true
-        case _ =>
-      }
+      def qualified(parts: IndexedSeq[String]): TermName =
+        if parts.isEmpty then nme.EmptyPackageName
+        else parts.view.drop(1).foldLeft(cached(termName(parts.head)))((name, p) => cached(name select termName(p)))
+
+      qualified(IArray.unsafeFromArray(dotSeparated.split('.')))
+
+    private[tastyquery] def topLevelTasty(cls: ClassSymbol)(using BaseContext): Option[List[Tree]] =
+      if !cls.outer.isPackage then
+        println(s"No top-level tasty for $cls: it is not top-level")
+        None
+      else if !Contexts.initialisedRoot(cls) then
+        println(s"No top-level tasty for $cls: it is not initialised")
+        None
+      else if cls.name.toTypeName.wrapsObjectName then
+        println(s"No top-level tasty for $cls: it is an object class")
+        None
+      else
+        topLevelTastys.get(cls) match
+          case None =>
+            println(s"No top-level tasty for $cls: it has no associated TASTy")
+            None
+          case some => some
+
+    /** @return true if loaded the classes inner definitions */
+    private[tastyquery] def scanClass(cls: ClassSymbol)(using baseCtx: BaseContext): Boolean =
+      def inspectClass(classData: ClassData, entry: Entry)(using ClassContext, permissions.LoadRoot): Boolean =
+        ClassfileParser.readKind(classData).toTry.get match
+          case ClassKind.Scala2(structure, runtimeAnnotStart) =>
+            ClassfileParser.loadScala2Class(structure, runtimeAnnotStart).toTry.get
+            Contexts.initialisedRoot(cls)
+          case ClassKind.Java(structure) =>
+            ClassfileParser.loadJavaClass(structure).toTry.get
+            Contexts.initialisedRoot(cls)
+          case ClassKind.TASTy =>
+            entry match
+              case Entry.ClassAndTasty(_, tasty) =>
+                // TODO: verify UUID of tasty matches classfile, then parse symbols
+                enterTasty(tasty)(using baseCtx.withFile(cls, tasty.debugPath))
+              case _ => throw MissingTopLevelTasty(cls)
+          case _ =>
+            false // no initialisation step to take
+      end inspectClass
+
+      def enterTasty(tastyData: TastyData)(using FileContext): Boolean =
+        // TODO: test reading tree from dependency not directly queried??
+        val unpickler = TastyUnpickler(tastyData.bytes)
+        val trees = unpickler.unpickle(TastyUnpickler.TreeSectionUnpickler()).get.unpickle(using ctx)
+        if Contexts.initialisedRoot(cls) then
+          topLevelTastys += cls -> trees
+          true
+        else false
+
+      // TODO: test against standalone objects, modules, etc.
+      lookup.get(cls) match
+        case Some(entry) =>
+          permissions.withLoadRootPrivelege {
+            require(!cls.initialised)
+            lookup -= cls
+            entry match
+              case entry: Entry.ClassOnly =>
+                // Tested in `TypeSuite` - aka Java and Scala 2 dependencies
+                inspectClass(entry.classData, entry)(using baseCtx.withRoot(cls))
+              case entry: Entry.ClassAndTasty =>
+                // Tested in `TypeSuite` - read Tasty file that may reference Java and Scala 2 dependencies
+                // maybe we do not need to parse the class, however the classfile could be missing the TASTY attribute.
+                inspectClass(entry.classData, entry)(using baseCtx.withRoot(cls))
+              case entry: Entry.TastyOnly =>
+                // Tested in `SymbolSuite`, `ReadTreeSuite`, these do not need to see class files.
+                enterTasty(entry.tastyData)(using baseCtx.withFile(cls, entry.tastyData.debugPath))
+          }
+
+        case _ => false
+    end scanClass
 
     def scanPackage(pkg: PackageClassSymbol)(using BaseContext): Unit = {
-      if !searched then initPackages() // fill in classes from classpath if package was initialised by TASTy
-      index.get(pkg) match {
-        case Some(classes) =>
-          def isNestedOrModuleClass(cd: ClassData): Boolean = {
+      require(searched)
+      packages.get(pkg) match {
+        case Some(data) =>
+          def isNestedOrModuleClassName(cls: SimpleName): Boolean = {
             def isNested = {
-              val name = cd.simpleName.name
+              val name = cls.name
               val idx = name.lastIndexOf('$', name.length - 2)
               idx >= 0 &&
-              (idx + str.topLevelSuffix.length + 1 != name.length || !name.endsWith(str.topLevelSuffix))
+              !(idx + str.topLevelSuffix.length == name.length && name.endsWith(str.topLevelSuffix))
             }
             def isModule = {
-              val name = cd.simpleName.name
+              val name = cls.name
               name.last == '$' && name.length > 1
             }
             isNested || isModule
           }
 
-          index -= pkg
+          packages -= pkg
           println(s"initialising root classes from $pkg")
-          // classes.filter(!isNestedClass(_)).foreach { cls => println(s"entering class ${cls.classPart}") }
-          classes.foreach { cls =>
-            if !isNestedOrModuleClass(cls) then
-              val clsSym = Classpaths.enterRoot(cls, pkg)
-              uninitialised += (clsSym -> cls) // TODO: what if someone searches for the module class first?
-          }
+
+          if data.classes.isEmpty then
+            for tasty <- data.tastys if !isNestedOrModuleClassName(tasty.simpleName) do
+              val clsSym = Classpaths.enterRoot(tasty.simpleName, pkg)
+              lookup += (clsSym -> Entry.TastyOnly(tasty))
+          else
+            val tastyMap = data.tastys.map(t => t.simpleName -> t).toMap
+            for cls <- data.classes if !isNestedOrModuleClassName(cls.simpleName) do
+              val clsSym = Classpaths.enterRoot(cls.simpleName, pkg)
+              val entry =
+                tastyMap.get(cls.simpleName).map(Entry.ClassAndTasty(cls, _)).getOrElse(Entry.ClassOnly(cls))
+              lookup += (clsSym -> entry) // TODO: what if someone searches for the module class first?
+
         case _ => // assume already loaded (possible that someone is only loading from tasty file with empty classpath)
       }
     }
 
-    def initPackages()(using BaseContext): Unit =
+    def initPackages()(using baseCtx: BaseContext)(using Contexts.permissions.InitAll): Unit =
       if !searched then {
         searched = true
 
         def enterPackages(packages: IArray[PackageData]) = {
           println(s"begin enter packages")
 
-          // TODO: do not use fully qualified name for storing packages in decls
-          val packageNameCache = mutable.HashMap.empty[TermName, TermName]
-
           packageNameCache.sizeHint(packages.size)
 
-          def cached(name: TermName): TermName =
-            packageNameCache.getOrElseUpdate(name, name)
-
-          def toPackageName(parts: IndexedSeq[String]): TermName =
-            if parts.isEmpty then nme.EmptyPackageName
-            else parts.view.drop(1).foldLeft(cached(termName(parts.head)))((name, p) => cached(name select termName(p)))
-
-          val packageNames =
-            packages.map(pkg => toPackageName(IArray.unsafeFromArray(pkg.name.name.split('.'))))
-          val classesFor = packageNames.lazyZip(packages.map(_.classes)).toMap
+          val packageNames = packages.map(pkg => toPackageName(pkg.name.name))
 
           var debugPackageCount = 0
 
@@ -145,7 +212,8 @@ object Classpaths {
             currentOwner
           }
 
-          loader.index = Map.from(for pkg <- packageNames yield createSubpackages(pkg) -> classesFor(pkg))
+          loader.packages =
+            Map.from(for (pkgName, data) <- packageNames.zip(packages) yield createSubpackages(pkgName) -> data)
 
           // println(s"init classpath with:\n${classes.map(_.className).mkString("\n")}")
           // println(s"init classpath with packages:\n${debugPackages.map(_.toDebugString).mkString("\n")}")

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Classpaths.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Classpaths.scala
@@ -49,7 +49,9 @@ object Classpaths {
   }
 
   sealed abstract class Classpath protected (val packages: IArray[PackageData]) {
-    def loader: Loader = Loader(this)
+
+    def loader[T](op: Loader => T): T = op(Loader(this))
+
   }
 
   object Classpath {
@@ -190,7 +192,7 @@ object Classpaths {
       }
     }
 
-    def initPackages()(using baseCtx: BaseContext)(using Contexts.permissions.InitAll): Unit =
+    def initPackages()(using baseCtx: BaseContext): Unit =
       if !searched then {
         searched = true
 

--- a/test-sources/src/main/scala/crosspackagetasty/BoxedConstants.scala
+++ b/test-sources/src/main/scala/crosspackagetasty/BoxedConstants.scala
@@ -1,0 +1,5 @@
+package crosspackagetasty
+
+class BoxedConstants(val boxed: simple_trees.Constants) {
+  def boxedUnitVal = boxed.unitVal
+}

--- a/test-sources/src/main/scala/mixjavascala/JavaBox.java
+++ b/test-sources/src/main/scala/mixjavascala/JavaBox.java
@@ -1,0 +1,13 @@
+package mixjavascala;
+
+public class JavaBox {
+  private int x;
+
+  public JavaBox(int x) {
+    this.x = x;
+  }
+
+  public int getX() {
+    return x;
+  }
+}

--- a/test-sources/src/main/scala/mixjavascala/ScalaBox.scala
+++ b/test-sources/src/main/scala/mixjavascala/ScalaBox.scala
@@ -1,0 +1,5 @@
+package mixjavascala
+
+class ScalaBox(val boxed: mixjavascala.JavaBox) {
+  def xMethod = boxed.getX()
+}


### PR DESCRIPTION
- assert that symbols can only be defined once.
- user must obtain top-level class symbol before
  reading tasty - to obtain top-level class they
  must first scan classpath.
- when scanning for a top-level class, create
  symbols for all sibling classes in the same
  package.
- only complete the members of a top-level class
  on demand.
- same entry point to complete members both top-level
  tasty and java/scala2 class files.
- adds example where a top-level class will be seen twice.