### PR TITLE
Use Windows-friendly paths.

### DIFF
--- a/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
+++ b/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
@@ -39,12 +39,6 @@ object ClasspathLoaders {
   def read(classpath: List[String], kinds: Set[FileKind]): Classpath = {
     def load(): IArray[PackageData] = {
 
-      val dirSep = {
-        import scala.language.unsafeNulls
-        val fs = FileSystems.getDefault
-        fs.getSeparator
-      }
-
       def classAndPackage(binaryName: SimpleName): (SimpleName, SimpleName) = {
         val name = binaryName.name
         val lastSep = name.lastIndexOf('.')
@@ -57,8 +51,14 @@ object ClasspathLoaders {
       }
 
       def binaryName(classFile: String): SimpleName = {
+        /* Replace *both* slashes and backslashes, because the Java file APIs
+         * are permissive in what they manipulate, so it's possible to get,
+         * especially on Windows.
+         */
         import scala.language.unsafeNulls
-        termName(classFile.replace(dirSep, "."))
+        val path1 = classFile.replace('/', '.')
+        val path2 = path1.replace('\\', '.')
+        termName(path2)
       }
 
       def streamPackages() =

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -169,23 +169,23 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
         case err: java.lang.AssertionError =>
           val msg = err.getMessage.nn
           assert(
-            msg.contains("unexpected package symbolic_>> in owners of top level class symbolic_$greater$greater.#::")
+            msg.contains("unexpected package symbolic_-- in owners of top level class symbolic_$minus$minus.#::")
           )
     }
 
     def runTest(using BaseContext): Unit =
-      val `symbolic_>>.#::` = name"symbolic_>>" / tname"#::"
-      val `symbolic_$greater$greater.#::` = name"symbolic_$$greater$$greater" / tname"#::"
+      val `symbolic_--.#::` = name"symbolic_--" / tname"#::"
+      val `symbolic_$minus$minus.#::` = name"symbolic_$$minus$$minus" / tname"#::"
 
       intercept[MissingTopLevelDecl] {
-        failingGetTopLevelClass(`symbolic_>>.#::`) // this will fail, we can't find a symbolic package
+        failingGetTopLevelClass(`symbolic_--.#::`) // this will fail, we can't find a symbolic package
       }
-      assertSymbolNotExistsOrNotLoadedYet(`symbolic_>>.#::`) // still does not exist
-      assertSymbolNotExistsOrNotLoadedYet(`symbolic_$greater$greater.#::`) // not existant yet
+      assertSymbolNotExistsOrNotLoadedYet(`symbolic_--.#::`) // still does not exist
+      assertSymbolNotExistsOrNotLoadedYet(`symbolic_$minus$minus.#::`) // not existant yet
 
       // we will read the TASTy file of this class, causing an assertion error when we read the symbolic
       // package in tasty - the owners of the classroot do not match
-      forceTopLevel(`symbolic_$greater$greater.#::`)
+      forceTopLevel(`symbolic_$minus$minus.#::`)
 
     runTest(using Contexts.init(testClasspath))
   }

--- a/test-sources/src/main/scala/symbolic_--/lazyCons.scala
+++ b/test-sources/src/main/scala/symbolic_--/lazyCons.scala
@@ -1,0 +1,3 @@
+package symbolic_--
+
+class #::

--- a/test-sources/src/main/scala/symbolic_>>/lazyCons.scala
+++ b/test-sources/src/main/scala/symbolic_>>/lazyCons.scala
@@ -1,3 +1,0 @@
-package symbolic_>>
-
-class #::


### PR DESCRIPTION
git crashes when trying to create a directory with '>' in it on Windows.