### PR TITLE
Make `Symbol.{declaredType,tree,declarations}` be auto-loading.

### DIFF
--- a/jvm/src/test/scala/tastyquery/BaseUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/BaseUnpicklingSuite.scala
@@ -1,81 +1,9 @@
 package tastyquery
 
-import tastyquery.Contexts
-import tastyquery.Contexts.{defn, BaseContext}
-import tastyquery.ast.Trees.Tree
-import tastyquery.ast.Types.{Type, SymResolutionProblem}
-import tastyquery.ast.Names.{TypeName, SuffixedName, nme}
-import tastyquery.reader.TastyUnpickler
-
 import tastyquery.testutil.{testPlatform, TestPlatform}
-
-import java.nio.file.{Files, Paths}
-import tastyquery.ast.Names.Name
-
-import BaseUnpicklingSuite.Decls.*
-import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
-import tastyquery.ast.Names.SimpleName
-import dotty.tools.tasty.TastyFormat.NameTags
-import scala.annotation.targetName
-import tastyquery.ast.Symbols.ClassSymbol
 
 abstract class BaseUnpicklingSuite extends munit.FunSuite {
   given TestPlatform = tastyquery.testutil.jdk.JavaTestPlatform // TODO: make abstract so we can test scala.js
 
   lazy val testClasspath = testPlatform.loadClasspath()
-
-  def resolve(path: DeclarationPath)(using BaseContext): Symbol =
-    summon[BaseContext].findSymbolFromRoot(path.toNameList)
-
-  extension (sc: StringContext)
-    def name(args: Any*): SimpleName =
-      SimpleName(sc.parts.mkString)
-    def tname(args: Any*): TypeName =
-      TypeName(SimpleName(sc.parts.mkString))
-    def objclass(args: Any*): TypeName =
-      TypeName(SuffixedName(NameTags.OBJECTCLASS, SimpleName(sc.parts.mkString)))
-}
-
-object BaseUnpicklingSuite {
-  object Decls {
-
-    opaque type DeclarationPath = List[Name] // Min 1 element
-    opaque type PackageDeclPath <: DeclarationPath = List[Name] // packages
-    opaque type TopLevelDeclPath <: DeclarationPath = List[Name] // top level classes
-    opaque type MemberDeclPath <: DeclarationPath = List[Name] // local classes / values
-
-    extension (pkg: SimpleName) {
-      @targetName("selectPackage") def /(pkg1: SimpleName): PackageDeclPath = pkg :: pkg1 :: Nil
-      @targetName("selectTopLevel") def /(cls: TypeName): TopLevelDeclPath = pkg :: cls :: Nil
-      def singleton: PackageDeclPath = pkg :: Nil
-    }
-    extension (cls: TypeName) {
-      def singleton: TopLevelDeclPath = cls :: Nil
-    }
-    extension (pkgs: PackageDeclPath) {
-      @targetName("selectPackage") def /(pkg: SimpleName): PackageDeclPath = pkgs :+ pkg
-      @targetName("selectTopLevel") def /(cls: TypeName): TopLevelDeclPath = pkgs :+ cls
-    }
-    extension (cls: TopLevelDeclPath) {
-      @targetName("selectMember") def /(x: Name): MemberDeclPath = cls :+ x
-      def fullClassName: String = cls.show
-    }
-    extension (member: MemberDeclPath) {
-      @targetName("selectMemberFromMember") def /(x: Name): MemberDeclPath = member :+ x
-    }
-    extension (path: DeclarationPath) {
-      def toNameList: List[Name] = path
-      def root: Name = path.head
-      def foldRemainder[T](whenEmpty: => T)(follow: DeclarationPath => T): T = path.tail match {
-        case Nil => whenEmpty
-        case xs  => follow(xs)
-      }
-      def show: String = path.mkString(".")
-      def debug: String = BaseUnpicklingSuite.toDebugString(path)
-    }
-  }
-
-  extension (names: IterableOnce[Name]) {
-    def toDebugString: String = names.map(_.toDebugString).mkString(".")
-  }
 }

--- a/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
@@ -4,7 +4,7 @@ import tastyquery.Contexts.*
 import tastyquery.ast.Names.*
 import tastyquery.ast.Symbols.*
 
-import BaseUnpicklingSuite.Decls.*
+import Paths.*
 import RestrictedUnpicklingSuite.MissingTopLevelDecl
 
 /** The lazy-loading suite explicitly tests that some operations do, and do

--- a/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
@@ -1,0 +1,121 @@
+package tastyquery
+
+import tastyquery.Contexts.*
+import tastyquery.ast.Names.*
+import tastyquery.ast.Symbols.*
+
+import BaseUnpicklingSuite.Decls.*
+import RestrictedUnpicklingSuite.MissingTopLevelDecl
+
+/** The lazy-loading suite explicitly tests that some operations do, and do
+  * not, trigger loading of particular information.
+  *
+  * These tests intentionally break the auto-loading semantics of the API,
+  * through access to `private[tastyquery]` methods.
+  */
+class LazyLoadingSuite extends RestrictedUnpicklingSuite {
+  val simple_trees = name"simple_trees".singleton
+
+  /** Dangerous operations that break auto-loading semantics of the API.
+    *
+    * They can only do that because they access `private[tastyquery]` methods,
+    * in particular `Symbol.getDeclInternal`.
+    */
+  object DangerousOps {
+    def followPathImpl(root: DeclaringSymbol, path: DeclarationPath): Either[String, Symbol] = {
+      def follow(selected: Symbol)(remainder: DeclarationPath): Either[String, Symbol] = selected match {
+        case nextDecl: DeclaringSymbol =>
+          followPathImpl(nextDecl, remainder)
+        case someSym =>
+          val symDebug = clue(someSym).toDebugString
+          Left(s"Unexpected non-declaring symbol $symDebug with remaining path ${remainder.debug}")
+      }
+      for
+        selected <- select(root, path.root)
+        sym <- path.foldRemainder(Right(selected))(follow(selected))
+      yield sym
+    }
+
+    private def select(root: DeclaringSymbol, next: Name): Either[String, Symbol] = {
+      val sel = (root, next) match {
+        case (p: PackageClassSymbol, s: SimpleName) if p.name != nme.RootName =>
+          p.name.toTermName.select(s)
+        case _ => next
+      }
+      root.getDeclInternal(sel) match {
+        case Some(someSym) => Right(someSym)
+        case _ => Left(s"No declaration for ${next.toDebugString} [${sel.toDebugString}] in ${root.toDebugString}")
+      }
+    }
+  }
+
+  def assertSymbolExistsAndIsLoaded(path: DeclarationPath)(implicit ctx: BaseContext): Unit =
+    DangerousOps.followPathImpl(defn.RootPackage, path).fold(fail(_), _ => ())
+
+  def assertSymbolNotExistsOrNotLoadedYet(path: DeclarationPath)(implicit ctx: BaseContext): Unit =
+    def unexpected(sym: Symbol) = fail(s"expected no symbol, but found ${sym.toDebugString}")
+    DangerousOps.followPathImpl(defn.RootPackage, path).fold(_ => (), unexpected)
+
+  /** Explicitly initializes any symbol. */
+  def explicitlyInitialize(sym: Symbol)(using BaseContext): Unit =
+    sym match
+      case sym: DeclaringSymbol => sym.declarations // trigger the initialization
+      case _                    => () // already initialized, by construction
+
+  test("sibling-top-level-class-loading") {
+    val Constants = simple_trees / tname"Constants"
+    val NestedMethod = simple_trees / tname"NestedMethod"
+    val outerMethod = NestedMethod / name"outerMethod"
+    val unitVal = Constants / name"unitVal"
+
+    given BaseContext = getUnpicklingContext(Constants, extraClasspath = NestedMethod)
+
+    explicitlyInitialize(resolve(Constants))
+
+    assertSymbolExistsAndIsLoaded(Constants) // we should have loaded Constants, we requested it
+    assertSymbolExistsAndIsLoaded(unitVal) // outerMethod is a member of Constants, it should be seen.
+
+    assertSymbolExistsAndIsLoaded(NestedMethod) // sibling top-level class is also seen in same package
+    assertSymbolNotExistsOrNotLoadedYet(outerMethod) // members of sibling top-level class are not seen unless requested
+  }
+
+  test("demo-symbolic-package-leaks".ignore) {
+    // ignore because this passes only on clean builds
+
+    def failingGetTopLevelClass(path: TopLevelDeclPath)(using BaseContext): Nothing =
+      baseCtx.getClassIfDefined(path.fullClassName) match
+        case Right(classRoot) => fail(s"expected no class, but got $classRoot")
+        case Left(err)        => throw MissingTopLevelDecl(path, err)
+
+    def forceTopLevel(path: TopLevelDeclPath)(using BaseContext): Unit = {
+      val classRoot = baseCtx.getClassIfDefined(path.fullClassName) match
+        case Right(cls) => cls
+        case Left(err)  => throw MissingTopLevelDecl(path, err)
+      try
+        baseCtx.classloader.scanClass(classRoot)
+        fail(s"expected failure when scanning class ${path.fullClassName}, $classRoot")
+      catch
+        case err: java.lang.AssertionError =>
+          val msg = err.getMessage.nn
+          assert(
+            msg.contains("unexpected package symbolic_-- in owners of top level class symbolic_$minus$minus.#::")
+          )
+    }
+
+    def runTest(using BaseContext): Unit =
+      val `symbolic_--.#::` = name"symbolic_--" / tname"#::"
+      val `symbolic_$minus$minus.#::` = name"symbolic_$$minus$$minus" / tname"#::"
+
+      intercept[MissingTopLevelDecl] {
+        failingGetTopLevelClass(`symbolic_--.#::`) // this will fail, we can't find a symbolic package
+      }
+      assertSymbolNotExistsOrNotLoadedYet(`symbolic_--.#::`) // still does not exist
+      assertSymbolNotExistsOrNotLoadedYet(`symbolic_$minus$minus.#::`) // not existant yet
+
+      // we will read the TASTy file of this class, causing an assertion error when we read the symbolic
+      // package in tasty - the owners of the classroot do not match
+      forceTopLevel(`symbolic_$minus$minus.#::`)
+
+    runTest(using Contexts.init(testClasspath))
+  }
+}

--- a/jvm/src/test/scala/tastyquery/Paths.scala
+++ b/jvm/src/test/scala/tastyquery/Paths.scala
@@ -1,0 +1,68 @@
+package tastyquery
+
+import scala.annotation.targetName
+
+import dotty.tools.tasty.TastyFormat.NameTags
+
+import tastyquery.Contexts.*
+import tastyquery.ast.Names.*
+import tastyquery.ast.Symbols.*
+
+/** Utilities to work with top-level paths to symbols. */
+object Paths {
+  opaque type DeclarationPath = List[Name] // Min 1 element
+  opaque type PackageDeclPath <: DeclarationPath = List[Name] // packages
+  opaque type TopLevelDeclPath <: DeclarationPath = List[Name] // top level classes
+  opaque type MemberDeclPath <: DeclarationPath = List[Name] // local classes / values
+
+  def resolve(path: DeclarationPath)(using BaseContext): Symbol =
+    summon[BaseContext].findSymbolFromRoot(path.toNameList)
+
+  extension (sc: StringContext) {
+    def name(args: Any*): SimpleName =
+      SimpleName(sc.parts.mkString)
+    def tname(args: Any*): TypeName =
+      TypeName(SimpleName(sc.parts.mkString))
+    def objclass(args: Any*): TypeName =
+      TypeName(SuffixedName(NameTags.OBJECTCLASS, SimpleName(sc.parts.mkString)))
+  }
+
+  extension (pkg: SimpleName) {
+    @targetName("selectPackage") def /(pkg1: SimpleName): PackageDeclPath = pkg :: pkg1 :: Nil
+    @targetName("selectTopLevel") def /(cls: TypeName): TopLevelDeclPath = pkg :: cls :: Nil
+    def singleton: PackageDeclPath = pkg :: Nil
+  }
+
+  extension (cls: TypeName) {
+    def singleton: TopLevelDeclPath = cls :: Nil
+  }
+
+  extension (pkgs: PackageDeclPath) {
+    @targetName("selectPackage") def /(pkg: SimpleName): PackageDeclPath = pkgs :+ pkg
+    @targetName("selectTopLevel") def /(cls: TypeName): TopLevelDeclPath = pkgs :+ cls
+  }
+
+  extension (cls: TopLevelDeclPath) {
+    @targetName("selectMember") def /(x: Name): MemberDeclPath = cls :+ x
+    def fullClassName: String = cls.show
+  }
+
+  extension (member: MemberDeclPath) {
+    @targetName("selectMemberFromMember") def /(x: Name): MemberDeclPath = member :+ x
+  }
+
+  extension (path: DeclarationPath) {
+    def toNameList: List[Name] = path
+    def root: Name = path.head
+    def foldRemainder[T](whenEmpty: => T)(follow: DeclarationPath => T): T = path.tail match {
+      case Nil => whenEmpty
+      case xs  => follow(xs)
+    }
+    def show: String = path.mkString(".")
+    def debug: String = toDebugString(path)
+  }
+
+  extension (names: IterableOnce[Name]) {
+    def toDebugString: String = names.map(_.toDebugString).mkString(".")
+  }
+}

--- a/jvm/src/test/scala/tastyquery/PositionSuite.scala
+++ b/jvm/src/test/scala/tastyquery/PositionSuite.scala
@@ -13,7 +13,7 @@ import scala.reflect.TypeTest
 import scala.util.control.Exception.Catch
 import tastyquery.ast.Types.RefinedType
 
-class PositionSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false, allowDeps = false) {
+class PositionSuite extends RestrictedUnpicklingSuite {
   import BaseUnpicklingSuite.Decls.*
 
   val ResourceCodeProperty = "test-resources-code"

--- a/jvm/src/test/scala/tastyquery/PositionSuite.scala
+++ b/jvm/src/test/scala/tastyquery/PositionSuite.scala
@@ -1,21 +1,16 @@
 package tastyquery
 
-import tastyquery.Contexts
-import tastyquery.Contexts.FileContext
-import tastyquery.ast.Trees.*
-import tastyquery.ast.TypeTrees.*
-import tastyquery.ast.Spans.{Span, NoSpan}
-import tastyquery.reader.TastyUnpickler
-import tastyquery.reader.PositionUnpickler
-
 import scala.io.Source
 import scala.reflect.TypeTest
-import scala.util.control.Exception.Catch
-import tastyquery.ast.Types.RefinedType
+
+import tastyquery.ast.Trees.*
+import tastyquery.ast.TypeTrees.*
+import tastyquery.ast.Types.*
+import tastyquery.ast.Spans.*
+
+import Paths.*
 
 class PositionSuite extends RestrictedUnpicklingSuite {
-  import BaseUnpicklingSuite.Decls.*
-
   val ResourceCodeProperty = "test-resources-code"
 
   val empty_class = name"empty_class".singleton

--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1,20 +1,20 @@
 package tastyquery
 
+import dotty.tools.tasty.TastyFormat.NameTags
+
 import munit.Location
 
 import tastyquery.Contexts
 import tastyquery.ast.Constants.{ClazzTag, Constant, IntTag, NullTag}
 import tastyquery.ast.Names.*
-import tastyquery.ast.Symbols.{NoSymbol, Symbol}
+import tastyquery.ast.Symbols.*
 import tastyquery.ast.Trees.*
 import tastyquery.ast.TypeTrees.*
 import tastyquery.ast.Types.*
-import tastyquery.reader.TastyUnpickler
-import dotty.tools.tasty.TastyFormat.NameTags
+
+import Paths.*
 
 class ReadTreeSuite extends RestrictedUnpicklingSuite {
-  import BaseUnpicklingSuite.Decls.*
-
   type StructureCheck = PartialFunction[Tree, Unit]
   type TypeStructureCheck = PartialFunction[Type, Unit]
 

--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -12,7 +12,7 @@ import tastyquery.ast.Types.*
 import tastyquery.reader.TastyUnpickler
 import dotty.tools.tasty.TastyFormat.NameTags
 
-class ReadTreeSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false, allowDeps = false) {
+class ReadTreeSuite extends RestrictedUnpicklingSuite {
   import BaseUnpicklingSuite.Decls.*
 
   type StructureCheck = PartialFunction[Tree, Unit]

--- a/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
@@ -1,0 +1,37 @@
+package tastyquery
+
+import tastyquery.Contexts.BaseContext
+import tastyquery.ast.Symbols.{ClassSymbol, Symbol}
+import tastyquery.ast.Trees.Tree
+import tastyquery.ast.Types.{Type, SymResolutionProblem}
+
+import BaseUnpicklingSuite.Decls.*
+
+abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
+  import RestrictedUnpicklingSuite.*
+
+  def getUnpicklingContext(path: TopLevelDeclPath, extraClasspath: TopLevelDeclPath*): BaseContext =
+    initRestrictedContext(path, extraClasspath)
+
+  protected def findTopLevelClass(path: TopLevelDeclPath)(extras: TopLevelDeclPath*): (BaseContext, ClassSymbol) = {
+    val base = initRestrictedContext(path, extras)
+    val topLevelClass = path.fullClassName
+    val classRoot = base.getClassIfDefined(topLevelClass) match
+      case Right(cls) => cls
+      case Left(err)  => throw MissingTopLevelDecl(path, err)
+    if !base.classloader.scanClass(classRoot)(using base) then fail(s"could not initialise $topLevelClass, $classRoot")
+    (base, classRoot)
+  }
+
+  private def initRestrictedContext(path: TopLevelDeclPath, extras: Seq[TopLevelDeclPath]): BaseContext =
+    val classpath = testClasspath.withFilter((path :: extras.toList).map(_.fullClassName))
+    Contexts.init(classpath)
+}
+
+object RestrictedUnpicklingSuite {
+  class MissingTopLevelDecl(path: TopLevelDeclPath, cause: SymResolutionProblem)
+      extends Exception(
+        s"Missing top-level declaration ${path.fullClassName}, perhaps it is not on the classpath?",
+        cause
+      )
+}

--- a/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
@@ -1,11 +1,10 @@
 package tastyquery
 
 import tastyquery.Contexts.BaseContext
-import tastyquery.ast.Symbols.{ClassSymbol, Symbol}
-import tastyquery.ast.Trees.Tree
-import tastyquery.ast.Types.{Type, SymResolutionProblem}
+import tastyquery.ast.Symbols.ClassSymbol
+import tastyquery.ast.Types.SymResolutionProblem
 
-import BaseUnpicklingSuite.Decls.*
+import Paths.*
 
 abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
   import RestrictedUnpicklingSuite.*

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -5,8 +5,6 @@ import tastyquery.ast.Names.{nme, Name, SimpleName, TypeName}
 import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
 import tastyquery.ast.Symbols.ClassSymbol
 
-import RestrictedUnpicklingSuite.MissingTopLevelDecl
-
 class SymbolSuite extends RestrictedUnpicklingSuite {
   import BaseUnpicklingSuite.Decls.*
   import BaseUnpicklingSuite.toDebugString
@@ -135,63 +133,5 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
       // local method `innerMethod` is not a declaration of `outerMethod`
       Set.empty
     )
-  }
-
-  test("sibling-top-level-class-loading") {
-    val Constants = simple_trees / tname"Constants"
-    val NestedMethod = simple_trees / tname"NestedMethod"
-    val outerMethod = NestedMethod / name"outerMethod"
-    val unitVal = Constants / name"unitVal"
-
-    given BaseContext = getUnpicklingContext(Constants, extraClasspath = NestedMethod)
-
-    // Force resolution of the Constants class symbol
-    resolve(Constants).asClass.declarations
-
-    assertSymbolExistsAndIsLoaded(Constants) // we should have loaded Constants, we requested it
-    assertSymbolExistsAndIsLoaded(unitVal) // outerMethod is a member of Constants, it should be seen.
-
-    assertSymbolExistsAndIsLoaded(NestedMethod) // sibling top-level class is also seen in same package
-    assertSymbolNotExistsOrNotLoadedYet(outerMethod) // members of sibling top-level class are not seen unless requested
-  }
-
-  test("demo-symbolic-package-leaks".ignore) {
-    // ignore because this passes only on clean builds
-
-    def failingGetTopLevelClass(path: TopLevelDeclPath)(using BaseContext): Nothing =
-      baseCtx.getClassIfDefined(path.fullClassName) match
-        case Right(classRoot) => fail(s"expected no class, but got $classRoot")
-        case Left(err)        => throw MissingTopLevelDecl(path, err)
-
-    def forceTopLevel(path: TopLevelDeclPath)(using BaseContext): Unit = {
-      val classRoot = baseCtx.getClassIfDefined(path.fullClassName) match
-        case Right(cls) => cls
-        case Left(err)  => throw MissingTopLevelDecl(path, err)
-      try
-        baseCtx.classloader.scanClass(classRoot)
-        fail(s"expected failure when scanning class ${path.fullClassName}, $classRoot")
-      catch
-        case err: java.lang.AssertionError =>
-          val msg = err.getMessage.nn
-          assert(
-            msg.contains("unexpected package symbolic_-- in owners of top level class symbolic_$minus$minus.#::")
-          )
-    }
-
-    def runTest(using BaseContext): Unit =
-      val `symbolic_--.#::` = name"symbolic_--" / tname"#::"
-      val `symbolic_$minus$minus.#::` = name"symbolic_$$minus$$minus" / tname"#::"
-
-      intercept[MissingTopLevelDecl] {
-        failingGetTopLevelClass(`symbolic_--.#::`) // this will fail, we can't find a symbolic package
-      }
-      assertSymbolNotExistsOrNotLoadedYet(`symbolic_--.#::`) // still does not exist
-      assertSymbolNotExistsOrNotLoadedYet(`symbolic_$minus$minus.#::`) // not existant yet
-
-      // we will read the TASTy file of this class, causing an assertion error when we read the symbolic
-      // package in tasty - the owners of the classroot do not match
-      forceTopLevel(`symbolic_$minus$minus.#::`)
-
-    runTest(using Contexts.init(testClasspath))
   }
 }

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -1,14 +1,12 @@
 package tastyquery
 
-import tastyquery.Contexts.{BaseContext, baseCtx}
-import tastyquery.ast.Names.{nme, Name, SimpleName, TypeName}
-import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
-import tastyquery.ast.Symbols.ClassSymbol
+import tastyquery.Contexts.BaseContext
+import tastyquery.ast.Names.*
+import tastyquery.ast.Symbols.*
+
+import Paths.*
 
 class SymbolSuite extends RestrictedUnpicklingSuite {
-  import BaseUnpicklingSuite.Decls.*
-  import BaseUnpicklingSuite.toDebugString
-
   val empty_class = name"empty_class".singleton
   val simple_trees = name"simple_trees".singleton
   val `simple_trees.nested` = simple_trees / name"nested"

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -5,7 +5,9 @@ import tastyquery.ast.Names.{nme, Name, SimpleName, TypeName}
 import tastyquery.ast.Symbols.{DeclaringSymbol, PackageClassSymbol, Symbol}
 import tastyquery.ast.Symbols.ClassSymbol
 
-class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = false, allowDeps = false) {
+import RestrictedUnpicklingSuite.MissingTopLevelDecl
+
+class SymbolSuite extends RestrictedUnpicklingSuite {
   import BaseUnpicklingSuite.Decls.*
   import BaseUnpicklingSuite.toDebugString
 
@@ -142,6 +144,9 @@ class SymbolSuite extends BaseUnpicklingSuite(withClasses = false, withStdLib = 
     val unitVal = Constants / name"unitVal"
 
     given BaseContext = getUnpicklingContext(Constants, extraClasspath = NestedMethod)
+
+    // Force resolution of the Constants class symbol
+    resolve(Constants).asClass.declarations
 
     assertSymbolExistsAndIsLoaded(Constants) // we should have loaded Constants, we requested it
     assertSymbolExistsAndIsLoaded(unitVal) // outerMethod is a member of Constants, it should be seen.

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -1,17 +1,16 @@
 package tastyquery
 
+import scala.collection.mutable
+
 import tastyquery.Contexts.BaseContext
 import tastyquery.ast.Names.*
 import tastyquery.ast.Symbols.*
 import tastyquery.ast.Trees.*
 import tastyquery.ast.Types.*
 
-import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
+import Paths.*
 
 class TypeSuite extends UnrestrictedUnpicklingSuite {
-  import BaseUnpicklingSuite.Decls.*
-
   def assertIsSymbolWithPath(path: DeclarationPath)(actualSymbol: Symbol)(using BaseContext): Unit = {
     val expectedSymbol = resolve(path)
     assert(actualSymbol eq expectedSymbol, clues(actualSymbol, expectedSymbol))

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -9,7 +9,7 @@ import tastyquery.ast.Types.*
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
-class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = true, allowDeps = true) {
+class TypeSuite extends UnrestrictedUnpicklingSuite {
   import BaseUnpicklingSuite.Decls.*
 
   def assertIsSymbolWithPath(path: DeclarationPath)(actualSymbol: Symbol)(using BaseContext): Unit = {
@@ -50,10 +50,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     def isArrayOf(arg: (Type | TypeBounds) => Boolean)(using BaseContext): Boolean =
       isApplied(_.isRef(resolve(name"scala" / tname"Array")), Seq(arg))
 
-  test("apply-recursive") {
+  testWithContext("apply-recursive") {
     val RecApply = name"simple_trees" / tname"RecApply"
-
-    given BaseContext = getUnpicklingContext(RecApply)
 
     val gcdSym = resolve(RecApply / name"gcd")
     val NumClass = resolve(RecApply / tname"Num")
@@ -77,15 +75,13 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
   }
 
-  test("java.lang-is-not-loaded".fail) {
-    getUnpicklingContext(name"java" / name"lang" / tname"String")
+  testWithContext("java.lang-is-not-loaded".fail) {
+    resolve(name"java" / name"lang" / tname"String").declaredType
   }
 
   def applyOverloadedTest(name: String)(callMethod: String, paramCls: DeclarationPath)(using munit.Location): Unit =
-    test(name) {
+    testWithContext(name) {
       val OverloadedApply = name"simple_trees" / tname"OverloadedApply"
-
-      given BaseContext = getUnpicklingContext(OverloadedApply)
 
       val callSym = resolve(OverloadedApply / termName(callMethod))
       val Acls = resolve(paramCls)
@@ -118,10 +114,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
   // applyOverloadedTest("apply-overloaded-arrayObj")("callD", name"scala" / tname"Array") // TODO: re-enable when we add types to scala 2 symbols
   applyOverloadedTest("apply-overloaded-byName")("callE", name"simple_trees" / tname"OverloadedApply" / tname"Num")
 
-  test("typeapply-recursive") {
+  testWithContext("typeapply-recursive") {
     val RecApply = name"simple_trees" / tname"RecApply"
-
-    given BaseContext = getUnpicklingContext(RecApply)
 
     val evalSym = resolve(RecApply / name"eval")
     val ExprClass = resolve(RecApply / tname"Expr")
@@ -149,10 +143,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
   }
 
-  test("basic-local-val") {
+  testWithContext("basic-local-val") {
     val AssignPath = name"simple_trees" / tname"Assign"
-
-    given BaseContext = getUnpicklingContext(AssignPath)
 
     val fSym = resolve(AssignPath / name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
@@ -192,10 +184,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(yCount == 1, clue(yCount))
   }
 
-  test("term-ref") {
+  testWithContext("term-ref") {
     val RepeatedPath = name"simple_trees" / tname"Repeated"
-
-    given BaseContext = getUnpicklingContext(RepeatedPath)
 
     val fSym = resolve(RepeatedPath / name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
@@ -217,10 +207,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(bitSetIdentCount == 1, clue(bitSetIdentCount))
   }
 
-  test("free-ident") {
+  testWithContext("free-ident") {
     val MatchPath = name"simple_trees" / tname"Match"
-
-    given BaseContext = getUnpicklingContext(MatchPath)
 
     val fSym = resolve(MatchPath / name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
@@ -246,10 +234,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(freeIdentCount == 2, clue(freeIdentCount))
   }
 
-  test("return") {
+  testWithContext("return") {
     val ReturnPath = name"simple_trees" / tname"Return"
-
-    given BaseContext = getUnpicklingContext(ReturnPath)
 
     val withReturnSym = resolve(ReturnPath / name"withReturn")
     val withReturnTree = withReturnSym.tree.get.asInstanceOf[DefDef]
@@ -270,10 +256,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(returnCount == 1, clue(returnCount))
   }
 
-  test("assign") {
+  testWithContext("assign") {
     val AssignPath = name"simple_trees" / tname"Assign"
-
-    given BaseContext = getUnpicklingContext(AssignPath)
 
     val fSym = resolve(AssignPath / name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
@@ -294,10 +278,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(assignCount == 1, clue(assignCount))
   }
 
-  test("basic-scala2-types") {
+  testWithContext("basic-scala2-types") {
     val ScalaRange = name"scala" / name"collection" / name"immutable" / tname"Range"
-
-    given BaseContext = getUnpicklingContext(ScalaRange)
 
     val rangeSym = resolve(ScalaRange)
     assert(rangeSym.isClass, rangeSym)
@@ -346,11 +328,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     }
   }
 
-  test("basic-java-class-dependency") {
+  testWithContext("basic-java-class-dependency") {
     val BoxedJava = name"javacompat" / tname"BoxedJava"
     val JavaDefined = name"javadefined" / tname"JavaDefined"
-
-    given BaseContext = getUnpicklingContext(BoxedJava)
 
     val boxedSym = resolve(BoxedJava / name"boxed")
 
@@ -359,10 +339,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assertIsSymbolWithPath(JavaDefined)(JavaDefinedRef.resolveToSymbol)
   }
 
-  test("bag-of-java-definitions") {
+  testWithContext("bag-of-java-definitions") {
     val BagOfJavaDefinitions = name"javadefined" / tname"BagOfJavaDefinitions"
 
-    given BaseContext = getUnpicklingContext(BagOfJavaDefinitions)
     val IntClass = resolve(name"scala" / tname"Int")
     val UnitClass = resolve(name"scala" / tname"Unit")
 
@@ -398,11 +377,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
   }
 
-  test("bag-of-generic-java-definitions[signatures]") {
+  testWithContext("bag-of-generic-java-definitions[signatures]") {
     val BagOfGenJavaDefinitions = name"javadefined" / tname"BagOfGenJavaDefinitions"
-
-    given BaseContext = getUnpicklingContext(BagOfGenJavaDefinitions)
-
     val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
     val GenericJavaClass = resolve(name"javadefined" / tname"GenericJavaClass")
     val JavaInterface1 = resolve(name"javadefined" / tname"JavaInterface1")
@@ -469,10 +445,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     }
   }
 
-  test("java-class-parents") {
+  testWithContext("java-class-parents") {
     val SubJavaDefined = name"javadefined" / tname"SubJavaDefined"
-
-    given BaseContext = getUnpicklingContext(SubJavaDefined)
 
     val (SubJavaDefinedTpe @ _: ClassType) = resolve(SubJavaDefined).declaredType: @unchecked
 
@@ -486,9 +460,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     )
   }
 
-  test("java-class-signatures-[RecClass]") {
+  testWithContext("java-class-signatures-[RecClass]") {
     val RecClass = name"javadefined" / tname"RecClass"
-    given BaseContext = getUnpicklingContext(RecClass)
 
     val (RecClassTpe @ _: ClassType) = resolve(RecClass).declaredType: @unchecked
 
@@ -497,9 +470,8 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(RecClassTpe.rawParents.isRef(ObjectClass))
   }
 
-  test("java-class-signatures-[SubRecClass]") {
+  testWithContext("java-class-signatures-[SubRecClass]") {
     val SubRecClass = name"javadefined" / tname"SubRecClass"
-    given BaseContext = getUnpicklingContext(SubRecClass)
 
     val (SubRecClassTpe @ _: ClassType) = resolve(SubRecClass).declaredType: @unchecked
 
@@ -519,11 +491,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     )
   }
 
-  test("select-method-from-java-class") {
+  testWithContext("select-method-from-java-class") {
     val BoxedJava = name"javacompat" / tname"BoxedJava"
     val getX = name"javadefined" / tname"JavaDefined" / name"getX"
-
-    given BaseContext = getUnpicklingContext(BoxedJava)
 
     val xMethodSym = resolve(BoxedJava / name"xMethod")
 
@@ -534,11 +504,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assertIsSymbolWithPath(getX)(getXRef.resolveToSymbol)
   }
 
-  test("select-field-from-java-class") {
+  testWithContext("select-field-from-java-class") {
     val BoxedJava = name"javacompat" / tname"BoxedJava"
     val x = name"javadefined" / tname"JavaDefined" / name"x"
-
-    given BaseContext = getUnpicklingContext(BoxedJava)
 
     val xFieldSym = resolve(BoxedJava / name"xField")
 
@@ -549,11 +517,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assertIsSymbolWithPath(x)(xRef.resolveToSymbol)
   }
 
-  test("basic-scala-2-stdlib-class-dependency") {
+  testWithContext("basic-scala-2-stdlib-class-dependency") {
     val BoxedCons = name"scala2compat" / tname"BoxedCons"
     val :: = name"scala" / name"collection" / name"immutable" / tname"::"
-
-    given BaseContext = getUnpicklingContext(BoxedCons)
 
     val ConsClass = resolve(::)
     val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
@@ -565,11 +531,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(targ.isOfClass(JavaDefinedClass), clue(targ))
   }
 
-  test("select-method-from-scala-2-stdlib-class") {
+  testWithContext("select-method-from-scala-2-stdlib-class") {
     val BoxedCons = name"scala2compat" / tname"BoxedCons"
     val canEqual = name"scala" / name"collection" / tname"Seq" / name"canEqual"
-
-    given BaseContext = getUnpicklingContext(BoxedCons)
 
     val AnyClass = resolve(name"scala" / tname"Any")
     val BooleanClass = resolve(name"scala" / tname"Boolean")
@@ -589,11 +553,9 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assert(resTpe.isOfClass(BooleanClass), clue(resTpe))
   }
 
-  test("select-field-from-tasty-in-other-package:dependency-from-class-file") {
+  testWithContext("select-field-from-tasty-in-other-package:dependency-from-class-file") {
     val BoxedConstants = name"crosspackagetasty" / tname"BoxedConstants"
     val unitVal = name"simple_trees" / tname"Constants" / name"unitVal"
-
-    given BaseContext = getUnpicklingContext(BoxedConstants)
 
     val boxedUnitValSym = resolve(BoxedConstants / name"boxedUnitVal")
 
@@ -604,7 +566,7 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
     assertIsSymbolWithPath(unitVal)(unitValRef.resolveToSymbol)
   }
 
-  test("select-method-from-java-class-same-package-as-tasty") {
+  testWithContext("select-method-from-java-class-same-package-as-tasty") {
     // This tests reading top level classes in the same package, defined by
     // both Java and Tasty. If we strictly require that all symbols are defined
     // exactly once, then we must be careful to not redefine `ScalaBox`/`JavaBox`
@@ -612,8 +574,6 @@ class TypeSuite extends BaseUnpicklingSuite(withClasses = true, withStdLib = tru
 
     val ScalaBox = name"mixjavascala" / tname"ScalaBox"
     val getX = name"mixjavascala" / tname"JavaBox" / name"getX"
-
-    given BaseContext = getUnpicklingContext(ScalaBox)
 
     val xMethodSym = resolve(ScalaBox / name"xMethod")
 

--- a/jvm/src/test/scala/tastyquery/UnrestrictedUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/UnrestrictedUnpicklingSuite.scala
@@ -1,0 +1,14 @@
+package tastyquery
+
+import tastyquery.Contexts.BaseContext
+
+abstract class UnrestrictedUnpicklingSuite extends BaseUnpicklingSuite {
+  def testWithContext(name: String)(using munit.Location)(body: BaseContext ?=> Unit): Unit =
+    testWithContext(new munit.TestOptions(name))(body)
+
+  def testWithContext(options: munit.TestOptions)(using munit.Location)(body: BaseContext ?=> Unit): Unit =
+    test(options) {
+      val ctx = Contexts.init(testClasspath)
+      body(using ctx)
+    }
+}

--- a/jvm/src/test/scala/tastyquery/testutil/jdk/JavaTestPlatform.scala
+++ b/jvm/src/test/scala/tastyquery/testutil/jdk/JavaTestPlatform.scala
@@ -18,11 +18,9 @@ object JavaTestPlatform extends TestPlatform {
     Properties.propOrEmpty(StdLibProperty).split(File.pathSeparator).toList
   }
 
-  def loadClasspath(includeClasses: Boolean, includeStdLib: Boolean): Classpath = {
-    val parts0 = resourcesDir :: Nil
-    val kinds0 = Set(ClasspathLoaders.FileKind.Tasty)
-    val kinds = if includeClasses then kinds0 + ClasspathLoaders.FileKind.Class else kinds0
-    val parts = if includeStdLib then parts0 ::: stdLibPaths else parts0
+  def loadClasspath(): Classpath = {
+    val kinds = Set(ClasspathLoaders.FileKind.Tasty, ClasspathLoaders.FileKind.Class)
+    val parts = resourcesDir :: stdLibPaths
     ClasspathLoaders.read(parts, kinds)
   }
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -40,7 +40,7 @@ object Symbols {
       myTree = Some(t)
       this
     }
-    final def tree: Option[DefTree] = myTree
+    def tree(using BaseContext): Option[DefTree] = myTree
 
     private var myDeclaredType: Type | Null = null
 
@@ -87,7 +87,7 @@ object Symbols {
       case null          => NoSymbol
     }
 
-    final def paramSymss: List[List[Symbol]] =
+    final def paramSymss(using BaseContext): List[List[Symbol]] =
       tree match
         case Some(ddef: DefDef) =>
           ddef.paramLists.map {
@@ -206,6 +206,10 @@ object Symbols {
       */
     private[tastyquery] def ensureInitialised()(using BaseContext): Unit =
       ()
+
+    override def tree(using BaseContext): Option[DefTree] =
+      ensureInitialised()
+      super.tree
 
     private[Symbols] final def hasOverloads(name: SignedName): Boolean =
       myDeclarations.get(name.underlying) match

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -64,7 +64,7 @@ object Symbols {
       if isFlagsInitialized then myFlags
       else throw IllegalStateException(s"flags of $this have not been initialized")
 
-    def declaredType: Type =
+    def declaredType(using BaseContext): Type =
       val local = myDeclaredType
       if local != null then local
       else throw new IllegalStateException(s"$this was not assigned a declared type")
@@ -277,6 +277,10 @@ object Symbols {
         maybeOuter match
           case pre: ClassSymbol => TypeRef(pre.accessibleThisType, cls)
           case _                => TypeRef(NoPrefix, cls)
+
+    override def declaredType(using BaseContext): Type =
+      ensureInitialised()
+      super.declaredType
 
     override final def getDecl(name: Name)(using BaseContext): Option[Symbol] =
       ensureInitialised()

--- a/shared/src/test/scala/tastyquery/testutil/TestPlatform.scala
+++ b/shared/src/test/scala/tastyquery/testutil/TestPlatform.scala
@@ -5,5 +5,5 @@ import tastyquery.reader.classfiles.Classpaths.Classpath
 transparent inline def testPlatform(using testPlatform: TestPlatform): testPlatform.type = testPlatform
 
 trait TestPlatform {
-  def loadClasspath(includeClasses: Boolean, includeStdLib: Boolean): Classpath
+  def loadClasspath(): Classpath
 }


### PR DESCRIPTION
~~Based on #63.~~