### PR TITLE
Add the classes of the JDK to the test classpaths.

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -8,15 +8,20 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        java: [ '8', '9', '11', '17' ]
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+        cache: 'sbt'
     - name: Run tests
       run: sbt test
     - name: Run scalafmt check

--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -69,8 +69,13 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
   }
 
-  testWithContext("java.lang-is-not-loaded".fail) {
-    resolve(name"java" / name"lang" / tname"String").declaredType
+  testWithContext("java.lang.String") {
+    val StringClass = resolve(name"java" / name"lang" / tname"String").asClass
+    val CharClass = resolve(name"scala" / tname"Char").asClass
+
+    val charAt = StringClass.getDecl(name"charAt").get
+    val tpe = charAt.declaredType.asInstanceOf[MethodType]
+    assert(clue(tpe.resultType).isRef(CharClass))
   }
 
   def applyOverloadedTest(name: String)(callMethod: String, paramCls: DeclarationPath)(using munit.Location): Unit =

--- a/jvm/src/test/scala/tastyquery/testutil/jdk/JavaTestPlatform.scala
+++ b/jvm/src/test/scala/tastyquery/testutil/jdk/JavaTestPlatform.scala
@@ -1,26 +1,48 @@
 package tastyquery.testutil.jdk
 
-import tastyquery.testutil.TestPlatform
-import java.nio.file.Files
-import java.nio.file.Paths
-import tastyquery.reader.classfiles.Classpaths.Classpath
 import scala.util.Properties
-import tastyquery.jdk.ClasspathLoaders
+
 import java.io.File
+import java.nio.file.*
+
+import tastyquery.jdk.ClasspathLoaders
+import tastyquery.reader.classfiles.Classpaths.Classpath
+import tastyquery.testutil.TestPlatform
 
 object JavaTestPlatform extends TestPlatform {
   private val ResourceProperty = "test-resources"
   private val StdLibProperty = "std-library"
 
-  private def resourcesDir = Properties.propOrNone(ResourceProperty).get
-  private def stdLibPaths = {
+  private lazy val jdk: Path = {
     import scala.language.unsafeNulls
-    Properties.propOrEmpty(StdLibProperty).split(File.pathSeparator).toList
+
+    System.getProperty("sun.boot.class.path") match
+      case null =>
+        // Assume jrt:/
+        FileSystems.getFileSystem(java.net.URI.create("jrt:/")).nn.getPath("modules", "java.base")
+
+      case bootClasspath =>
+        val rtJarOpt = bootClasspath.split(java.io.File.pathSeparatorChar).find { path =>
+          new java.io.File(path).getName() == "rt.jar"
+        }
+        rtJarOpt match
+          case Some(rtJar) =>
+            Paths.get(rtJar)
+          case None =>
+            throw new AssertionError(s"cannot find rt.jar in $bootClasspath")
+  }
+
+  private def resourcesDir: Path =
+    Paths.get(Properties.propOrNone(ResourceProperty).get).nn
+
+  private def stdLibPaths: List[Path] = {
+    import scala.language.unsafeNulls
+    Properties.propOrEmpty(StdLibProperty).split(File.pathSeparator).toList.map(Paths.get(_).nn)
   }
 
   def loadClasspath(): Classpath = {
     val kinds = Set(ClasspathLoaders.FileKind.Tasty, ClasspathLoaders.FileKind.Class)
-    val parts = resourcesDir :: stdLibPaths
-    ClasspathLoaders.read(parts, kinds)
+    val classpath = jdk :: resourcesDir :: stdLibPaths
+    ClasspathLoaders.read(classpath, kinds)
   }
 }

--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -151,9 +151,8 @@ object Contexts {
       initialise(nothingClass)
 
       def fakeJavaLangClassIfNotFound(name: String): ClassSymbol =
-        // TODO: add java.lang package in tests
         val tname = typeName(name)
-        javaLangPackage.getDeclInternal(tname) match
+        javaLangPackage.getDecl(tname) match
           case Some(sym: ClassSymbol) =>
             sym
           case _ =>


### PR DESCRIPTION
This allows to actually inspect JDK classes like `java.lang.String`.