### PR TITLE
Fix the spans of shared tags

### DIFF
--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -665,7 +665,7 @@ class TreeUnpickler(
     case SHAREDterm =>
       val spn = span
       reader.readByte()
-      forkAt(reader.readAddr()).readTerm
+      forkAt(reader.readAddr()).readTerm.withSpan(spn)
 
     // paths
     case THIS =>
@@ -703,7 +703,7 @@ class TreeUnpickler(
     case SHAREDtype =>
       val spn = span
       reader.readByte()
-      forkAt(reader.readAddr()).readTerm
+      forkAt(reader.readAddr()).readTerm.withSpan(spn)
     case tag if isConstantTag(tag) =>
       val spn = span
       Literal(readConstant)(spn)
@@ -964,8 +964,9 @@ class TreeUnpickler(
       reader.readByte()
       ByNameTypeTree(readTypeTree)(spn)
     case SHAREDterm =>
+      val spn = span
       reader.readByte()
-      forkAt(reader.readAddr()).readTypeTree
+      forkAt(reader.readAddr()).readTypeTree.withSpan(spn)
     case tag if isTypeTreeTag(tag) =>
       throw TreeUnpicklerException(s"Unexpected type tree tag ${astTagToString(tag)} $posErrorMsg")
     case _ => TypeWrapper(readType)(span)

--- a/test-sources/src/main/scala/simple_trees/SharedType.scala
+++ b/test-sources/src/main/scala/simple_trees/SharedType.scala
@@ -1,0 +1,7 @@
+package simple_trees
+
+class SharedType:
+  
+  def f: Unit =
+    println()
+    println()


### PR DESCRIPTION
This is a fix for the spans of `SHAREDterm` and `SHAREDtype`. In the previous implementation, the spans are incorrectly set to the span of the term/path they reference to.