### PR TITLE
First step of dealing with Scala 2 existential types.

### DIFF
--- a/jvm/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SignatureSuite.scala
@@ -155,4 +155,11 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(getOrElse.signedName, "getOrElse", "(1,scala.Function0):java.lang.Object")
   }
 
+  testWithContext("scala2-existential-type") {
+    val ClassTag = resolve(name"scala" / name"reflect" / tname"ClassTag" / obj).asClass
+
+    val apply = ClassTag.getDecl(name"apply").get
+    assertIsSignedName(apply.signedName, "apply", "(1,java.lang.Class):scala.reflect.ClassTag")
+  }
+
 end SignatureSuite

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -775,6 +775,9 @@ object Types {
 
     override protected def designator_=(d: Designator): Unit = myDesignator = d
 
+    private[tastyquery] def isLocalRef(sym: Symbol): Boolean =
+      myDesignator == sym
+
     override def underlying(using Context): Type = symbol.declaredType
 
     override def findMember(name: Name, pre: Type)(using Context): Symbol =


### PR DESCRIPTION
We can deal with them when they are direct AppliedTypes. There are other cases that dotc handles but that we do not handle yet, notably RefinedTypes.