### PR TITLE
Fix unpickling type whose bounds depend on itself

### DIFF
--- a/jvm/src/test/scala/tastyquery/TypeSuite.scala
+++ b/jvm/src/test/scala/tastyquery/TypeSuite.scala
@@ -770,4 +770,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val polyMethod = HigherKindedClass.getDecl(name"m").get
     println(polyMethod.declaredType.asInstanceOf[PolyType].resultType)
   }
+
+  testWithContext("scala.collection.:+") {
+    // type parameter C <: SeqOps[A, CC, C]
+    val `:+` = resolve(name"scala" / name"collection" / tname"package" / obj / tname":+" / obj).asClass
+  }
 }

--- a/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -55,7 +55,7 @@ class PickleReader {
     val tOpt = entries(i).asInstanceOf[T | Null]
     if tOpt == null then {
       val res = pkl.unsafeFork(index(i))(op)
-      assert(entries(i) == null, entries(i))
+      assert(entries(i) == null || (entries(i) == res), entries(i))
       entries(i) = res
       res
     } else tOpt


### PR DESCRIPTION
In `scala.collection.:+` there is a type parameter `C <: SeqOps[A, CC, C]`.

This is what happen when we read the type of  `C`:
```
read type C
  read symbol C
  store symbol C
  read declared type of symbol C
    read type C
    get symbol C from entries
    store type C
  set declared type of symbol C 
store type C // crash
``` 