### PR TITLE
Fix #116: Correctly erase polymorphic opaque type aliases.

### DIFF
--- a/jvm/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/jvm/src/test/scala/tastyquery/SignatureSuite.scala
@@ -162,4 +162,11 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(apply.signedName, "apply", "(1,java.lang.Class):scala.reflect.ClassTag")
   }
 
+  testWithContext("iarray") {
+    val IArraySig = resolve(name"simple_trees" / tname"IArraySig").asClass
+
+    val from = IArraySig.getDecl(name"from").get
+    assertIsSignedName(from.signedName, "from", "():java.lang.String[]")
+  }
+
 end SignatureSuite

--- a/shared/src/main/scala/tastyquery/ast/Symbols.scala
+++ b/shared/src/main/scala/tastyquery/ast/Symbols.scala
@@ -210,6 +210,9 @@ object Symbols {
       case scope: DeclaringSymbol => scope.allOverloads(name)
       case _                      => Nil
 
+    /** Is this symbol a user-defined opaque type alias? */
+    final def isOpaqueTypeAlias(using Context): Boolean = is(Opaque) && !isClass
+
     override def toString: String = {
       val kind = this match
         case _: PackageClassSymbol => "package "

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -163,7 +163,7 @@ object TypeTrees {
 
   case class TypeLambdaTree(tparams: List[TypeParam], body: TypeTree)(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
-      TypeLambda.fromParams(tparams)(_ => body.toType)
+      TypeLambda.fromParams(tparams)(tl => tl.integrate(tparams.map(_.symbol), body.toType))
 
     override final def withSpan(span: Span): TypeLambdaTree = TypeLambdaTree(tparams, body)(span)
   }

--- a/test-sources/src/main/scala/simple_trees/IArraySig.scala
+++ b/test-sources/src/main/scala/simple_trees/IArraySig.scala
@@ -1,0 +1,5 @@
+package simple_trees
+
+trait IArraySig {
+  def from(): IArray[String]
+}


### PR DESCRIPTION
In particular, `opaque type IArray[+A] = Array[_ <: A]`.

Before that, we had to correctly integrate and instantiate higher-kinded `TypeLambda`s, similarly to how we already do for `PolyType`s.