### PR TITLE
Make package symbols separate from ClassSymbol's.

### DIFF
--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -38,7 +38,7 @@ object Contexts {
   final class Context private[Contexts] (val classloader: Loader) {
     private given Context = this
 
-    private val (RootPackage @ _, EmptyPackage @ _) = PackageClassSymbol.createRoots()
+    private val (RootPackage @ _, EmptyPackage @ _) = PackageSymbol.createRoots()
 
     val defn: Definitions = Definitions(this: @unchecked, RootPackage, EmptyPackage)
 
@@ -85,9 +85,9 @@ object Contexts {
         case e: SymResolutionProblem =>
           Left(SymbolLookupException(rootName, s"unknown package $packageName"))
 
-    def findPackageFromRoot(fullyQualifiedName: FullyQualifiedName): PackageClassSymbol =
+    def findPackageFromRoot(fullyQualifiedName: FullyQualifiedName): PackageSymbol =
       @tailrec
-      def rec(owner: PackageClassSymbol, path: List[Name]): PackageClassSymbol =
+      def rec(owner: PackageSymbol, path: List[Name]): PackageSymbol =
         path match
           case Nil =>
             owner
@@ -139,14 +139,14 @@ object Contexts {
         case some =>
           throw ExistingDefinitionException(owner, name)
 
-    def createPackageSymbolIfNew(name: SimpleName, owner: PackageClassSymbol): PackageClassSymbol =
+    def createPackageSymbolIfNew(name: SimpleName, owner: PackageSymbol): PackageSymbol =
       assert(owner != EmptyPackage, s"Trying to create a subpackage $name of $owner")
       owner.getPackageDeclInternal(name) match {
         case Some(pkg) => pkg
-        case None      => PackageClassSymbol.create(name, owner)
+        case None      => PackageSymbol.create(name, owner)
       }
 
-    def createPackageSymbolIfNew(fullyQualifiedName: FullyQualifiedName): PackageClassSymbol =
+    def createPackageSymbolIfNew(fullyQualifiedName: FullyQualifiedName): PackageSymbol =
       fullyQualifiedName.path.foldLeft(RootPackage) { (owner, name) =>
         createPackageSymbolIfNew(name.asSimpleName, owner)
       }
@@ -160,9 +160,7 @@ object Contexts {
           case Some(sym: ClassSymbol) =>
             sym
           case _ =>
-            val sym = createClassSymbol(tname, defn.javaLangPackage)
-            sym.initialised = true
-            sym
+            createClassSymbol(tname, defn.javaLangPackage)
 
       fakeJavaLangClassIfNotFound("Object")
       fakeJavaLangClassIfNotFound("Comparable")

--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -6,11 +6,7 @@ import tastyquery.ast.Names.*
 import tastyquery.ast.Symbols.*
 import tastyquery.ast.Types.*
 
-final class Definitions private[tastyquery] (
-  ctx: Context,
-  rootPackage: PackageClassSymbol,
-  emptyPackage: PackageClassSymbol
-):
+final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageSymbol, emptyPackage: PackageSymbol):
   private given Context = ctx
 
   // Core packages
@@ -29,7 +25,6 @@ final class Definitions private[tastyquery] (
     cls.withTypeParams(Nil, Nil)
     cls.withDeclaredType(ClassInfo.direct(cls, if parents.isEmpty then Nil else parents))
     cls.withFlags(flags)
-    cls.initialised = true
     cls
 
   val AnyClass = createSpecialClass(typeName("Any"), Nil, Abstract)
@@ -63,7 +58,7 @@ final class Definitions private[tastyquery] (
 
     val AnyRefAlias = ctx.createSymbol(typeName("AnyRef"), scalaPackage)
     AnyRefAlias.withFlags(EmptyFlagSet)
-    val ObjectType = TypeRef(javaLangPackage.accessibleThisType, typeName("Object"))
+    val ObjectType = TypeRef(javaLangPackage.packageRef, typeName("Object"))
     AnyRefAlias.withDeclaredType(BoundedType(TypeAlias(ObjectType), NoType))
   }
 
@@ -83,7 +78,6 @@ final class Definitions private[tastyquery] (
 
     val parents = parentConstrs(TypeRef(NoPrefix, tparam))
     cls.withDeclaredType(ClassInfo.direct(cls, parents))
-    cls.initialised = true
     cls
   end createSpecialPolyClass
 
@@ -95,7 +89,7 @@ final class Definitions private[tastyquery] (
 
   // Derived symbols, found on the classpath
 
-  extension (pkg: PackageClassSymbol)
+  extension (pkg: PackageSymbol)
     private def requiredClass(name: String): ClassSymbol = pkg.getDecl(typeName(name)).get.asClass
 
   private lazy val scalaCollectionPackage = scalaPackage.getPackageDecl(termName("collection")).get

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -128,7 +128,7 @@ object Trees {
 
   trait DefTree(val symbol: Symbol)
 
-  case class PackageDef(pid: PackageClassSymbol, stats: List[Tree])(span: Span) extends Tree(span) with DefTree(pid) {
+  case class PackageDef(pid: PackageSymbol, stats: List[Tree])(span: Span) extends Tree(span) with DefTree(pid) {
     override protected final def calculateType(using Context): Type = NoType
 
     override final def withSpan(span: Span): PackageDef = PackageDef(pid, stats)(span)

--- a/shared/src/main/scala/tastyquery/ast/TypeMaps.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeMaps.scala
@@ -41,7 +41,7 @@ object TypeMaps {
         || {
           val stop = stopAt
           (stop == StopAt.Static && tp.symbol.isStatic && isStaticPrefix(tp.prefix))
-          || (stop == StopAt.Package && tp.symbol.isInstanceOf[PackageClassSymbol])
+          || (stop == StopAt.Package && tp.symbol.isPackage)
         }
     end stopBecauseStaticOrLocal
   end VariantTraversal

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -578,7 +578,7 @@ object Types {
       case Scala2ExternalSymRef(owner, path) =>
         val sym = path.foldLeft(owner) { (owner, name) =>
           val cls = if owner.isTerm then owner.declaredType.asInstanceOf[Symbolic].symbol else owner
-          cls.asClass.getDecl(name).getOrElse {
+          cls.asDeclaringSymbol.getDecl(name).getOrElse {
             throw new SymbolLookupException(name, s"cannot find symbol $owner.$name")
           }
         }
@@ -782,13 +782,13 @@ object Types {
   }
 
   final case class PackageRef(fullyQualifiedName: FullyQualifiedName) extends Type {
-    private var packageSymbol: PackageClassSymbol | Null = null
+    private var packageSymbol: PackageSymbol | Null = null
 
-    def this(packageSym: PackageClassSymbol) =
+    def this(packageSym: PackageSymbol) =
       this(packageSym.fullName)
       packageSymbol = packageSym
 
-    def symbol(using Context): PackageClassSymbol = {
+    def symbol(using Context): PackageSymbol = {
       val local = packageSymbol
       if (local == null) {
         val resolved = ctx.findPackageFromRoot(fullyQualifiedName)
@@ -804,7 +804,7 @@ object Types {
   }
 
   object PackageRef {
-    def apply(packageSym: PackageClassSymbol): PackageRef =
+    def apply(packageSym: PackageSymbol): PackageRef =
       new PackageRef(packageSym)
   }
 

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -80,14 +80,13 @@ class TreeUnpickler(
         val newOwner =
           if tag == TEMPLATE then ClassSymbol.create(name, localCtx.owner)
           else RegularSymbol.create(name, localCtx.owner)
-        localCtx.registerSym(start, newOwner, addToDecls = localCtx.owner.isClass)
+        localCtx.registerSym(start, newOwner, addToDecls = localCtx.owner.isDeclaringSymbol)
         readSymbolModifiers(newOwner, tag, end)
         reader.until(end)(createSymbols()(using localCtx.withOwner(newOwner)))
-        if tag == TEMPLATE then newOwner.asInstanceOf[ClassSymbol].initialised = true
       case DEFDEF | VALDEF | PARAM | TYPEPARAM =>
         val end = reader.readEnd()
         val name = if tag == TYPEPARAM then readName.toTypeName else readName
-        val addToDecls = tag != TYPEPARAM && localCtx.owner.isClass
+        val addToDecls = tag != TYPEPARAM && localCtx.owner.isDeclaringSymbol
         val newSymbol = RegularSymbol.create(name, localCtx.owner)
         localCtx.registerSym(start, newSymbol, addToDecls)
         readSymbolModifiers(newSymbol, tag, end)

--- a/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -121,8 +121,6 @@ object ClassfileParser {
         sigOrDesc match
           case SigOrDesc.Desc(desc) => sym.withDeclaredType(Descriptors.parseDescriptor(sym, desc))
           case SigOrDesc.Sig(sig)   => sym.withDeclaredType(JavaSignatures.parseSignature(sym, sig))
-      cls.initialised = true
-      moduleClass.initialised = true
     }
   }
 

--- a/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -24,7 +24,7 @@ object Descriptors:
     superRef :: interfaces.map(classRef).toList
 
   private def classRef(binaryName: String)(using Context): TypeRef =
-    def followPackages(acc: PackageClassSymbol, parts: List[String]): TypeRef =
+    def followPackages(acc: PackageSymbol, parts: List[String]): TypeRef =
       (parts: @unchecked) match
         case className :: Nil =>
           TypeRef(PackageRef(acc), typeName(className))

--- a/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -134,7 +134,7 @@ object JavaSignatures:
 
     def classTypeSignature(env: JavaSignature): Option[Type] =
       def readSimpleClassType: TypeRef =
-        def followPackages(acc: PackageClassSymbol): TypeRef =
+        def followPackages(acc: PackageSymbol): TypeRef =
           val next = identifier
           if consume('/') then // must have '/', identifier, and terminal char.
             acc.getPackageDecl(next) match

--- a/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -135,7 +135,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
   testWithContext("empty-package-contains-no-packages", simple_trees / tname"SharedPackageReference$$package") {
     // simple_trees is not a subpackage of empty package
-    assertForallWithPrefix(EmptyPkg, s => s.name == nme.EmptyPackageName || !s.isInstanceOf[PackageClassSymbol])
+    assertForallWithPrefix(EmptyPkg, s => s.name == nme.EmptyPackageName || !s.isPackage)
   }
 
   testWithContext("class-parameter-is-a-decl", simple_trees / tname"ConstructorWithParameters") {
@@ -193,11 +193,11 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     assert(resolve(InNestedPackage).fullName.toString == "simple_trees.nested.InNestedPackage")
 
-    val (simpleTreesPkg @ _: PackageClassSymbol) = resolve(simple_trees): @unchecked
+    val (simpleTreesPkg @ _: PackageSymbol) = resolve(simple_trees): @unchecked
 
     assert(simpleTreesPkg.fullName.toString == "simple_trees")
 
-    val (simpleTreesNestedPkg @ _: PackageClassSymbol) = simpleTreesPkg.getDecl(name"nested").get: @unchecked
+    val (simpleTreesNestedPkg @ _: PackageSymbol) = simpleTreesPkg.getDecl(name"nested").get: @unchecked
 
     assert(simpleTreesNestedPkg.fullName.toString == "simple_trees.nested")
 

--- a/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -780,7 +780,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("read-scala.collection.mutable.StringBuilder_after-force-scala-pkg") {
-    val scala = resolve(RootPkg / name"scala").asClass
+    val scala = resolve(RootPkg / name"scala").asPackage
     scala.declarations
 
     val StringBuilder = resolve(RootPkg / name"scala" / name"collection" / name"mutable" / tname"StringBuilder").asClass


### PR DESCRIPTION
Previously, `PackageClassSymbol` was a subclass of `ClassSymbol`. The notion of `DeclaringSymbol` was confused with `ClassSymbol`.

We now make these concepts entirely distinct:

* Rename `PackageClassSymbol` to `PackageSymbol`.
* Make `DeclaringSymbol` a `trait extends Symbol`.
* `PackageSymbol` extends `DeclaringSymbol` but not `ClassSymbol`.
* Move the logic for initialization to `DeclaringSymbol` and clearly name it as `ensureDeclsInitialized()`, since it is only ensuring that declarations are ready to be used; not that the symbol as a hole is ready.
* Remove `ClassSymbol.initialised`, since it is not used anymore.