### PR TITLE
The Great Symbols Refactoring.

### DIFF
--- a/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/shared/src/main/scala/tastyquery/Contexts.scala
@@ -121,32 +121,14 @@ object Contexts {
       rec(RootPackage, path)
     end findSymbolFromRoot
 
-    def createClassSymbol(name: TypeName, owner: DeclaringSymbol): ClassSymbol =
-      owner.getDeclInternal(name) match
-        case None =>
-          val cls = ClassSymbol.create(name, owner)
-          owner.addDecl(cls)
-          cls
-        case some =>
-          throw ExistingDefinitionException(owner, name)
-
-    def createSymbol(name: Name, owner: DeclaringSymbol): RegularSymbol =
-      owner.getDeclInternal(name) match
-        case None =>
-          val sym = RegularSymbol.create(name, owner)
-          owner.addDecl(sym)
-          sym
-        case some =>
-          throw ExistingDefinitionException(owner, name)
-
-    def createPackageSymbolIfNew(name: SimpleName, owner: PackageSymbol): PackageSymbol =
+    private[tastyquery] def createPackageSymbolIfNew(name: SimpleName, owner: PackageSymbol): PackageSymbol =
       assert(owner != EmptyPackage, s"Trying to create a subpackage $name of $owner")
       owner.getPackageDeclInternal(name) match {
         case Some(pkg) => pkg
         case None      => PackageSymbol.create(name, owner)
       }
 
-    def createPackageSymbolIfNew(fullyQualifiedName: FullyQualifiedName): PackageSymbol =
+    private[tastyquery] def createPackageSymbolIfNew(fullyQualifiedName: FullyQualifiedName): PackageSymbol =
       fullyQualifiedName.path.foldLeft(RootPackage) { (owner, name) =>
         createPackageSymbolIfNew(name.asSimpleName, owner)
       }
@@ -160,7 +142,7 @@ object Contexts {
           case Some(sym: ClassSymbol) =>
             sym
           case _ =>
-            createClassSymbol(tname, defn.javaLangPackage)
+            ClassSymbol.create(tname, defn.javaLangPackage)
 
       fakeJavaLangClassIfNotFound("Object")
       fakeJavaLangClassIfNotFound("Comparable")

--- a/shared/src/main/scala/tastyquery/api/TastyQuery.scala
+++ b/shared/src/main/scala/tastyquery/api/TastyQuery.scala
@@ -11,8 +11,8 @@ class TastyTrees(trees: List[Tree]):
       tree.walkTree {
         case ddef: DefTree =>
           def nameOf(s: Symbol): String =
-            if s.outer.isStatic then s.fullName.toDebugString
-            else s"${nameOf(s.outer)} { ${s.name.toDebugString} }"
+            if s.owner.nn.isStatic then s.fullName.toDebugString
+            else s"${nameOf(s.owner.nn)} { ${s.name.toDebugString} }"
           if ddef.symbol.exists then println(nameOf(ddef.symbol))
         case _ =>
       }

--- a/shared/src/main/scala/tastyquery/ast/Trees.scala
+++ b/shared/src/main/scala/tastyquery/ast/Trees.scala
@@ -177,7 +177,7 @@ object Trees {
     *  mods type name >: lo <: hi,          if rhs = TypeBoundsTree(lo, hi)      or
     *  mods type name >: lo <: hi = rhs     if rhs = TypeBoundsTree(lo, hi, alias) and opaque in mods
     */
-  abstract class TypeDef(name: TypeName, override val symbol: Symbol)(span: Span)
+  abstract class TypeDef(name: TypeName, override val symbol: TypeSymbol)(span: Span)
       extends Tree(span)
       with DefTree(symbol) {
     override protected final def calculateType(using Context): Type = NoType
@@ -189,7 +189,7 @@ object Trees {
   }
 
   /** A type member has a type tree rhs if the member is defined by the user, or typebounds if it's synthetic */
-  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds, override val symbol: RegularSymbol)(span: Span)
+  case class TypeMember(name: TypeName, rhs: TypeTree | TypeBounds, override val symbol: TypeMemberSymbol)(span: Span)
       extends TypeDef(name, symbol)(span) {
     override final def withSpan(span: Span): TypeMember = TypeMember(name, rhs, symbol)(span)
   }
@@ -198,7 +198,7 @@ object Trees {
   case class TypeParam(
     name: TypeName,
     bounds: TypeBoundsTree | TypeBounds | TypeLambdaTree,
-    override val symbol: RegularSymbol
+    override val symbol: TypeParamSymbol
   )(span: Span)
       extends TypeDef(name, symbol)(span) {
     private[tastyquery] def computeDeclarationTypeBounds()(using Context): TypeBounds = bounds match
@@ -226,7 +226,7 @@ object Trees {
   }
 
   /** mods val name: tpt = rhs */
-  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: RegularSymbol)(span: Span)
+  case class ValDef(name: TermName, tpt: TypeTree, rhs: Tree, override val symbol: TermSymbol)(span: Span)
       extends Tree(span)
       with DefTree(symbol) {
     override protected final def calculateType(using Context): Type = NoType
@@ -254,7 +254,7 @@ object Trees {
     paramLists: List[ParamsClause],
     resultTpt: TypeTree,
     rhs: Tree,
-    override val symbol: RegularSymbol
+    override val symbol: TermSymbol
   )(span: Span)
       extends Tree(span)
       with DefTree(symbol) {
@@ -481,7 +481,7 @@ object Trees {
   }
 
   /** pattern in {@link Unapply} */
-  case class Bind(name: Name, body: Tree, override val symbol: RegularSymbol)(span: Span)
+  case class Bind(name: Name, body: Tree, override val symbol: TermSymbol)(span: Span)
       extends Tree(span)
       with DefTree(symbol) {
     override def calculateType(using Context): Type =

--- a/shared/src/main/scala/tastyquery/ast/TypeOps.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeOps.scala
@@ -47,7 +47,7 @@ object TypeOps:
               /*else if (pre.termSymbol.isPackage && !thiscls.isPackage)
               toPrefix(pre.select(nme.PACKAGE), cls, thiscls)*/
               else
-                toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner, thiscls)
+                toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner.nn, thiscls)
           }
       end toPrefix
 

--- a/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
+++ b/shared/src/main/scala/tastyquery/ast/TypeTrees.scala
@@ -115,7 +115,7 @@ object TypeTrees {
 
   case class TypeCaseDef(pattern: TypeTree, body: TypeTree)
 
-  case class TypeTreeBind(name: TypeName, body: TypeTree, override val symbol: RegularSymbol)(span: Span)
+  case class TypeTreeBind(name: TypeName, body: TypeTree, override val symbol: LocalTypeParamSymbol)(span: Span)
       extends TypeTree(span)
       with DefTree(symbol) {
     override protected def calculateType(using Context): Type =

--- a/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -58,36 +58,34 @@ object ClassfileParser {
   ): Either[ReadException, Unit] = {
     import structure.{reader, given}
 
-    val cls = ctx.createClassSymbol(name.toTypeName, classOwner)
+    val cls = ClassSymbol.create(name.toTypeName, classOwner)
 
-    val moduleClass = ctx
-      .createClassSymbol(name.withObjectSuffix.toTypeName, classOwner)
+    val moduleClass = ClassSymbol
+      .create(name.withObjectSuffix.toTypeName, classOwner)
       .withTypeParams(Nil, Nil)
       .withFlags(Flags.ModuleClassCreationFlags)
     moduleClass.withParentsDirect(ObjectType :: Nil)
 
-    val module = ctx
-      .createSymbol(name.toTermName, classOwner)
+    val module = TermSymbol
+      .create(name.toTermName, classOwner)
       .withDeclaredType(moduleClass.typeRef)
       .withFlags(Flags.ModuleValCreationFlags)
 
-    def loadFields(fields: Forked[DataStream]): IndexedSeq[(Symbol, SigOrDesc)] =
+    def loadFields(fields: Forked[DataStream]): IndexedSeq[(TermSymbol, SigOrDesc)] =
       fields.use {
-        val buf = IndexedSeq.newBuilder[(Symbol, SigOrDesc)]
+        val buf = IndexedSeq.newBuilder[(TermSymbol, SigOrDesc)]
         reader.readFields { (name, sigOrDesc) =>
-          val sym = RegularSymbol.create(name, cls).withFlags(Flags.EmptyFlagSet)
-          cls.addDecl(sym)
+          val sym = TermSymbol.create(name, cls).withFlags(Flags.EmptyFlagSet)
           buf += sym -> sigOrDesc
         }
         buf.result()
       }
 
-    def loadMethods(methods: Forked[DataStream]): IndexedSeq[(Symbol, SigOrDesc)] =
+    def loadMethods(methods: Forked[DataStream]): IndexedSeq[(TermSymbol, SigOrDesc)] =
       methods.use {
-        val buf = IndexedSeq.newBuilder[(Symbol, SigOrDesc)]
+        val buf = IndexedSeq.newBuilder[(TermSymbol, SigOrDesc)]
         reader.readMethods { (name, sigOrDesc) =>
-          val sym = RegularSymbol.create(name, cls).withFlags(Flags.Method)
-          cls.addDecl(sym)
+          val sym = TermSymbol.create(name, cls).withFlags(Flags.Method)
           buf += sym -> sigOrDesc
         }
         buf.result()

--- a/shared/src/main/scala/tastyquery/reader/pickles/PickleFlagSet.scala
+++ b/shared/src/main/scala/tastyquery/reader/pickles/PickleFlagSet.scala
@@ -1,6 +1,6 @@
 package tastyquery.reader.pickles
 
-class PickleFlagSet(rawFlags: Long, isType: Boolean):
+class PickleFlagSet(rawFlags: Long, val isType: Boolean):
   private def hasFlag(flag: Long): Boolean = (rawFlags & flag) != 0L
 
   def isImplicit: Boolean = hasFlag(0x00000001)

--- a/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -29,54 +29,54 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("java.lang.String") {
     val StringClass = resolve(name"java" / name"lang" / tname"String").asClass
 
-    val charAt = StringClass.getDecl(name"charAt").get
+    val charAt = StringClass.getDecl(name"charAt").get.asTerm
     assertIsSignedName(charAt.signedName, "charAt", "(scala.Int):scala.Char")
 
-    val contains = StringClass.getDecl(name"contains").get
+    val contains = StringClass.getDecl(name"contains").get.asTerm
     assertIsSignedName(contains.signedName, "contains", "(java.lang.CharSequence):scala.Boolean")
 
-    val length = StringClass.getDecl(name"length").get
+    val length = StringClass.getDecl(name"length").get.asTerm
     assertIsSignedName(length.signedName, "length", "():scala.Int")
   }
 
   testWithContext("GenericClass") {
     val GenericClass = resolve(name"simple_trees" / tname"GenericClass").asClass
 
-    val field = GenericClass.getDecl(name"field").get
+    val field = GenericClass.getDecl(name"field").get.asTerm
     assertNotSignedName(field.signedName)
 
-    val getter = GenericClass.getDecl(name"getter").get
+    val getter = GenericClass.getDecl(name"getter").get.asTerm
     assertIsSignedName(getter.signedName, "getter", "():java.lang.Object")
 
-    val method = GenericClass.getDecl(name"method").get
+    val method = GenericClass.getDecl(name"method").get.asTerm
     assertIsSignedName(method.signedName, "method", "(java.lang.Object):java.lang.Object")
   }
 
   testWithContext("GenericMethod") {
     val GenericMethod = resolve(name"simple_trees" / tname"GenericMethod").asClass
 
-    val identity = GenericMethod.getDecl(name"identity").get
+    val identity = GenericMethod.getDecl(name"identity").get.asTerm
     assertIsSignedName(identity.signedName, "identity", "(1,java.lang.Object):java.lang.Object")
   }
 
   testWithContext("RichInt") {
     val RichInt = resolve(name"scala" / name"runtime" / tname"RichInt").asClass
 
-    val toHexString = RichInt.getDecl(name"toHexString").get
+    val toHexString = RichInt.getDecl(name"toHexString").get.asTerm
     assertIsSignedName(toHexString.signedName, "toHexString", "():java.lang.String")
   }
 
   testWithContext("Product") {
     val Product = resolve(name"scala" / tname"Product").asClass
 
-    val productIterator = Product.getDecl(name"productIterator").get
+    val productIterator = Product.getDecl(name"productIterator").get.asTerm
     assertIsSignedName(productIterator.signedName, "productIterator", "():scala.collection.Iterator")
   }
 
   testWithContext("with type") {
     val RefinedTypeTree = resolve(name"simple_trees" / tname"RefinedTypeTree").asClass
 
-    val andType = RefinedTypeTree.getDecl(name"andType").get
+    val andType = RefinedTypeTree.getDecl(name"andType").get.asTerm
     assertIsSignedName(andType.signedName, "andType", "():simple_trees.RefinedTypeTree.AndTypeA")
   }
 
@@ -85,36 +85,36 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
 
     // TODO The erasure is not actually correct here, but at least we don't crash
 
-    val withArray = TypeRefIn.getDecl(name"withArray").get
+    val withArray = TypeRefIn.getDecl(name"withArray").get.asTerm
     assertIsSignedName(withArray.signedName, "withArray", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayOfSubtype = TypeRefIn.getDecl(name"withArrayOfSubtype").get
+    val withArrayOfSubtype = TypeRefIn.getDecl(name"withArrayOfSubtype").get.asTerm
     assertIsSignedName(withArrayOfSubtype.signedName, "withArrayOfSubtype", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayAnyRef = TypeRefIn.getDecl(name"withArrayAnyRef").get
+    val withArrayAnyRef = TypeRefIn.getDecl(name"withArrayAnyRef").get.asTerm
     assertIsSignedName(withArrayAnyRef.signedName, "withArrayAnyRef", "(1,java.lang.Object[]):scala.Unit")
 
-    val withArrayOfSubtypeAnyRef = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyRef").get
+    val withArrayOfSubtypeAnyRef = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyRef").get.asTerm
     assertIsSignedName(
       withArrayOfSubtypeAnyRef.signedName,
       "withArrayOfSubtypeAnyRef",
       "(1,java.lang.Object[]):scala.Unit"
     )
 
-    val withArrayAnyVal = TypeRefIn.getDecl(name"withArrayAnyVal").get
+    val withArrayAnyVal = TypeRefIn.getDecl(name"withArrayAnyVal").get.asTerm
     assertIsSignedName(withArrayAnyVal.signedName, "withArrayAnyVal", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayOfSubtypeAnyVal = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyVal").get
+    val withArrayOfSubtypeAnyVal = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyVal").get.asTerm
     assertIsSignedName(
       withArrayOfSubtypeAnyVal.signedName,
       "withArrayOfSubtypeAnyVal",
       "(1,java.lang.Object):scala.Unit"
     )
 
-    val withArrayList = TypeRefIn.getDecl(name"withArrayList").get
+    val withArrayList = TypeRefIn.getDecl(name"withArrayList").get.asTerm
     assertIsSignedName(withArrayList.signedName, "withArrayList", "(1,scala.collection.immutable.List[]):scala.Unit")
 
-    val withArrayOfSubtypeList = TypeRefIn.getDecl(name"withArrayOfSubtypeList").get
+    val withArrayOfSubtypeList = TypeRefIn.getDecl(name"withArrayOfSubtypeList").get.asTerm
     assertIsSignedName(
       withArrayOfSubtypeList.signedName,
       "withArrayOfSubtypeList",
@@ -125,77 +125,77 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("type-member") {
     val TypeMember = resolve(name"simple_trees" / tname"TypeMember").asClass
 
-    val mTypeAlias = TypeMember.getDecl(name"mTypeAlias").get
+    val mTypeAlias = TypeMember.getDecl(name"mTypeAlias").get.asTerm
     assertIsSignedName(mTypeAlias.signedName, "mTypeAlias", "(scala.Int):scala.Int")
 
-    val mAbstractType = TypeMember.getDecl(name"mAbstractType").get
+    val mAbstractType = TypeMember.getDecl(name"mAbstractType").get.asTerm
     assertIsSignedName(mAbstractType.signedName, "mAbstractType", "(java.lang.Object):java.lang.Object")
 
-    val mAbstractTypeWithBounds = TypeMember.getDecl(name"mAbstractTypeWithBounds").get
+    val mAbstractTypeWithBounds = TypeMember.getDecl(name"mAbstractTypeWithBounds").get.asTerm
     assertIsSignedName(mAbstractTypeWithBounds.signedName, "mAbstractTypeWithBounds", "(scala.Product):scala.Product")
 
-    val mOpaque = TypeMember.getDecl(name"mOpaque").get
+    val mOpaque = TypeMember.getDecl(name"mOpaque").get.asTerm
     assertIsSignedName(mOpaque.signedName, "mOpaque", "(scala.Int):scala.Int")
 
-    val mOpaqueWithBounds = TypeMember.getDecl(name"mOpaqueWithBounds").get
+    val mOpaqueWithBounds = TypeMember.getDecl(name"mOpaqueWithBounds").get.asTerm
     assertIsSignedName(mOpaqueWithBounds.signedName, "mOpaqueWithBounds", "(scala.Null):scala.Null")
   }
 
   testWithContext("scala2-case-class-varargs") {
     val StringContext = resolve(name"scala" / tname"StringContext").asClass
 
-    val parts = StringContext.getDecl(name"parts").get
+    val parts = StringContext.getDecl(name"parts").get.asTerm
     assertIsSignedName(parts.signedName, "parts", "():scala.collection.immutable.Seq")
   }
 
   testWithContext("scala2-method-byname") {
     val StringContext = resolve(name"scala" / tname"Option").asClass
 
-    val getOrElse = StringContext.getDecl(name"getOrElse").get
+    val getOrElse = StringContext.getDecl(name"getOrElse").get.asTerm
     assertIsSignedName(getOrElse.signedName, "getOrElse", "(1,scala.Function0):java.lang.Object")
   }
 
   testWithContext("scala2-existential-type") {
     val ClassTag = resolve(name"scala" / name"reflect" / tname"ClassTag" / obj).asClass
 
-    val apply = ClassTag.getDecl(name"apply").get
+    val apply = ClassTag.getDecl(name"apply").get.asTerm
     assertIsSignedName(apply.signedName, "apply", "(1,java.lang.Class):scala.reflect.ClassTag")
   }
 
   testWithContext("iarray") {
     val IArraySig = resolve(name"simple_trees" / tname"IArraySig").asClass
 
-    val from = IArraySig.getDecl(name"from").get
+    val from = IArraySig.getDecl(name"from").get.asTerm
     assertIsSignedName(from.signedName, "from", "():java.lang.String[]")
   }
 
   testWithContext("value-class-arrayOps-generic") {
     val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
-    val genericArrayOps = MyArrayOps.getDecl(name"genericArrayOps").get
+    val genericArrayOps = MyArrayOps.getDecl(name"genericArrayOps").get.asTerm
     assertIsSignedName(genericArrayOps.signedName, "genericArrayOps", "(1,java.lang.Object):java.lang.Object")
   }
 
   testWithContext("value-class-arrayOps-int") {
     val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
-    val intArrayOps = MyArrayOps.getDecl(name"intArrayOps").get
+    val intArrayOps = MyArrayOps.getDecl(name"intArrayOps").get.asTerm
     assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):java.lang.Object")
   }
 
   testWithContext("value-class-monomorphic") {
     val MyFlags = resolve(name"inheritance" / tname"MyFlags").asClass
-    val merge = MyFlags.getDecl(name"merge").get
+    val merge = MyFlags.getDecl(name"merge").get.asTerm
     assertIsSignedName(merge.signedName, "merge", "(scala.Long):scala.Long")
   }
 
   testWithContext("value-class-monomorphic-arrayOf") {
     val MyFlags = resolve(name"inheritance" / tname"MyFlags" / obj).asClass
-    val mergeAll = MyFlags.getDecl(name"mergeAll").get
+    val mergeAll = MyFlags.getDecl(name"mergeAll").get.asTerm
     assertIsSignedName(mergeAll.signedName, "mergeAll", "(inheritance.MyFlags[]):scala.Long")
   }
 
   testWithContext("value-class-polymorphic-arrayOf") {
     val MyArrayOps = resolve(name"inheritance" / tname"MyArrayOps" / obj).asClass
-    val arrayOfIntArrayOps = MyArrayOps.getDecl(name"arrayOfIntArrayOps").get
+    val arrayOfIntArrayOps = MyArrayOps.getDecl(name"arrayOfIntArrayOps").get.asTerm
     assertIsSignedName(arrayOfIntArrayOps.signedName, "arrayOfIntArrayOps", "(scala.Int[][]):inheritance.MyArrayOps[]")
   }
 

--- a/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -209,7 +209,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     val SubClass = resolve(Sub).asClass
 
-    val fooMethod = SubClass.ref.member(name"foo")
+    val fooMethod = SubClass.typeRef.member(name"foo")
   }
 
   testWithContext("complex-inheritance-same-root", inheritance / tname"SameTasty" / obj, fundamentalClasses*) {
@@ -226,7 +226,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     val SubWithMixinClass = resolve(SubWithMixin).asClass
 
-    val barMethod = SubWithMixinClass.ref.member(name"bar")
+    val barMethod = SubWithMixinClass.typeRef.member(name"bar")
   }
 
   testWithContext(
@@ -238,6 +238,6 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     val SubCrossTastyClass = resolve(SubCrossTasty).asClass
 
-    val fooMethod = SubCrossTastyClass.ref.member(name"foo")
+    val fooMethod = SubCrossTastyClass.typeRef.member(name"foo")
   }
 }


### PR DESCRIPTION
Previously, the hierarchy of `Symbol` was limited to `ClassSymbol`, `PackageSymbol` and `RegularSymbol`. `RegularSymbol`s could equally represent terms or (non-class) types.

In the latter case, their `declaredType` would contain a dubious encoding of the type definition. Notably, we used `WildcardTypeBounds` as a way to wrap `TypeBounds` in a `Type`, but that was a hack, and they had to be extracted everywhere.

Now, the hierarchy is more elaborate. In particular, we distinguish `TermSymbol`s, with a `declaredType: Type`, from the `TypeSymbol`s, which are either `ClassSymbol`s or `TypeSymbolWithBounds`, the latter being further classified and exposing `bounds: TypeBounds`.

Some aspects of `Type`s are refined to expose and manipulate the appropriate subtypes of `Symbol`s. In particular, `TermRef`s are guaranteed to point to `TermSymbol`s while `TypeRef`s point to `TypeSymbol`s.