### PR TITLE
Give types to all the simple things.

### DIFF
--- a/shared/src/main/scala/tastyquery/ast/Constants.scala
+++ b/shared/src/main/scala/tastyquery/ast/Constants.scala
@@ -22,6 +22,20 @@ object Constants {
     import java.lang.Double.doubleToRawLongBits
     import java.lang.Float.floatToRawIntBits
 
+    def wideType: Type = tag match
+      case UnitTag    => Types.UnitType
+      case BooleanTag => Types.BooleanType
+      case CharTag    => Types.CharType
+      case ByteTag    => Types.ByteType
+      case ShortTag   => Types.ShortType
+      case IntTag     => Types.IntType
+      case LongTag    => Types.LongType
+      case FloatTag   => Types.FloatType
+      case DoubleTag  => Types.DoubleType
+      case StringTag  => Types.StringType
+      case NullTag    => Types.NullType
+      case ClazzTag   => Types.ClassTypeOf(typeValue)
+
     def isByteRange: Boolean = isIntRange && Byte.MinValue <= intValue && intValue <= Byte.MaxValue
     def isShortRange: Boolean = isIntRange && Short.MinValue <= intValue && intValue <= Short.MaxValue
     def isCharRange: Boolean = isIntRange && Char.MinValue <= intValue && intValue <= Char.MaxValue

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -62,6 +62,29 @@ object Names {
     val Constructor: SimpleName = termName("<init>")
     val Wildcard: SimpleName = termName("_")
     val RefinementClass = typeName("<refinement>")
+
+    val scalaPackageName: TermName = termName("scala")
+    val javaPackageName: TermName = termName("java")
+    val javalangPackageName: TermName = javaPackageName.select(termName("lang"))
+  }
+
+  object tpnme {
+    val Nothing: TypeName = typeName("Nothing")
+    val Null: TypeName = typeName("Null")
+
+    val Unit: TypeName = typeName("Unit")
+    val Boolean: TypeName = typeName("Boolean")
+    val Char: TypeName = typeName("Char")
+    val Byte: TypeName = typeName("Byte")
+    val Short: TypeName = typeName("Short")
+    val Int: TypeName = typeName("Int")
+    val Long: TypeName = typeName("Long")
+    val Float: TypeName = typeName("Float")
+    val Double: TypeName = typeName("Double")
+
+    val String: TypeName = typeName("String")
+    val Class: TypeName = typeName("Class")
+    val Object: TypeName = typeName("Object")
   }
 
   /** Create a type name from the characters in cs[offset..offset+len-1].

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -814,9 +814,9 @@ class TreeUnpickler(protected val reader: TastyReader, nameAtRef: NameTable) {
     // select type from a term
     case SELECT =>
       reader.readByte()
-      val name = readName.toTypeName
+      val name = readName
       val qual = readTerm
-      SelectTypeFromTerm(qual, name)
+      TermRefTypeTree(qual, name)
     case SELECTtpt =>
       reader.readByte()
       val name = readName.toTypeName


### PR DESCRIPTION
This requires synthetic declarations for `scala.Nothing` and `scala.Null`. They are added when we initialize the root context.

Applications do not receive types yet, because that will require `calculateType` to actually resolve symbols to get to functions' `MethodType`s.