### PR TITLE
Make default symbol/decl lookup load things when necessary.

### DIFF
--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -24,9 +24,6 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val List(List(xParamDef: ValDef)) = fTree.params: @unchecked
 
-    // HACK: Get scala.Int to load
-    xParamDef.tpe.asInstanceOf[Symbolic].resolveToSymbol
-
     val IntClass = resolve(name"scala" / tname"Int")
     assert(xParamDef.tpe.isRef(IntClass))
 
@@ -88,9 +85,6 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val List(List(xParamDef: ValDef)) = fTree.params: @unchecked
 
-    // HACK: Get scala.Int to load
-    xParamDef.tpe.asInstanceOf[Symbolic].resolveToSymbol
-
     val IntClass = resolve(name"scala" / tname"Int")
     assert(xParamDef.tpe.isRef(IntClass))
 
@@ -148,10 +142,6 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
       tree match {
         case Assign(lhs, rhs) =>
           assignCount += 1
-
-          // HACK: Get scala.Unit to load
-          tree.tpe.asInstanceOf[Symbolic].resolveToSymbol
-
           val UnitClass = resolve(name"scala" / tname"Unit")
           assert(tree.tpe.isOfClass(UnitClass), clue(tree.tpe))
         case _ =>

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -9,15 +9,9 @@ import tastyquery.ast.Types.*
 class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = true, allowDeps = true) {
   import BaseUnpicklingSuite.Decls.*
 
-  def assertMissingDeclaration(path: DeclarationPath)(using BaseContext): Unit =
-    absent(path)
-
-  def forceAbsentSymbol(path: DeclarationPath)(action: BaseContext ?=> Symbol)(using BaseContext): Symbol = {
-    assertMissingDeclaration(path)
-    val found = action
-    val didForce = resolve(path)
-    assert(found eq didForce)
-    found
+  def assertIsSymbolWithPath(path: DeclarationPath)(actualSymbol: Symbol)(using BaseContext): Unit = {
+    val expectedSymbol = resolve(path)
+    assert(actualSymbol eq expectedSymbol, clues(actualSymbol, expectedSymbol))
   }
 
   test("basic-local-val") {
@@ -178,7 +172,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (JavaDefinedRef @ _: Symbolic) = boxedSym.tree.tpe: @unchecked
 
-    forceAbsentSymbol(JavaDefined)(JavaDefinedRef.resolveToSymbol)
+    assertIsSymbolWithPath(JavaDefined)(JavaDefinedRef.resolveToSymbol)
   }
 
   test("select-method-from-java-class") {
@@ -193,7 +187,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (getXRef @ _: Symbolic) = getXSelection.tpe: @unchecked
 
-    forceAbsentSymbol(getX)(getXRef.resolveToSymbol)
+    assertIsSymbolWithPath(getX)(getXRef.resolveToSymbol)
   }
 
   test("select-field-from-java-class") {
@@ -208,7 +202,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (xRef @ _: Symbolic) = xSelection.tpe: @unchecked
 
-    forceAbsentSymbol(x)(xRef.resolveToSymbol)
+    assertIsSymbolWithPath(x)(xRef.resolveToSymbol)
   }
 
   test("basic-scala-2-stdlib-class-dependency") {
@@ -221,7 +215,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (AppliedType(ConsRef @ _: Symbolic, _)) = boxedSym.tree.tpe: @unchecked
 
-    forceAbsentSymbol(::)(ConsRef.resolveToSymbol)
+    assertIsSymbolWithPath(::)(ConsRef.resolveToSymbol)
   }
 
   test("select-method-from-scala-2-stdlib-class") {
@@ -236,7 +230,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (canEqualRef @ _: Symbolic) = canEqualSelection.tpe: @unchecked
 
-    forceAbsentSymbol(canEqual)(canEqualRef.resolveToSymbol)
+    assertIsSymbolWithPath(canEqual)(canEqualRef.resolveToSymbol)
   }
 
   test("select-field-from-tasty-in-other-package:dependency-from-class-file") {
@@ -251,7 +245,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (unitValRef @ _: Symbolic) = unitValSelection.tpe: @unchecked
 
-    forceAbsentSymbol(unitVal)(unitValRef.resolveToSymbol)
+    assertIsSymbolWithPath(unitVal)(unitValRef.resolveToSymbol)
   }
 
   test("select-method-from-java-class-same-package-as-tasty") {
@@ -271,7 +265,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val (getXRef @ _: Symbolic) = getXSelection.tpe: @unchecked
 
-    forceAbsentSymbol(getX)(getXRef.resolveToSymbol)
+    assertIsSymbolWithPath(getX)(getXRef.resolveToSymbol)
   }
 
 }

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -175,17 +175,7 @@ object Types {
         val sym = {
           val symOption = prefixSym match {
             case declaring: DeclaringSymbol =>
-              def force() = declaring match {
-                case p: PackageClassSymbol =>
-                  baseCtx.classloader.scanPackage(p)
-                case p: ClassSymbol =>
-                  baseCtx.classloader.scanClass(p)
-                case _ =>
-              }
-              declaring.getDecl(name).orElse {
-                force()
-                declaring.getDecl(name)
-              }
+              declaring.getDecl(name)
             case _ =>
               throw SymbolLookupException(name, s"$prefixSym is not a package or class")
           }


### PR DESCRIPTION
The previous behavior of finding decls without loading anything was renamed as `getDeclInternal`. It is used in a couple of internal locations where we really have no business loading stuff, because we are already within code that loads.

Otherwise, methods that lookup symbols require an implicit `BaseContext` so that they can load things when necessary.

This allows to remove the hacks in the TypeSuite to load symbols. They get loaded automatically.