### PR TITLE
unpickling top level classpath symbols can be done in any order

### DIFF
--- a/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/LazyLoadingSuite.scala
@@ -14,7 +14,7 @@ import RestrictedUnpicklingSuite.MissingTopLevelDecl
   * through access to `private[tastyquery]` methods.
   */
 class LazyLoadingSuite extends RestrictedUnpicklingSuite {
-  val simple_trees = name"simple_trees".singleton
+  val simple_trees = RootPkg / name"simple_trees"
 
   /** Dangerous operations that break auto-loading semantics of the API.
     *
@@ -75,17 +75,17 @@ class LazyLoadingSuite extends RestrictedUnpicklingSuite {
     // ignore because this passes only on clean builds
 
     def failingGetTopLevelClass(path: TopLevelDeclPath)(using Context): Nothing =
-      ctx.getClassIfDefined(path.fullClassName) match
+      ctx.getClassIfDefined(path.rootClassName) match
         case Right(classRoot) => fail(s"expected no class, but got $classRoot")
         case Left(err)        => throw MissingTopLevelDecl(path, err)
 
     def forceTopLevel(path: TopLevelDeclPath)(using Context): Unit = {
-      val classRoot = ctx.getClassIfDefined(path.fullClassName) match
+      val classRoot = ctx.getClassIfDefined(path.rootClassName) match
         case Right(cls) => cls
         case Left(err)  => throw MissingTopLevelDecl(path, err)
       try
         ctx.classloader.scanClass(classRoot)
-        fail(s"expected failure when scanning class ${path.fullClassName}, $classRoot")
+        fail(s"expected failure when scanning class ${path.rootClassName}, $classRoot")
       catch
         case err: java.lang.AssertionError =>
           val msg = err.getMessage.nn

--- a/jvm/src/test/scala/tastyquery/PositionSuite.scala
+++ b/jvm/src/test/scala/tastyquery/PositionSuite.scala
@@ -13,9 +13,9 @@ import Paths.*
 class PositionSuite extends RestrictedUnpicklingSuite {
   val ResourceCodeProperty = "test-resources-code"
 
-  val empty_class = name"empty_class".singleton
-  val simple_trees = name"simple_trees".singleton
-  val imports = name"imports".singleton
+  val empty_class = RootPkg / name"empty_class"
+  val simple_trees = RootPkg / name"simple_trees"
+  val imports = RootPkg / name"imports"
 
   private def getCodePath(name: String): String =
     var Array(dir, filename) = name.split('.')
@@ -28,8 +28,8 @@ class PositionSuite extends RestrictedUnpicklingSuite {
     val (base, classRoot) = findTopLevelClass(path)()
     val tree = base.classloader.topLevelTasty(classRoot)(using base) match
       case Some(trees) => trees.head
-      case _           => fail(s"Missing tasty for ${path.fullClassName}, $classRoot")
-    val codePath = getCodePath(path.fullClassName)
+      case _           => fail(s"Missing tasty for ${path.rootClassName}, $classRoot")
+    val codePath = getCodePath(path.rootClassName)
     val code = Source.fromFile(codePath).mkString
     (tree, code)
   }

--- a/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
+++ b/jvm/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
@@ -14,7 +14,7 @@ abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
 
   protected def findTopLevelClass(path: TopLevelDeclPath)(extras: TopLevelDeclPath*): (Context, ClassSymbol) = {
     val base = initRestrictedContext(path, extras)
-    val topLevelClass = path.fullClassName
+    val topLevelClass = path.rootClassName
     val classRoot = base.getClassIfDefined(topLevelClass) match
       case Right(cls) => cls
       case Left(err)  => throw MissingTopLevelDecl(path, err)
@@ -23,14 +23,14 @@ abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
   }
 
   private def initRestrictedContext(path: TopLevelDeclPath, extras: Seq[TopLevelDeclPath]): Context =
-    val classpath = testClasspath.withFilter((path :: extras.toList).map(_.fullClassName))
+    val classpath = testClasspath.withFilter((path :: extras.toList).map(_.rootClassName))
     Contexts.init(classpath)
 }
 
 object RestrictedUnpicklingSuite {
   class MissingTopLevelDecl(path: TopLevelDeclPath, cause: SymResolutionProblem)
       extends Exception(
-        s"Missing top-level declaration ${path.fullClassName}, perhaps it is not on the classpath?",
+        s"Missing top-level declaration ${path.rootClassName}, perhaps it is not on the classpath?",
         cause
       )
 }

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -1,9 +1,7 @@
 package tastyquery
 
 import tastyquery.ast.Names.nme
-import tastyquery.ast.Symbols.PackageClassSymbol
+import tastyquery.ast.Symbols.PackageClassSymbolFactory
 
-class Definitions {
-  val RootPackage = PackageClassSymbol(nme.RootName, null)
-  val EmptyPackage = PackageClassSymbol(nme.EmptyPackageName, RootPackage)
-}
+class Definitions:
+  val (RootPackage @ _, EmptyPackage @ _) = PackageClassSymbolFactory.createRoots

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -294,8 +294,12 @@ object Names {
       case SuffixedName(NameTags.OBJECTCLASS, _) => true
       case _                                     => false
 
-    def toObjectName: TypeName =
-      if wrapsObjectName then this
-      else toTermName.withObjectSuffix.toTypeName
+    def companionName: TypeName = toTermName match
+      case SuffixedName(NameTags.OBJECTCLASS, clsName) => clsName.toTypeName
+      case name                                        => name.withObjectSuffix.toTypeName
+
+    def sourceObjectName: TermName = toTermName match
+      case SuffixedName(NameTags.OBJECTCLASS, objName) => objName
+      case name                                        => name
   }
 }


### PR DESCRIPTION
with these changes you can force top-level module class, module value, or class in any order. The root class will be selected

fixes #72 