### PR TITLE
WiP: Fix reading THIStpe of package refs in the pickle reader.

### DIFF
--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -662,4 +662,12 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(clue(body.tpe).isOfClass(IntClass))
   }
 
+  testWithContext("console-outvar") {
+    val Console = resolve(name"scala" / tname"Console").asClass
+
+    println(Console.name.toDebugString)
+    println(Console.getDecl(name"outVar"))
+    println(Console.getDecl(name"outVar").get.declaredType)
+  }
+
 }

--- a/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -278,7 +278,9 @@ class PickleReader {
           case sym: Symbol =>
             sym.asClass.accessibleThisType
           case external: ExternalSymbolRef =>
-            ThisType(external.toTypeRef(NoPrefix))
+            external.toNamedType(NoPrefix) match
+              case termRef: TermRef => termRef // necessary for package refs?
+              case typeRef: TypeRef => ThisType(typeRef)
       case SINGLEtpe =>
         val pre = readPrefix()
         val designator = readMaybeExternalSymbolRef()


### PR DESCRIPTION
Apparently, Scala 2 uses THIStpe of a TermRef to the package,
which we can collapse as just the TermRef (hopefully).