### PR TITLE
erase ValueClasses defined in tasty

### DIFF
--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -109,4 +109,19 @@ final class Definitions private[tastyquery] (
   lazy val SeqClass = scalaCollectionImmutablePackage.requiredClass("Seq")
   lazy val Function0Class = scalaPackage.requiredClass("Function0")
 
+  lazy val IntClass = scalaPackage.requiredClass("Int")
+  lazy val LongClass = scalaPackage.requiredClass("Long")
+  lazy val FloatClass = scalaPackage.requiredClass("Float")
+  lazy val DoubleClass = scalaPackage.requiredClass("Double")
+  lazy val BooleanClass = scalaPackage.requiredClass("Boolean")
+  lazy val ByteClass = scalaPackage.requiredClass("Byte")
+  lazy val ShortClass = scalaPackage.requiredClass("Short")
+  lazy val CharClass = scalaPackage.requiredClass("Char")
+  lazy val UnitClass = scalaPackage.requiredClass("Unit")
+
+  def isPrimitiveValueClass(sym: ClassSymbol): Boolean =
+    sym == IntClass || sym == LongClass || sym == FloatClass || sym == DoubleClass ||
+      sym == BooleanClass || sym == ByteClass || sym == ShortClass || sym == CharClass ||
+      sym == UnitClass
+
 end Definitions

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -83,7 +83,7 @@ final class Definitions private[tastyquery] (
 
     val parents = parentConstrs(TypeRef(NoPrefix, tparam))
     cls.withDeclaredType(ClassInfo.direct(cls, parents))
-
+    cls.initialised = true
     cls
   end createSpecialPolyClass
 

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -67,6 +67,8 @@ object Names {
     val Wildcard: SimpleName = termName("_")
     val RefinementClass = typeName("<refinement>")
 
+    val Scala2Constructor: SimpleName = termName("this")
+
     val scalaPackageName: SimpleName = termName("scala")
     val javaPackageName: SimpleName = termName("java")
     val langPackageName: SimpleName = termName("lang")

--- a/shared/src/main/scala/tastyquery/ast/Names.scala
+++ b/shared/src/main/scala/tastyquery/ast/Names.scala
@@ -67,8 +67,6 @@ object Names {
     val Wildcard: SimpleName = termName("_")
     val RefinementClass = typeName("<refinement>")
 
-    val Scala2Constructor: SimpleName = termName("this")
-
     val scalaPackageName: SimpleName = termName("scala")
     val javaPackageName: SimpleName = termName("java")
     val langPackageName: SimpleName = termName("lang")

--- a/shared/src/main/scala/tastyquery/ast/Signature.scala
+++ b/shared/src/main/scala/tastyquery/ast/Signature.scala
@@ -32,8 +32,8 @@ object Signature {
         case PolyType(_, tbounds, res) =>
           rec(res, acc ::: TypeLenSig(tbounds.length) :: Nil)
         case tpe =>
-          val retType = optCtorReturn.map(_.erasedName).getOrElse(ErasedTypeRef.erase(tpe).toSigFullName)
-          Signature(acc, retType)
+          val retType = optCtorReturn.map(_.typeRef).getOrElse(tpe)
+          Signature(acc, ErasedTypeRef.erase(retType).toSigFullName)
       }
 
     info match

--- a/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -158,7 +158,10 @@ class PickleReader {
     if storedWhileReadingOwner != null then return storedWhileReadingOwner.asInstanceOf[MaybeExternalSymbol]
 
     val flags = readFlags(name1.isTypeName)
-    val name = if flags.is(ModuleClass) then name1.toTermName.withObjectSuffix.toTypeName else name1
+    val name =
+      if flags.is(ModuleClass) then name1.toTermName.withObjectSuffix.toTypeName
+      else if flags.is(Method) && name1 == nme.Scala2Constructor then nme.Constructor
+      else name1
 
     val (privateWithin, infoRef) = {
       val ref = pkl.readNat()

--- a/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -160,7 +160,7 @@ class PickleReader {
     val flags = readFlags(name1.isTypeName)
     val name =
       if flags.is(ModuleClass) then name1.toTermName.withObjectSuffix.toTypeName
-      else if flags.is(Method) && name1 == nme.Scala2Constructor then nme.Constructor
+      else if flags.is(Method) && name1 == Scala2Constructor then nme.Constructor
       else name1
 
     val (privateWithin, infoRef) = {
@@ -642,5 +642,7 @@ object PickleReader {
   }
 
   type MaybeExternalSymbol = Symbol | ExternalSymbolRef
+
+  private val Scala2Constructor: SimpleName = termName("this")
 
 }

--- a/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -178,7 +178,25 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("value-class-arrayOps-int") {
     val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
     val intArrayOps = MyArrayOps.getDecl(name"intArrayOps").get
-    assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):scala.Int[]")
+    assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):java.lang.Object")
+  }
+
+  testWithContext("value-class-monomorphic") {
+    val MyFlags = resolve(name"inheritance" / tname"MyFlags").asClass
+    val merge = MyFlags.getDecl(name"merge").get
+    assertIsSignedName(merge.signedName, "merge", "(scala.Long):scala.Long")
+  }
+
+  testWithContext("value-class-monomorphic-arrayOf") {
+    val MyFlags = resolve(name"inheritance" / tname"MyFlags" / obj).asClass
+    val mergeAll = MyFlags.getDecl(name"mergeAll").get
+    assertIsSignedName(mergeAll.signedName, "mergeAll", "(inheritance.MyFlags[]):scala.Long")
+  }
+
+  testWithContext("value-class-polymorphic-arrayOf") {
+    val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
+    val arrayOfIntArrayOps = MyArrayOps.getDecl(name"arrayOfIntArrayOps").get
+    assertIsSignedName(arrayOfIntArrayOps.signedName, "arrayOfIntArrayOps", "(scala.Int[][]):inheritance.MyArrayOps[]")
   }
 
 end SignatureSuite

--- a/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -169,10 +169,16 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(from.signedName, "from", "():java.lang.String[]")
   }
 
-  testWithContext("value-class-arrayOps") {
+  testWithContext("value-class-arrayOps-generic") {
     val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
     val genericArrayOps = MyArrayOps.getDecl(name"genericArrayOps").get
     assertIsSignedName(genericArrayOps.signedName, "genericArrayOps", "(1,java.lang.Object):java.lang.Object")
+  }
+
+  testWithContext("value-class-arrayOps-int") {
+    val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
+    val intArrayOps = MyArrayOps.getDecl(name"intArrayOps").get
+    assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):scala.Int[]")
   }
 
 end SignatureSuite

--- a/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -169,4 +169,10 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(from.signedName, "from", "():java.lang.String[]")
   }
 
+  testWithContext("value-class-arrayOps") {
+    val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
+    val genericArrayOps = MyArrayOps.getDecl(name"genericArrayOps").get
+    assertIsSignedName(genericArrayOps.signedName, "genericArrayOps", "(1,java.lang.Object):java.lang.Object")
+  }
+
 end SignatureSuite

--- a/test-sources/src/main/scala/inheritance/MyArrayOps.scala
+++ b/test-sources/src/main/scala/inheritance/MyArrayOps.scala
@@ -1,0 +1,6 @@
+package inheritance
+
+class MyArrayOps[T](val value: Array[T]) extends AnyVal
+
+object MyArrayOps:
+  def genericArrayOps[T](xs: Array[T]): MyArrayOps[T] = new MyArrayOps(xs)

--- a/test-sources/src/main/scala/inheritance/MyArrayOps.scala
+++ b/test-sources/src/main/scala/inheritance/MyArrayOps.scala
@@ -5,3 +5,5 @@ class MyArrayOps[T](val value: Array[T]) extends AnyVal
 object MyArrayOps:
   def intArrayOps(xs: Array[Int]): MyArrayOps[Int] = new MyArrayOps(xs)
   def genericArrayOps[T](xs: Array[T]): MyArrayOps[T] = new MyArrayOps(xs)
+
+  def arrayOfIntArrayOps(xss: Array[Array[Int]]): Array[MyArrayOps[Int]] = xss.map(intArrayOps)

--- a/test-sources/src/main/scala/inheritance/MyArrayOps.scala
+++ b/test-sources/src/main/scala/inheritance/MyArrayOps.scala
@@ -3,4 +3,5 @@ package inheritance
 class MyArrayOps[T](val value: Array[T]) extends AnyVal
 
 object MyArrayOps:
+  def intArrayOps(xs: Array[Int]): MyArrayOps[Int] = new MyArrayOps(xs)
   def genericArrayOps[T](xs: Array[T]): MyArrayOps[T] = new MyArrayOps(xs)

--- a/test-sources/src/main/scala/inheritance/MyFlags.scala
+++ b/test-sources/src/main/scala/inheritance/MyFlags.scala
@@ -1,0 +1,9 @@
+package inheritance
+
+class MyFlags(val bits: Long) extends AnyVal:
+  def merge(that: MyFlags): MyFlags = MyFlags(bits | that.bits)
+
+object MyFlags:
+  val Private: MyFlags = new MyFlags(1L << 0)
+
+  def mergeAll(xs: Array[MyFlags]): MyFlags = xs.reduce(_.merge(_))


### PR DESCRIPTION
it's not yet possible for scala 2 classes until we read the parents.

For this reason this PR is not enough to fix the issue https://github.com/scalacenter/tasty-query/issues/119, we should read parents for scala 2 classes