### PR TITLE
Separate FullyQualifiedName's out of the Name hierarchy.

### DIFF
--- a/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -2,7 +2,7 @@ package tastyquery
 
 import dotty.tools.tasty.TastyFormat.NameTags
 
-import munit.Location
+import munit.{Location, TestOptions}
 
 import tastyquery.Contexts
 import tastyquery.Contexts.Context
@@ -46,19 +46,31 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
         ) =>
   }
 
-  def testUnpickleTopLevel(name: String, path: TopLevelDeclPath)(
+  def testUnpickleTopLevel(name: String, path: TopLevelDeclPath)(using Location)(
+    body: Contexts.Context ?=> Tree => Unit
+  ): Unit =
+    testUnpickleTopLevel(new TestOptions(name), path)(body)
+  end testUnpickleTopLevel
+
+  def testUnpickleTopLevel(testOptions: TestOptions, path: TopLevelDeclPath)(
     using Location
   )(body: Contexts.Context ?=> Tree => Unit): Unit =
-    test(name) {
+    test(testOptions) {
       val (base, tree) = findTopLevelTasty(path)()
       body(using base)(tree)
     }
   end testUnpickleTopLevel
 
-  def testUnpickle(name: String, path: TopLevelDeclPath)(
+  def testUnpickle(name: String, path: TopLevelDeclPath)(using Location)(
+    body: Contexts.Context ?=> Tree => Unit
+  ): Unit =
+    testUnpickle(new TestOptions(name), path)(body)
+  end testUnpickle
+
+  def testUnpickle(testOptions: TestOptions, path: TopLevelDeclPath)(
     using Location
   )(body: Contexts.Context ?=> Tree => Unit): Unit =
-    test(name) {
+    test(testOptions) {
       given Context = getUnpicklingContext(path)
       val cls = resolve(path)
       val tree = cls.tree.getOrElse {

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -19,7 +19,8 @@ final class Definitions private[tastyquery] (
   val EmptyPackage = emptyPackage
 
   val scalaPackage = ctx.createPackageSymbolIfNew(nme.scalaPackageName, RootPackage)
-  val javaLangPackage = ctx.createPackageSymbolIfNew(nme.javalangPackageName, RootPackage)
+  private val javaPackage = ctx.createPackageSymbolIfNew(nme.javaPackageName, RootPackage)
+  val javaLangPackage = ctx.createPackageSymbolIfNew(nme.langPackageName, javaPackage)
 
   // Magic symbols that are not found on the classpath, but rather created by hand
 

--- a/shared/src/main/scala/tastyquery/ast/Signature.scala
+++ b/shared/src/main/scala/tastyquery/ast/Signature.scala
@@ -1,16 +1,16 @@
 package tastyquery.ast
 
-import tastyquery.ast.Names.TypeName
-import tastyquery.ast.Types.{PolyType, MethodType, ExprType, MethodicType, ErasedTypeRef, Type}
+import tastyquery.ast.Names.*
+import tastyquery.ast.Types.*
 import tastyquery.Contexts.Context
 
 abstract class ParamSig
 
-case class TermSig(typ: TypeName) extends ParamSig
+case class TermSig(typ: FullyQualifiedName) extends ParamSig
 
 case class TypeLenSig(len: Int) extends ParamSig
 
-case class Signature(paramsSig: List[ParamSig], resSig: TypeName) derives CanEqual:
+case class Signature(paramsSig: List[ParamSig], resSig: FullyQualifiedName) derives CanEqual:
   def toDebugString = paramsSig.map {
     case TermSig(typ)    => typ.toDebugString
     case TypeLenSig(len) => len.toString
@@ -26,16 +26,16 @@ object Signature {
     def rec(info: Type, acc: List[ParamSig]): Signature =
       info match {
         case info: MethodType =>
-          val erased = info.paramTypes.map(tpe => TermSig(ErasedTypeRef.erase(tpe).toSigTypeName))
+          val erased = info.paramTypes.map(tpe => TermSig(ErasedTypeRef.erase(tpe).toSigFullName))
           rec(info.resultType, acc ::: erased)
         case PolyType(_, tbounds, res) =>
           rec(res, acc ::: TypeLenSig(tbounds.length) :: Nil)
         case tpe =>
-          Signature(acc, ErasedTypeRef.erase(tpe).toSigTypeName)
+          Signature(acc, ErasedTypeRef.erase(tpe).toSigFullName)
       }
 
     info match
-      case ExprType(resType) => Signature(Nil, ErasedTypeRef.erase(resType).toSigTypeName)
+      case ExprType(resType) => Signature(Nil, ErasedTypeRef.erase(resType).toSigFullName)
       case _                 => rec(info, Nil)
   end fromMethodic
 }

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -254,13 +254,14 @@ object Trees {
   }
 
   /** reference to a package, seen as a term */
-  final class ReferencedPackage(override val name: TermName)(span: Span) extends Ident(name)(span) {
+  final class ReferencedPackage(val fullyQualifiedName: FullyQualifiedName)(span: Span)
+      extends Ident(fullyQualifiedName.path.last.asSimpleName)(span) {
     override protected final def calculateType(using Context): Type =
-      PackageRef(name)
+      PackageRef(fullyQualifiedName)
 
-    override final def withSpan(span: Span): ReferencedPackage = ReferencedPackage(name)(span)
+    override final def withSpan(span: Span): ReferencedPackage = ReferencedPackage(fullyQualifiedName)(span)
 
-    override def toString: String = s"ReferencedPackage($name)"
+    override def toString: String = s"ReferencedPackage($fullyQualifiedName)"
   }
 
   object ReferencedPackage {

--- a/shared/src/main/scala/tastyquery/reader/PositionUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/PositionUnpickler.scala
@@ -12,7 +12,7 @@ import TastyFormat.SOURCE
 import TastyBuffer.{Addr, NameRef}
 
 /** Unpickler for tree positions */
-class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
+class PositionUnpickler(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable) {
   import reader.*
 
   private var myLineSizes: Array[Int] = _
@@ -37,7 +37,7 @@ class PositionUnpickler(reader: TastyReader, nameAtRef: NameRef => TermName) {
       while (!isAtEnd) {
         val header = readInt()
         if (header == SOURCE) {
-          val path = nameAtRef(readNameRef()).toString
+          val path = nameAtRef.simple(readNameRef()).toString
           mySourcePaths(Addr(curIndex)) = path
         } else {
           val addrDelta = header >> 3

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -32,12 +32,8 @@ object Descriptors:
     end followPackages
 
     val parts = binaryName.split('/').toList
-    (parts: @unchecked) match
-      case classInEmptyPackageName :: Nil =>
-        TypeRef(PackageRef(nme.EmptyPackageName), typeName(classInEmptyPackageName))
-      case firstPackageName :: rest =>
-        val firstPackageRef = PackageRef(termName(firstPackageName))
-        followPackages(firstPackageRef.resolveToSymbol, rest)
+    val initPackage = if parts.tail.isEmpty then defn.EmptyPackage else defn.RootPackage
+    followPackages(initPackage, parts)
   end classRef
 
   @throws[ReadException]

--- a/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -1,11 +1,11 @@
 package tastyquery.reader.classfiles
 
 import tastyquery.Contexts.*
+import tastyquery.ast.Flags
+import tastyquery.ast.Names.*
 import tastyquery.ast.Types
 import tastyquery.ast.Types.*
 import tastyquery.ast.Symbols.*
-import tastyquery.ast.Flags
-import tastyquery.ast.Names.{SimpleName, TypeName, termName, nme}
 import tastyquery.util.syntax.chaining.given
 
 import scala.annotation.switch
@@ -147,9 +147,11 @@ object JavaSignatures:
 
         val firstIdent = identifier
         if consume('/') then // must have '/', identifier, and terminal char.
-          val init = PackageRef(firstIdent)
-          followPackages(init.resolveToSymbol)
-        else TypeRef(PackageRef(nme.EmptyPackageName), firstIdent.toTypeName)
+          val firstPackage = defn.RootPackage.getPackageDecl(firstIdent).getOrElse {
+            sys.error(s"cannot find package $firstIdent in ${defn.RootPackage}")
+          }
+          followPackages(firstPackage)
+        else TypeRef(PackageRef(FullyQualifiedName.emptyPackageName), firstIdent.toTypeName)
       end readSimpleClassType
 
       def simpleClassTypeSignature(clsTpe: TypeRef): Type =


### PR DESCRIPTION
There are two use cases for fully qualified names:

* in erased names for Signatures, and
* in pickled TASTy, for package definitions and references.

Package symbols used to have a fully qualified `name`, but that was inconsistent wrt. other symbols, whose `name`s are relative to their owner. Now, the `name` of package symbols is also a simple name relative to their parent packages.