### PR TITLE
Fix ReadTreeSuite.testUnpickle; it was void.

### DIFF
--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -65,7 +65,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       val tree = cls.tree.getOrElse {
         fail(s"Missing tasty for ${path.fullClassName}, $cls")
       }
-      tree.asInstanceOf[Tree]
+      body(tree.asInstanceOf[Tree])
     }
   end testUnpickle
 


### PR DESCRIPTION
We did not actually call the provided `body` lambda, so the test was completely void.