### PR TITLE
Explicitly wrap TypeBounds as WildcardTypeBounds in AppliedTypes.

### DIFF
--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1604,9 +1604,11 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             TypeWrapper(
               AppliedType(
                 TypeRef(PackageRef(_), TypeName(SimpleName("List"))),
-                RealTypeBounds(
-                  TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing"))),
-                  TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Any")))
+                WildcardTypeBounds(
+                  RealTypeBounds(
+                    TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing"))),
+                    TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Any")))
+                  )
                 ) :: Nil
               )
             ),
@@ -1622,9 +1624,11 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("anyList"),
             AppliedTypeTree(
               TypeIdent(TypeName(SimpleName("List"))),
-              TypeBoundsTree(
-                TypeWrapper(TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing")))),
-                TypeWrapper(TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Any"))))
+              WildcardTypeBoundsTree(
+                TypeBoundsTree(
+                  TypeWrapper(TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing")))),
+                  TypeWrapper(TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Any"))))
+                )
               ) :: Nil
             ),
             EmptyTree,
@@ -1638,9 +1642,13 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case New(
             AppliedTypeTree(
               TypeIdent(TypeName(SimpleName("GenericWithTypeBound"))),
-              RealTypeBounds(
-                TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing"))),
-                TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("AnyKind")))
+              TypeWrapper(
+                WildcardTypeBounds(
+                  RealTypeBounds(
+                    TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("Nothing"))),
+                    TypeRef(PackageRef(SimpleName("scala")), TypeName(SimpleName("AnyKind")))
+                  )
+                )
               ) :: Nil
             )
           ) =>

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -70,17 +70,9 @@ object TypeTrees {
   /** tpt[args]
     * TypeBounds[Tree] for wildcard application: tpt[_], tpt[?]
     */
-  case class AppliedTypeTree(tycon: TypeTree, args: List[TypeTree | TypeBoundsTree | TypeBounds])(span: Span)
-      extends TypeTree(span) {
+  case class AppliedTypeTree(tycon: TypeTree, args: List[TypeTree])(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
-      AppliedType(
-        tycon.toType,
-        args.map {
-          case arg: TypeTree       => arg.toType
-          case arg: TypeBoundsTree => arg.toTypeBounds
-          case arg: TypeBounds     => arg
-        }
-      )
+      AppliedType(tycon.toType, args.map(_.toType))
 
     override final def withSpan(span: Span): AppliedTypeTree = AppliedTypeTree(tycon, args)(span)
   }
@@ -156,6 +148,14 @@ object TypeTrees {
       NamedTypeBounds(name, bounds)
 
     override final def withSpan(span: Span): NamedTypeBoundsTree = NamedTypeBoundsTree(name, bounds)(span)
+  }
+
+  case class WildcardTypeBoundsTree(bounds: TypeBoundsTree)(span: Span) extends TypeTree(span) {
+    override protected def calculateType(using Context): Type =
+      WildcardTypeBounds(bounds.toTypeBounds)
+
+    override final def withSpan(span: Span): WildcardTypeBoundsTree =
+      WildcardTypeBoundsTree(bounds)(span)
   }
 
   case class TypeLambdaTree(tparams: List[TypeParam], body: TypeTree)(span: Span) extends TypeTree(span) {

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -468,7 +468,7 @@ object Types {
   /** A type application `C[T_1, ..., T_n]`
     * Typebounds for wildcard application: C[_], C[?]
     */
-  case class AppliedType(tycon: Type, args: List[Type | TypeBounds]) extends TypeProxy with ValueType {
+  case class AppliedType(tycon: Type, args: List[Type]) extends TypeProxy with ValueType {
     override def underlying(using Context): Type = tycon
   }
 
@@ -599,6 +599,10 @@ object Types {
   case class BoundedType(bounds: TypeBounds, alias: Type) extends Type
 
   case class NamedTypeBounds(name: TypeName, bounds: TypeBounds) extends Type
+
+  case class WildcardTypeBounds(bounds: TypeBounds) extends TypeProxy {
+    override def underlying(using Context): Type = bounds.high
+  }
 
   // ----- Ground Types -------------------------------------------------
 

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -804,7 +804,10 @@ class TreeUnpickler(
       val end = reader.readEnd()
       val tycon = readType
       // TODO: type operations can be much more complicated
-      AppliedType(tycon, reader.until(end)(if (tagFollowShared == TYPEBOUNDS) readTypeBounds else readType))
+      AppliedType(
+        tycon,
+        reader.until(end)(if (tagFollowShared == TYPEBOUNDS) WildcardTypeBounds(readTypeBounds) else readType)
+      )
     case THIS =>
       reader.readByte()
       ThisType(readType.asInstanceOf[TypeRef])
@@ -896,8 +899,8 @@ class TreeUnpickler(
       AppliedTypeTree(
         tycon,
         reader.until(end)(
-          if (tagFollowShared == TYPEBOUNDS) readTypeBounds
-          else if (tagFollowShared == TYPEBOUNDStpt) readTypeBoundsTree
+          if (tagFollowShared == TYPEBOUNDS) TypeWrapper(WildcardTypeBounds(readTypeBounds))(spn)
+          else if (tagFollowShared == TYPEBOUNDStpt) WildcardTypeBoundsTree(readTypeBoundsTree)(spn)
           else readTypeTree
         )
       )(spn)

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -18,13 +18,13 @@ object Descriptors:
     val superRef = superClass.map(classRef).getOrElse(ObjectType)
     interfaces.foldLeft(superRef)((parents, interface) => AndType(parents, classRef(interface)))
 
-  private[tastyquery] def rawTypeArguments(cls: ClassSymbol)(using Context): List[TypeBounds] =
+  private[tastyquery] def rawTypeArguments(cls: ClassSymbol)(using Context): List[WildcardTypeBounds] =
     if !cls.initParents then
       // we have initialised our own parents,
       // therefore it is an external class,
       // force it so we can see its type params.
       cls.ensureInitialised()
-    cls.typeParamSyms.map(Function.const(RealTypeBounds(NothingType, AnyType)))
+    cls.typeParamSyms.map(Function.const(WildcardTypeBounds(RealTypeBounds(NothingType, AnyType))))
 
   private def classRef(binaryName: String)(using Context): Type =
     val className = binaryName.replace('/', '.').nn

--- a/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -185,16 +185,20 @@ object JavaSignatures:
       else None
     end classTypeSignature
 
-    def typeArgument(env: JavaSignature): Type | TypeBounds =
+    def typeArgument(env: JavaSignature): Type =
       if available >= 1 then
         (peek: @switch) match
-          case '*' => commitSimple(1, RealTypeBounds(NothingType, AnyType))
-          case '+' => commit(1) { val upper = referenceType(env); RealTypeBounds(NothingType, upper) }
-          case '-' => commit(1) { val lower = referenceType(env); RealTypeBounds(lower, AnyType) }
-          case _   => referenceType(env)
+          case '*' =>
+            commitSimple(1, WildcardTypeBounds(RealTypeBounds(NothingType, AnyType)))
+          case '+' =>
+            commit(1) { val upper = referenceType(env); WildcardTypeBounds(RealTypeBounds(NothingType, upper)) }
+          case '-' =>
+            commit(1) { val lower = referenceType(env); WildcardTypeBounds(RealTypeBounds(lower, AnyType)) }
+          case _ =>
+            referenceType(env)
       else abort
 
-    def typeArgumentsRest(env: JavaSignature): List[Type | TypeBounds] =
+    def typeArgumentsRest(env: JavaSignature): List[Type] =
       readUntil('>', typeArgument(env))
 
     def typeParameter(env: JavaSignature): TypeBounds =


### PR DESCRIPTION
TypeBounds of the form `>: L <: H` used in AppliedTypes actually mean wildcards of the form `? >: L <: H`. Previously, we carried around `Type | TypeBounds` in many places. Now, we explicitly wrap `TypeBounds` in a `WildcardTypeBounds` in places where they mean wildcards.

A corresponding change is done to `TypeTree`s.