### PR TITLE
filter classpath to ensure no dependencies

### DIFF
--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -10,7 +10,7 @@ import tastyquery.ast.Types.*
 import tastyquery.reader.TastyUnpickler
 import dotty.tools.tasty.TastyFormat.NameTags
 
-class ReadTreeSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false) {
+class ReadTreeSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false, allowDeps = false) {
   import BaseUnpicklingSuite.Decls.*
 
   type StructureCheck = PartialFunction[Tree, Unit]

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -5,7 +5,7 @@ import tastyquery.ast.Names.{nme, Name, SimpleName, TypeName}
 import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
 import tastyquery.ast.Symbols.ClassSymbol
 
-class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false) {
+class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false, allowDeps = false) {
   import BaseUnpicklingSuite.Decls.*
   import BaseUnpicklingSuite.toDebugString
 
@@ -154,7 +154,7 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
     val outerMethod = NestedMethod / name"outerMethod"
     val unitVal = Constants / name"unitVal"
 
-    val ctx = getUnpicklingContext(Constants)
+    val ctx = getUnpicklingContext(Constants, extraClasspath = NestedMethod)
 
     assertContainsDeclaration(ctx, Constants) // we should have loaded Constants, we requested it
     assertContainsDeclaration(ctx, unitVal) // outerMethod is a member of Constants, it should be seen.

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -6,7 +6,7 @@ import tastyquery.ast.Symbols.*
 import tastyquery.ast.Trees.*
 import tastyquery.ast.Types.*
 
-class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = true) {
+class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = true, allowDeps = true) {
   import BaseUnpicklingSuite.Decls.*
 
   def assertMissingDeclaration(path: DeclarationPath)(using BaseContext): Unit =


### PR DESCRIPTION
`SymbolSuite` and `ReadTreeSuite` no longer allow dependencies between TASTy files unless explicitly specified. Dependencies should be tested in `TypeSuite`