### PR TITLE
Only enter top level root symbols when reading the class/tasty file.

### DIFF
--- a/jvm/src/test/scala/tastyquery/Paths.scala
+++ b/jvm/src/test/scala/tastyquery/Paths.scala
@@ -24,8 +24,8 @@ object Paths:
       SimpleName(sc.parts.mkString)
     def tname(args: Any*): TypeName =
       TypeName(SimpleName(sc.parts.mkString))
-    def objclass(args: Any*): TypeName =
-      TypeName(SuffixedName(NameTags.OBJECTCLASS, SimpleName(sc.parts.mkString)))
+
+  case object obj
 
   val RootPkg: PackageDeclPath = Nil
   val EmptyPkg: PackageDeclPath = nme.EmptyPackageName :: Nil
@@ -33,11 +33,12 @@ object Paths:
   extension (pkg: SimpleName)
     @targetName("selectPackage") def /(pkg1: SimpleName): PackageDeclPath = pkg :: pkg1 :: Nil
     @targetName("selectTopLevel") def /(cls: TypeName): TopLevelClassDeclPath = pkg :: cls :: Nil
+    @targetName("selectModule") def /(asObj: obj.type): TopLevelDeclPath = pkg :: Nil
 
   extension (pkgs: PackageDeclPath)
     @targetName("selectPackage") def /(pkg: SimpleName): PackageDeclPath = pkgs :+ pkg
     @targetName("selectTopLevel") def /(cls: TypeName): TopLevelClassDeclPath = pkgs :+ cls
-    def obj: TopLevelDeclPath = pkgs
+    @targetName("selectModule") def /(asObj: obj.type): TopLevelDeclPath = pkgs // no need to convert
 
   extension (cls: TopLevelDeclPath)
     /** the binary name of the class root for this declaration */
@@ -46,11 +47,15 @@ object Paths:
   extension (cls: TopLevelClassDeclPath)
     // currently we have not set up member selection from object values, only the object class itself
     @targetName("selectMember") def /(x: Name): MemberDeclPath = cls :+ x
+    @targetName("selectCompanion") def /(companion: obj.type): TopLevelClassDeclPath = cls.convertAsObject
 
-  extension (member: MemberDeclPath) @targetName("selectMemberFromMember") def /(x: Name): MemberDeclPath = member :+ x
+  extension (member: MemberDeclPath)
+    @targetName("selectMemberFromMember") def /(x: Name): MemberDeclPath = member :+ x
+    @targetName("selectMemberAsModule") def /(companionOrSelf: obj.type): MemberDeclPath = member.convertAsObject
 
   extension (path: DeclarationPath)
     def toNameList: List[Name] = path
+    def name: Name = if path.isEmpty then nme.RootName else path.last
     def root: Name = path.head
     def foldRemainder[T](whenEmpty: => T)(follow: DeclarationPath => T): T = path.tail match {
       case Nil => whenEmpty
@@ -58,5 +63,14 @@ object Paths:
     }
     def show: String = path.mkString(".")
     def debug: String = toDebugString(path)
+
+  extension [T <: DeclarationPath](path: T)
+    private def convertAsObject: T =
+      val pre :+ last = path: @unchecked
+      last match
+        case clsName: TypeName =>
+          if clsName.wrapsObjectName then path // already an object
+          else (pre :+ clsName.toTermName.withObjectSuffix.toTypeName).asInstanceOf[T] // select the companion object
+        case _ => path
 
   extension (names: IterableOnce[Name]) def toDebugString: String = names.map(_.toDebugString).mkString(".")

--- a/jvm/src/test/scala/tastyquery/PositionSuite.scala
+++ b/jvm/src/test/scala/tastyquery/PositionSuite.scala
@@ -25,10 +25,7 @@ class PositionSuite extends RestrictedUnpicklingSuite {
     s"${System.getProperty(ResourceCodeProperty)}/main/scala/$dir/$filename.scala"
 
   private def unpickleWithCode(path: TopLevelDeclPath): (Tree, String) = {
-    val (base, classRoot) = findTopLevelClass(path)()
-    val tree = base.classloader.topLevelTasty(classRoot)(using base) match
-      case Some(trees) => trees.head
-      case _           => fail(s"Missing tasty for ${path.rootClassName}, $classRoot")
+    val (base, tree) = findTopLevelTasty(path)()
     val codePath = getCodePath(path.rootClassName)
     val code = Source.fromFile(codePath).mkString
     (tree, code)

--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -50,10 +50,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     using Location
   )(body: Contexts.Context ?=> Tree => Unit): Unit =
     test(name) {
-      val (base, classRoot) = findTopLevelClass(path)()
-      val tree = base.classloader.topLevelTasty(classRoot)(using base) match
-        case Some(trees) => trees.head
-        case _           => fail(s"Missing tasty for ${path.rootClassName}, $classRoot")
+      val (base, tree) = findTopLevelTasty(path)()
       body(using base)(tree)
     }
   end testUnpickleTopLevel
@@ -479,7 +476,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(intFieldMatch)(clue(tree)))
   }
 
-  testUnpickle("object", simple_trees / objclass"ScalaObject") { tree =>
+  testUnpickle("object", simple_trees / tname"ScalaObject" / obj) { tree =>
     val selfDefMatch: StructureCheck = {
       case ValDef(nme.Wildcard, SingletonTypeTree(Ident(SimpleName("ScalaObject"))), EmptyTree, NoSymbol) =>
     }
@@ -1009,7 +1006,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(genericMethod)(clue(tree)))
   }
 
-  testUnpickle("generic-extension", simple_trees / objclass"GenericExtension$$package") { tree =>
+  testUnpickle("generic-extension", simple_trees / tname"GenericExtension$$package" / obj) { tree =>
     val extensionCheck: StructureCheck = {
       case DefDef(
             SimpleName("genericExtension"),
@@ -1579,7 +1576,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(matchWithBind)(clue(tree)))
   }
 
-  testUnpickle("package-type-ref", (EmptyPkg / name"toplevelEmptyPackage$$package").obj) { tree =>
+  testUnpickle("package-type-ref", EmptyPkg / name"toplevelEmptyPackage$$package" / obj) { tree =>
     // Empty package (the path to the toplevel$package[ModuleClass]) is a THIS of a TYPEREFpkg as opposed to
     // non-empty package, which is simply TERMREFpkg. Therefore, reading the type of the package object reads TYPEREFpkg.
     val packageVal: StructureCheck = {
@@ -1667,7 +1664,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(newInner)(clue(tree)))
   }
 
-  testUnpickle("shared-package-reference", simple_trees / objclass"SharedPackageReference$$package") { tree =>
+  testUnpickle("shared-package-reference", simple_trees / tname"SharedPackageReference$$package" / obj) { tree =>
     // TODO: once references are created, check correctness
   }
 

--- a/jvm/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SymbolSuite.scala
@@ -44,19 +44,19 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
   }
 
   test("top-level-package-object[class]-empty-package") {
-    val toplevelEmptyPackage_package = EmptyPkg / objclass"toplevelEmptyPackage$$package"
+    val toplevelEmptyPackage_package = EmptyPkg / tname"toplevelEmptyPackage$$package" / obj
     given Context = getUnpicklingContext(toplevelEmptyPackage_package)
 
     val toplevelEmptyPackage_packageClass = resolve(toplevelEmptyPackage_package)
 
     val (tree @ _: ClassDef) = toplevelEmptyPackage_packageClass.tree.get: @unchecked
 
-    assert(tree.name == objclass"toplevelEmptyPackage$$package")
+    assert(tree.name == toplevelEmptyPackage_package.name)
     assert(tree.symbol == toplevelEmptyPackage_packageClass)
   }
 
   test("top-level-package-object[value]-empty-package") {
-    val toplevelEmptyPackage_package = (EmptyPkg / name"toplevelEmptyPackage$$package").obj
+    val toplevelEmptyPackage_package = EmptyPkg / name"toplevelEmptyPackage$$package" / obj
     given Context = getUnpicklingContext(toplevelEmptyPackage_package)
 
     val toplevelEmptyPackage_packageValue = resolve(toplevelEmptyPackage_package)
@@ -65,6 +65,19 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     assert(tree.name == name"toplevelEmptyPackage$$package")
     assert(tree.symbol == toplevelEmptyPackage_packageValue)
+  }
+
+  test("top-level-package-object[companion class]-empty-package") {
+    val toplevelEmptyPackage_package = EmptyPkg / name"toplevelEmptyPackage$$package" / obj
+    val toplevelEmptyPackage_package_companion = EmptyPkg / tname"toplevelEmptyPackage$$package"
+    given Context = getUnpicklingContext(toplevelEmptyPackage_package)
+
+    try
+      resolve(toplevelEmptyPackage_package_companion)
+      fail(s"Expected not to resolve class ${toplevelEmptyPackage_package_companion.rootClassName}")
+    catch
+      case ex: IllegalArgumentException =>
+        assert(ex.getMessage.nn.contains(s"cannot find member ${tname"toplevelEmptyPackage$$package".toDebugString}"))
   }
 
   test("basic-symbol-structure") {

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -108,7 +108,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   applyOverloadedTest("apply-overloaded-gen")("callB", name"simple_trees" / tname"OverloadedApply" / tname"Box")
   applyOverloadedTest("apply-overloaded-nestedObj")(
     "callC",
-    name"simple_trees" / tname"OverloadedApply" / objclass"Foo" / name"Bar"
+    name"simple_trees" / tname"OverloadedApply" / tname"Foo" / obj / name"Bar"
   )
   // applyOverloadedTest("apply-overloaded-arrayObj")("callD", name"scala" / tname"Array") // TODO: re-enable when we add types to scala 2 symbols
   applyOverloadedTest("apply-overloaded-byName")("callE", name"simple_trees" / tname"OverloadedApply" / tname"Num")

--- a/shared/src/main/scala/tastyquery/api/ProjectReader.scala
+++ b/shared/src/main/scala/tastyquery/api/ProjectReader.scala
@@ -10,9 +10,8 @@ class ProjectReader {
     val trees = classes.flatMap { className =>
       val trees =
         for
-          cls <- ctx.getClassIfDefined(className).toOption
-          if ctx.classloader.scanClass(cls)
-          tasty <- ctx.classloader.topLevelTasty(cls)
+          root <- ctx.rootSymbolsIfDefined(className).headOption
+          tasty <- ctx.classloader.topLevelTasty(root)
         yield tasty
 
       trees.getOrElse {

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -604,22 +604,6 @@ object Types {
   class CyclicReference(val kind: String) extends Exception(s"cyclic evaluation of $kind")
   class NonMethodReference(val kind: String) extends Exception(s"reference to non method type in $kind")
 
-  class ReferenceResolutionError(val ref: TermRef, explanation: String, cause: Throwable | Null)
-      extends SymResolutionProblem(
-        ReferenceResolutionError.addExplanation(s"Could not compute type of the term, referenced by $ref", explanation),
-        cause
-      ):
-    def this(ref: TermRef, explanation: String) = this(ref, explanation, null)
-    def this(ref: TermRef) = this(ref, "")
-  end ReferenceResolutionError
-
-  object ReferenceResolutionError {
-    def unapply(e: ReferenceResolutionError): Option[TermRef] = Some(e.ref)
-
-    def addExplanation(msg: String, explanation: String): String =
-      if (explanation.isEmpty) msg else s"$msg: $explanation"
-  }
-
   /** The singleton type for path prefix#myDesignator. */
   case class TermRef(override val prefix: Type, var myDesignator: Designator)
       extends NamedType
@@ -646,13 +630,7 @@ object Types {
 
     private def computeUnderlying(using ctx: Context): Type = {
       val termSymbol = resolveToSymbol
-      //try {
       termSymbol.declaredType.asSeenFrom(prefix, termSymbol.owner)
-      /*} catch {
-        case e =>
-          val msg = e.getMessage
-          throw new ReferenceResolutionError(this, if msg == null then "" else msg, e)
-      }*/
     }
 
     override def isOverloaded(using Context): Boolean =

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -64,7 +64,7 @@ class TreeUnpickler(
           if pkg != defn.EmptyPackage then
             // can happen for symbolic packages
             assert(
-              fileCtx.classRoot.enclosingDecls.exists(_ == pkg),
+              fileCtx.classRoot.packages.exists(_ == pkg),
               s"unexpected package ${pkg.name} in owners of top level class ${fileCtx.classRoot.fullName}"
             )
           pkg

--- a/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -176,8 +176,6 @@ object ClassfileParser {
   }
 
   private def toplevel(classRoot: ClassData)(using ClassContext): Structure = {
-    val root = clsCtx.classRoot
-
     def headerAndStructure(reader: ClassfileReader)(using DataStream) = {
       reader.acceptHeader()
       structure(reader)(using reader.readConstantPool())

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -24,7 +24,7 @@ object Descriptors:
         case className :: Nil =>
           TypeRef(PackageRef(acc), typeName(className))
         case nextPackageName :: rest =>
-          acc.findPackageSymbol(termName(nextPackageName)) match
+          acc.getPackageDecl(termName(nextPackageName)) match
             case Some(pkg) =>
               followPackages(pkg, rest)
             case res =>

--- a/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -137,7 +137,7 @@ object JavaSignatures:
         def followPackages(acc: PackageClassSymbol): TypeRef =
           val next = identifier
           if consume('/') then // must have '/', identifier, and terminal char.
-            acc.findPackageSymbol(next) match
+            acc.getPackageDecl(next) match
               case Some(pkg) =>
                 followPackages(pkg)
               case res =>


### PR DESCRIPTION
differences:
- getDecl will now force a
  top level class' inner definitions,
  this is not observable from the public API,
  but some LazyLoadingSuite tests needed to
  change.
- getTopLevelTasty now accepts any top level
  class or module symbol.

add test case: assert no class for standalone object

experiment: replace `objclass"foo"` with `tname"foo" / obj`