### PR TITLE
Use a dedicated tree node SelfDef for self type definitions.

### DIFF
--- a/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
+++ b/shared/src/main/scala/tastyquery/reader/TreeUnpickler.scala
@@ -549,16 +549,15 @@ class TreeUnpickler(
     acc.toList
   }
 
-  private def readSelf(using LocalContext): ValDef =
+  private def readSelf(using LocalContext): SelfDef =
     if (reader.nextByte != SELFDEF) {
-      reusable.EmptyValDef
+      SelfDef.ReusableEmpty
     } else {
       val spn = span
       reader.readByte()
       val name = readName
       val tpt = readTypeTree
-      // no symbol for self, because it's never referred to by symbol
-      ValDef(name, tpt, EmptyTree, NoSymbol)(tpt.span)
+      SelfDef(name, tpt)(tpt.span)
     }
 
   private def readValOrDefDef(using LocalContext): Tree = {

--- a/shared/src/test/scala/tastyquery/PositionSuite.scala
+++ b/shared/src/test/scala/tastyquery/PositionSuite.scala
@@ -200,12 +200,12 @@ class PositionSuite extends RestrictedUnpicklingSuite {
 
   testUnpickleWithCode("class-with-self", simple_trees / tname"ClassWithSelf") { (tree, code) =>
     // ignore because the span of Self is impossible to construct
-    assertEquals(collectCode[ValDef](tree, code), Nil)
+    assertEquals(collectCode[SelfDef](tree, code), Nil)
   }
 
   testUnpickleWithCode("trait-with-self", simple_trees / tname"TraitWithSelf") { (tree, code) =>
     // ignore because the span of Self is impossible to construct
-    assertEquals(collectCode[ValDef](tree, code), List("ClassWithSelf"))
+    assertEquals(collectCode[SelfDef](tree, code), List("ClassWithSelf"))
   }
 
   /** Import and export */

--- a/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -110,8 +110,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                     ),
                     // a single parent -- java.lang.Object
                     List(parent: Apply),
-                    // self not specified => EmptyValDef
-                    reusable.EmptyValDef,
+                    // self not specified
+                    SelfDef(nme.Wildcard, EmptyTypeTree),
                     // empty body
                     List()
                   ),
@@ -467,11 +467,9 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("defaultSelfType", simple_trees / tname"ClassWithSelf") { tree =>
     val selfDefMatch: StructureCheck = {
-      case ValDef(
+      case SelfDef(
             SimpleName("self"),
-            TypeWrapper(TypeRef(SimpleTreesPackageRef(), Symbol(TypeName(SimpleName("ClassWithSelf"))))),
-            EmptyTree,
-            NoSymbol
+            TypeWrapper(TypeRef(SimpleTreesPackageRef(), Symbol(TypeName(SimpleName("ClassWithSelf")))))
           ) =>
     }
     assert(containsSubtree(selfDefMatch)(clue(tree)))
@@ -479,7 +477,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("selfType", simple_trees / tname"TraitWithSelf") { tree =>
     val selfDefMatch: StructureCheck = {
-      case ValDef(SimpleName("self"), TypeIdent(TypeName(SimpleName("ClassWithSelf"))), EmptyTree, NoSymbol) =>
+      case SelfDef(SimpleName("self"), TypeIdent(TypeName(SimpleName("ClassWithSelf")))) =>
     }
     assert(containsSubtree(selfDefMatch)(clue(tree)))
   }
@@ -499,7 +497,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("object", simple_trees / tname"ScalaObject" / obj) { tree =>
     val selfDefMatch: StructureCheck = {
-      case ValDef(nme.Wildcard, SingletonTypeTree(Ident(SimpleName("ScalaObject"))), EmptyTree, NoSymbol) =>
+      case SelfDef(nme.Wildcard, SingletonTypeTree(Ident(SimpleName("ScalaObject")))) =>
     }
     assert(containsSubtree(selfDefMatch)(clue(tree)))
 


### PR DESCRIPTION
This way, we do not need to store a NoSymbol in the tree, and we do not have meaningless fields `rhs` and `symbol`.