### PR TITLE
Make Symbol.signature more robust and expose Symbol.signedName.

### DIFF
--- a/jvm/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SignatureSuite.scala
@@ -1,0 +1,62 @@
+package tastyquery
+
+import tastyquery.Contexts.Context
+import tastyquery.ast.Names.*
+import tastyquery.ast.Symbols.*
+import tastyquery.ast.Trees.*
+import tastyquery.ast.Types.*
+
+import Paths.*
+import tastyquery.ast.Signature
+import munit.Location
+import tastyquery.ast.ParamSig
+import tastyquery.ast.TermSig
+
+class SignatureSuite extends UnrestrictedUnpicklingSuite:
+
+  def assertIsSignedName(actual: Name, simpleName: String, signature: String)(using Location): Unit =
+    actual match
+      case name: SignedName =>
+        assert(clue(name.underlying) == clue(termName(simpleName)))
+        assert(clue(name.sig.toString) == clue(signature))
+      case _ =>
+        fail("not a Signed name", clues(actual))
+  end assertIsSignedName
+
+  def assertNotSignedName(actual: Name)(using Location): Unit =
+    assert(!clue(actual).isInstanceOf[SignedName])
+
+  testWithContext("java.lang.String") {
+    val StringClass = resolve(name"java" / name"lang" / tname"String").asClass
+
+    val charAt = StringClass.getDecl(name"charAt").get
+    assertIsSignedName(charAt.signedName, "charAt", "(scala.Int):scala.Char")
+
+    val contains = StringClass.getDecl(name"contains").get
+    assertIsSignedName(contains.signedName, "contains", "(java.lang.CharSequence):scala.Boolean")
+
+    val length = StringClass.getDecl(name"length").get
+    assertIsSignedName(length.signedName, "length", "():scala.Int")
+  }
+
+  testWithContext("GenericClass") {
+    val GenericClass = resolve(name"simple_trees" / tname"GenericClass").asClass
+
+    val field = GenericClass.getDecl(name"field").get
+    assertNotSignedName(field.signedName)
+
+    val getter = GenericClass.getDecl(name"getter").get
+    assertIsSignedName(getter.signedName, "getter", "():scala.Any")
+
+    val method = GenericClass.getDecl(name"method").get
+    assertIsSignedName(method.signedName, "method", "(scala.Any):scala.Any")
+  }
+
+  testWithContext("GenericMethod") {
+    val GenericMethod = resolve(name"simple_trees" / tname"GenericMethod").asClass
+
+    val identity = GenericMethod.getDecl(name"identity").get
+    assertIsSignedName(identity.signedName, "identity", "(1,scala.Any):scala.Any")
+  }
+
+end SignatureSuite

--- a/shared/src/main/scala/tastyquery/ast/Signature.scala
+++ b/shared/src/main/scala/tastyquery/ast/Signature.scala
@@ -22,7 +22,7 @@ case class Signature(paramsSig: List[ParamSig], resSig: TypeName) derives CanEqu
   }.mkString("(", ",", ")") + ":" + resSig.toString
 
 object Signature {
-  def fromMethodOrPoly(info: MethodType | PolyType)(using Context): Signature =
+  def fromMethodic(info: MethodicType)(using Context): Signature =
     def rec(info: Type, acc: List[ParamSig]): Signature =
       info match {
         case info: MethodType =>
@@ -33,5 +33,9 @@ object Signature {
         case tpe =>
           Signature(acc, ErasedTypeRef.erase(tpe))
       }
-    rec(info, Nil)
+
+    info match
+      case ExprType(resType) => Signature(Nil, ErasedTypeRef.erase(resType))
+      case _                 => rec(info, Nil)
+  end fromMethodic
 }

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -112,6 +112,14 @@ object Symbols {
 
     private[tastyquery] def signature(using Context): Option[Signature]
 
+    /** If this symbol has a `MethodicType`, returns a `SignedName`, otherwise a `Name`. */
+    final def signedName(using Context): Name =
+      signature.fold(name) { sig =>
+        val name = this.name.asSimpleName
+        val targetName = name // TODO We may have to take `@targetName` into account here, one day
+        SignedName(name, sig, targetName)
+      }
+
     final def flags: FlagSet =
       if isFlagsInitialized then myFlags
       else throw IllegalStateException(s"flags of $this have not been initialized")
@@ -235,8 +243,8 @@ object Symbols {
       if local != null then local
       else
         val sig = declaredType match
-          case methodOrPoly: (MethodType | PolyType) => Some(Signature.fromMethodOrPoly(methodOrPoly))
-          case _                                     => None
+          case methodic: MethodicType => Some(Signature.fromMethodic(methodic))
+          case _                      => None
         mySignature = sig
         sig
   }

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -57,7 +57,10 @@ object Types {
                 case SuffixedName(NameTags.OBJECTCLASS, full) => specialise(arrayDims, full).withObjectSuffix
                 case full                                     => specialise(arrayDims, full)
             case sym => // TODO: abstract types
-              throw IllegalStateException(s"Cannot erase symbolic type $tpe, with symbol $sym")
+              if sym.isAllOf(ClassTypeParam) then rec(arrayDims, sym.declaredType.upperBound)
+              else throw IllegalStateException(s"Cannot erase symbolic type $tpe, with symbol $sym")
+        case tpe: TypeParamRef =>
+          rec(arrayDims, tpe.bounds.high)
         case tpe =>
           throw IllegalStateException(s"Cannot erase $tpe")
 

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -436,6 +436,11 @@ class TreeUnpickler(
       val end = reader.readEnd()
       val name = readName.toTypeName
       val bounds = readTypeParamType(using fileCtx.withOwner(paramSymbol))
+      val typeBounds = bounds match
+        case bounds: TypeBounds     => bounds
+        case bounds: TypeBoundsTree => bounds.toTypeBounds
+        case bounds: TypeLambdaTree => RealTypeBounds(NothingType, AnyType)
+      paramSymbol.withDeclaredType(WildcardTypeBounds(typeBounds))
       skipModifiers(end)
       TypeParam(name, bounds, paramSymbol)(spn).definesTreeOf(paramSymbol)
     }


### PR DESCRIPTION
`signedName` returns a `SignedName` with the `signature` if there is a signature, i.e., if the symbol has a `MethodicType`. Otherwise, it returns the regular `name`.