### PR TITLE
Store the parents of a class in the ClassSymbol instead of the ClassInfo.

### DIFF
--- a/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/shared/src/main/scala/tastyquery/Definitions.scala
@@ -23,7 +23,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   private def createSpecialClass(name: TypeName, parents: List[Type], flags: FlagSet): ClassSymbol =
     val cls = ctx.createClassSymbol(name, scalaPackage)
     cls.withTypeParams(Nil, Nil)
-    cls.withDeclaredType(ClassInfo.direct(cls, if parents.isEmpty then Nil else parents))
+    cls.withParentsDirect(parents)
     cls.withFlags(flags)
     cls
 
@@ -77,7 +77,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     cls.withFlags(EmptyFlagSet | Artifact)
 
     val parents = parentConstrs(TypeRef(NoPrefix, tparam))
-    cls.withDeclaredType(ClassInfo.direct(cls, parents))
+    cls.withParentsDirect(parents)
     cls
   end createSpecialPolyClass
 

--- a/shared/src/main/scala/tastyquery/ast/Types.scala
+++ b/shared/src/main/scala/tastyquery/ast/Types.scala
@@ -1313,21 +1313,7 @@ object Types {
       else AndType(first, second)
   }
 
-  case class ClassInfo(cls: ClassSymbol)(private var mkRawParents: (() => List[Type]) | Null) extends GroundType {
-    var _rawParents: List[Type] | Null = null
-
-    def rawParents: List[Type] =
-      val localParents = _rawParents
-      if localParents != null then localParents
-      else
-        val localFactory = mkRawParents
-        if localFactory == null then throw CyclicReference(s"class info for ${cls.toDebugString}")
-        else
-          mkRawParents = null // we are evaluating the parents, avoid cycles by set to null
-          val computedParents = localFactory()
-          _rawParents = computedParents
-          computedParents
-
+  case class ClassInfo(cls: ClassSymbol) extends GroundType {
     def findMember(name: Name, pre: Type)(using Context): Symbol =
       ClassInfo.findMember(cls, name, pre)
 
@@ -1340,11 +1326,7 @@ object Types {
       cls.findMember(pre, name).getOrElse {
         throw new AssertionError(s"Cannot find member named '$name' in $pre")
       }
-
-    def direct(cls: ClassSymbol, rawParents: List[Type])(using Context): ClassInfo =
-      ClassInfo(cls)(() => rawParents)
-    def defer(cls: ClassSymbol, rawParents: => List[Type])(using Context): ClassInfo =
-      ClassInfo(cls)(() => rawParents)
+  end ClassInfo
 
   case object NoType extends GroundType {
     def findMember(name: Name, pre: Type)(using Context): Symbol =

--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -502,12 +502,13 @@ class TreeUnpickler(
           case _     => readTypeTree
         }
       }
-    def parentsTpes = parents.map {
-      case parent: Apply    => parent.tpe
-      case parent: Block    => parent.tpe
-      case parent: TypeTree => parent.toType
+    cls.withParentsDelayed { () =>
+      parents.map {
+        case parent: Apply    => parent.tpe
+        case parent: Block    => parent.tpe
+        case parent: TypeTree => parent.toType
+      }
     }
-    cls.withDeclaredType(ClassInfo.defer(cls, parentsTpes))
     val self = readSelf
     // The first entry is the constructor
     val cstr = readStat.asInstanceOf[DefDef]

--- a/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -64,7 +64,7 @@ object ClassfileParser {
       .createClassSymbol(name.withObjectSuffix.toTypeName, classOwner)
       .withTypeParams(Nil, Nil)
       .withFlags(Flags.ModuleClassCreationFlags)
-    moduleClass.withDeclaredType(ClassInfo.direct(moduleClass, ObjectType :: Nil))
+    moduleClass.withParentsDirect(ObjectType :: Nil)
 
     val module = ctx
       .createSymbol(name.toTermName, classOwner)
@@ -108,8 +108,7 @@ object ClassfileParser {
             Descriptors.parseSupers(cls, superClass, interfaces)
           }
       end parents
-      val classType = ClassInfo.direct(cls, parents)
-      cls.withDeclaredType(classType)
+      cls.withParentsDirect(parents)
     end initParents
 
     ClassfileReader.read {

--- a/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -474,43 +474,34 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("java-class-parents") {
-    val SubJavaDefined = name"javadefined" / tname"SubJavaDefined"
-
-    val (SubJavaDefinedTpe @ _: ClassInfo) = resolve(SubJavaDefined).declaredType: @unchecked
-
+    val SubJavaDefinedClass = resolve(name"javadefined" / tname"SubJavaDefined").asClass
     val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
     val JavaInterface1Class = resolve(name"javadefined" / tname"JavaInterface1")
     val JavaInterface2Class = resolve(name"javadefined" / tname"JavaInterface2")
 
     assert(
-      SubJavaDefinedTpe.rawParents
+      SubJavaDefinedClass.parents
         .isListOf(_.isRef(JavaDefinedClass), _.isRef(JavaInterface1Class), _.isRef(JavaInterface2Class))
     )
   }
 
   testWithContext("java-class-signatures-[RecClass]") {
-    val RecClass = name"javadefined" / tname"RecClass"
-
-    val (RecClassTpe @ _: ClassInfo) = resolve(RecClass).declaredType: @unchecked
-
+    val RecClass = resolve(name"javadefined" / tname"RecClass").asClass
     val ObjectClass = resolve(name"java" / name"lang" / tname"Object")
 
-    assert(RecClassTpe.rawParents.isListOf(_.isRef(ObjectClass)))
+    assert(RecClass.parents.isListOf(_.isRef(ObjectClass)))
   }
 
   testWithContext("java-class-signatures-[SubRecClass]") {
-    val SubRecClass = name"javadefined" / tname"SubRecClass"
-
-    val (SubRecClassTpe @ _: ClassInfo) = resolve(SubRecClass).declaredType: @unchecked
-
+    val SubRecClass = resolve(name"javadefined" / tname"SubRecClass").asClass
     val RecClass = resolve(name"javadefined" / tname"RecClass")
     val JavaInterface1 = resolve(name"javadefined" / tname"JavaInterface1")
 
-    val List(tparamT) = SubRecClassTpe.cls.typeParamSyms: @unchecked
+    val List(tparamT) = SubRecClass.typeParamSyms: @unchecked
 
     assert(
-      SubRecClassTpe.rawParents.isListOf(
-        _.isApplied(_.isRef(RecClass), List(_.isApplied(_.isRef(SubRecClassTpe.cls), List(_.isRef(tparamT))))),
+      SubRecClass.parents.isListOf(
+        _.isApplied(_.isRef(RecClass), List(_.isApplied(_.isRef(SubRecClass), List(_.isRef(tparamT))))),
         _.isRef(JavaInterface1)
       )
     )


### PR DESCRIPTION
Unlike in dotc, we don't have different periods, so we will always have the same parent list for any given class.