### PR TITLE
Move the core type definitions to `Definitions`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
@@ -2,6 +2,7 @@ package tastyquery
 
 import scala.compiletime.asMatchable
 
+import tastyquery.Contexts.*
 import tastyquery.Types.Type
 
 object Constants {
@@ -20,19 +21,19 @@ object Constants {
   final val ClazzTag = 12
 
   class Constant(val value: Matchable, val tag: Int) {
-    def wideType: Type = tag match
-      case UnitTag    => Types.UnitType
-      case BooleanTag => Types.BooleanType
-      case CharTag    => Types.CharType
-      case ByteTag    => Types.ByteType
-      case ShortTag   => Types.ShortType
-      case IntTag     => Types.IntType
-      case LongTag    => Types.LongType
-      case FloatTag   => Types.FloatType
-      case DoubleTag  => Types.DoubleType
-      case StringTag  => Types.StringType
-      case NullTag    => Types.NullType
-      case ClazzTag   => Types.ClassTypeOf(typeValue)
+    def wideType(using Context): Type = tag match
+      case UnitTag    => defn.UnitType
+      case BooleanTag => defn.BooleanType
+      case CharTag    => defn.CharType
+      case ByteTag    => defn.ByteType
+      case ShortTag   => defn.ShortType
+      case IntTag     => defn.IntType
+      case LongTag    => defn.LongType
+      case FloatTag   => defn.FloatType
+      case DoubleTag  => defn.DoubleType
+      case StringTag  => defn.StringType
+      case NullTag    => defn.NullType
+      case ClazzTag   => defn.ClassTypeOf(typeValue)
 
     def isByteRange: Boolean = isIntRange && Byte.MinValue <= intValue && intValue <= Byte.MaxValue
     def isShortRange: Boolean = isIntRange && Short.MinValue <= intValue && intValue <= Short.MaxValue

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -18,6 +18,43 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   private val javaPackage = ctx.createPackageSymbolIfNew(nme.javaPackageName, RootPackage)
   val javaLangPackage = ctx.createPackageSymbolIfNew(nme.langPackageName, javaPackage)
 
+  private val scalaCollectionPackage =
+    ctx.createPackageSymbolIfNew(termName("collection"), scalaPackage)
+  private val scalaCollectionImmutablePackage =
+    ctx.createPackageSymbolIfNew(termName("immutable"), scalaCollectionPackage)
+
+  // Cached TypeRef's for core types
+
+  val AnyType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Any"))
+  val AnyRefType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("AnyRef"))
+  val AnyValType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("AnyVal"))
+
+  val NullType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Null"))
+  val NothingType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Nothing"))
+
+  val ObjectType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("Object"))
+
+  val ArrayTypeUnapplied: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Array"))
+  def ArrayTypeOf(tpe: Type): AppliedType = AppliedType(ArrayTypeUnapplied, List(tpe))
+
+  val SeqTypeUnapplied: TypeRef = TypeRef(scalaCollectionImmutablePackage.packageRef, typeName("Seq"))
+  def SeqTypeOf(tpe: Type): AppliedType = AppliedType(SeqTypeUnapplied, List(tpe))
+
+  val IntType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Int"))
+  val LongType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Long"))
+  val FloatType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Float"))
+  val DoubleType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Double"))
+  val BooleanType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Boolean"))
+  val ByteType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Byte"))
+  val ShortType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Short"))
+  val CharType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Char"))
+  val UnitType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Unit"))
+
+  val StringType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("String"))
+
+  val UnappliedClassType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("Class"))
+  def ClassTypeOf(tpe: Type): AppliedType = AppliedType(UnappliedClassType, List(tpe))
+
   // Magic symbols that are not found on the classpath, but rather created by hand
 
   private def createSpecialClass(name: TypeName, parents: List[Type], flags: FlagSet): ClassSymbol =
@@ -62,7 +99,6 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
     val AnyRefAlias = TypeMemberSymbol.create(typeName("AnyRef"), scalaPackage)
     AnyRefAlias.withFlags(EmptyFlagSet)
-    val ObjectType = TypeRef(javaLangPackage.packageRef, typeName("Object"))
     AnyRefAlias.withDefinition(TypeMemberDefinition.TypeAlias(ObjectType))
   }
 
@@ -95,10 +131,6 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   extension (pkg: PackageSymbol)
     private def requiredClass(name: String): ClassSymbol = pkg.getDecl(typeName(name)).get.asClass
-
-  private lazy val scalaCollectionPackage = scalaPackage.getPackageDecl(termName("collection")).get
-  private lazy val scalaCollectionImmutablePackage =
-    scalaCollectionPackage.getPackageDecl(termName("immutable")).get
 
   lazy val ObjectClass = javaLangPackage.requiredClass("Object")
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -600,7 +600,7 @@ object Symbols {
     private[tastyquery] def createRefinedClassSymbol(owner: Symbol, span: Span)(using Context): ClassSymbol =
       val cls = create(tpnme.RefinedClassMagic, owner)
       cls
-        .withParentsDirect(ObjectType :: Nil)
+        .withParentsDirect(defn.ObjectType :: Nil)
         .withFlags(EmptyFlagSet)
       cls
   end ClassSymbol

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -207,7 +207,7 @@ object Trees {
       case bounds: TypeBounds  => bounds
       case tlt: TypeLambdaTree =>
         // TODO See the <init> in HigherKinded and HigherKindedWithParam
-        RealTypeBounds(NothingType, AnyType)
+        defn.NothingAnyBounds
 
     override final def withSpan(span: Span): TypeParam = TypeParam(name, bounds, symbol)(span)
   }
@@ -406,7 +406,7 @@ object Trees {
   /** name = arg, outside a parameter list */
   case class Assign(lhs: Tree, rhs: Tree)(span: Span) extends Tree(span) {
     override def calculateType(using Context): Type =
-      UnitType
+      defn.UnitType
 
     override final def withSpan(span: Span): Assign = Assign(lhs, rhs)(span)
   }
@@ -522,7 +522,7 @@ object Trees {
   /** while (cond) { body } */
   case class While(cond: Tree, body: Tree)(span: Span) extends Tree(span) {
     override def calculateType(using Context): Type =
-      UnitType
+      defn.UnitType
 
     override final def withSpan(span: Span): While = While(cond, body)(span)
   }
@@ -530,7 +530,7 @@ object Trees {
   /** throw expr */
   case class Throw(expr: Tree)(span: Span) extends Tree(span) {
     override def calculateType(using Context): Type =
-      NothingType
+      defn.NothingType
 
     override final def withSpan(span: Span): Throw = Throw(expr)(span)
   }
@@ -552,7 +552,7 @@ object Trees {
 
   case class Return(expr: Tree, from: Tree)(span: Span) extends Tree(span) {
     override def calculateType(using Context): Type =
-      NothingType
+      defn.NothingType
 
     override final def withSpan(span: Span): Return = Return(expr, from)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -207,7 +207,7 @@ object TypeMaps {
       else if (lo `eq` hi) lo
       else Range(lower(lo), upper(hi))
 
-    protected def emptyRange: Type = range(NothingType, AnyType)
+    protected def emptyRange: Type = range(defn.NothingType, defn.AnyType)
 
     protected def lower(tp: Type): Type = tp match {
       case tp: Range => tp.lo
@@ -391,10 +391,10 @@ object TypeMaps {
             }
             if (distributeArgs(args, tp.tyconTypeParams))
               range(tp.derivedAppliedType(tycon, loBuf.toList), tp.derivedAppliedType(tycon, hiBuf.toList))
-            else if tycon.isLambdaSub || args.exists(isRangeOfNonTermTypes) then range(Types.NothingType, Types.AnyType)
+            else if tycon.isLambdaSub || args.exists(isRangeOfNonTermTypes) then range(defn.NothingType, defn.AnyType)
             else
               // See lampepfl/dotty#14152
-              range(Types.NothingType, tp.derivedAppliedType(tycon, args.map(rangeToBounds)))
+              range(defn.NothingType, tp.derivedAppliedType(tycon, args.map(rangeToBounds)))
           else tp.derivedAppliedType(tycon, args)
       }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
@@ -110,7 +110,7 @@ object TypeTrees {
   case class MatchTypeTree(bound: TypeTree, selector: TypeTree, cases: List[TypeCaseDef])(span: Span)
       extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
-      NothingType // TODO
+      defn.NothingType // TODO
 
     override final def withSpan(span: Span): MatchTypeTree = MatchTypeTree(bound, selector, cases)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -439,42 +439,6 @@ object Types {
       NamedType(this, sym) // dotc also calls reduceProjection here, should we do it?
   }
 
-  private def scalaPackage: PackageRef = PackageRef(FullyQualifiedName.scalaPackageName)
-
-  private def javalangPackage: PackageRef = PackageRef(FullyQualifiedName.javaLangPackageName)
-
-  private def scalaDot(name: TypeName): TypeRef =
-    TypeRef(scalaPackage, name)
-
-  private def javalangDot(name: TypeName): Type =
-    TypeRef(javalangPackage, name)
-
-  def AnyType: Type = scalaDot(tpnme.Any)
-  def NothingType: Type = scalaDot(tpnme.Nothing)
-  def NullType: Type = scalaDot(tpnme.Null)
-
-  def ArrayTypeUnapplied: TypeRef = scalaDot(tpnme.Array)
-  def ArrayTypeOf(tpe: Type): AppliedType = AppliedType(ArrayTypeUnapplied, List(tpe))
-
-  def SeqTypeUnapplied: TypeRef = scalaDot(tpnme.Seq)
-  def SeqTypeOf(tpe: Type): AppliedType = AppliedType(SeqTypeUnapplied, List(tpe))
-
-  def UnitType: Type = scalaDot(tpnme.Unit)
-  def BooleanType: Type = scalaDot(tpnme.Boolean)
-  def CharType: Type = scalaDot(tpnme.Char)
-  def ByteType: Type = scalaDot(tpnme.Byte)
-  def ShortType: Type = scalaDot(tpnme.Short)
-  def IntType: Type = scalaDot(tpnme.Int)
-  def LongType: Type = scalaDot(tpnme.Long)
-  def FloatType: Type = scalaDot(tpnme.Float)
-  def DoubleType: Type = scalaDot(tpnme.Double)
-
-  def StringType: Type = javalangDot(tpnme.String)
-  def ObjectType: Type = javalangDot(tpnme.Object)
-  def ClassTypeOf(cls: Type): Type = AppliedType(javalangDot(tpnme.Class), List(cls))
-
-  def UnconstrainedTypeBounds: TypeBounds = RealTypeBounds(NothingType, AnyType)
-
   // ----- Type categories ----------------------------------------------
 
   // Every type is expected to inherit either TypeProxy or GroundType.
@@ -938,7 +902,7 @@ object Types {
         //case tycon: HKTypeLambda => defn.AnyType
         case tycon: TypeRef if tycon.symbol.isClass => tycon
         case tycon: TypeProxy                       => tycon.superType.applyIfParameterized(args)
-        case _                                      => AnyType
+        case _                                      => defn.AnyType
 
     override def translucentSuperType(using Context): Type = tycon match
       case tycon: TypeRef if tycon.symbol.isOpaqueTypeAlias =>
@@ -1272,7 +1236,7 @@ object Types {
 
     def companion: LambdaTypeCompanion[TypeName, TypeBounds, TypeLambda] = TypeLambda
 
-    override def underlying(using Context): Type = AnyType
+    override def underlying(using Context): Type = defn.AnyType
 
     override def toString: String =
       if evaluating then s"TypeLambda($paramNames)(<evaluating>)"
@@ -1406,7 +1370,7 @@ object Types {
       val myJoin = this.myJoin
       if (myJoin != null) then myJoin
       else
-        val computedJoin = ObjectType // TypeOps.orDominator(this)
+        val computedJoin = defn.ObjectType // TypeOps.orDominator(this)
         this.myJoin = computedJoin
         computedJoin
     }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -61,7 +61,7 @@ private[reader] object ClassfileParser {
       .create(name.withObjectSuffix.toTypeName, classOwner)
       .withTypeParams(Nil, Nil)
       .withFlags(Flags.ModuleClassCreationFlags)
-    moduleClass.withParentsDirect(ObjectType :: Nil)
+    moduleClass.withParentsDirect(defn.ObjectType :: Nil)
 
     val module = TermSymbol
       .create(name.toTermName, classOwner)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -18,8 +18,8 @@ private[classfiles] object Descriptors:
       // More efficient would be to only do this check once in Definitions,
       // but parents are immutable currently.
       // !!! Cannot access `defn.ObjectClass` here, because that's a cycle when initializing defn.ObjectClass itself
-      if cls.owner == defn.javaLangPackage && cls.name == tpnme.Object then AnyType
-      else ObjectType
+      if cls.owner == defn.javaLangPackage && cls.name == tpnme.Object then defn.AnyType
+      else defn.ObjectType
     }
     superRef :: interfaces.map(classRef).toList
 
@@ -74,14 +74,14 @@ private[classfiles] object Descriptors:
     def baseType: Option[Type] =
       if available >= 1 then
         (peek: @switch) match
-          case 'B' => commitSimple(1, Some(ByteType))
-          case 'C' => commitSimple(1, Some(CharType))
-          case 'D' => commitSimple(1, Some(DoubleType))
-          case 'F' => commitSimple(1, Some(FloatType))
-          case 'I' => commitSimple(1, Some(IntType))
-          case 'J' => commitSimple(1, Some(LongType))
-          case 'S' => commitSimple(1, Some(ShortType))
-          case 'Z' => commitSimple(1, Some(BooleanType))
+          case 'B' => commitSimple(1, Some(defn.ByteType))
+          case 'C' => commitSimple(1, Some(defn.CharType))
+          case 'D' => commitSimple(1, Some(defn.DoubleType))
+          case 'F' => commitSimple(1, Some(defn.FloatType))
+          case 'I' => commitSimple(1, Some(defn.IntType))
+          case 'J' => commitSimple(1, Some(defn.LongType))
+          case 'S' => commitSimple(1, Some(defn.ShortType))
+          case 'Z' => commitSimple(1, Some(defn.BooleanType))
           case _   => None
       else None
 
@@ -94,14 +94,14 @@ private[classfiles] object Descriptors:
     def arrayType: Option[Type] =
       if consume('[') then
         val tpe = fieldDescriptor
-        Some(ArrayTypeOf(tpe))
+        Some(defn.ArrayTypeOf(tpe))
       else None
 
     def fieldDescriptor: Type =
       baseType.orElse(objectType).orElse(arrayType).getOrElse(abort)
 
     def returnDescriptor: Type =
-      if consume('V') then UnitType
+      if consume('V') then defn.UnitType
       else fieldDescriptor
 
     def methodDescriptor: Type =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -115,14 +115,14 @@ private[classfiles] object JavaSignatures:
     def baseType: Option[Type] =
       if available >= 1 then
         (peek: @switch) match
-          case 'B' => commitSimple(1, Some(ByteType))
-          case 'C' => commitSimple(1, Some(CharType))
-          case 'D' => commitSimple(1, Some(DoubleType))
-          case 'F' => commitSimple(1, Some(FloatType))
-          case 'I' => commitSimple(1, Some(IntType))
-          case 'J' => commitSimple(1, Some(LongType))
-          case 'S' => commitSimple(1, Some(ShortType))
-          case 'Z' => commitSimple(1, Some(BooleanType))
+          case 'B' => commitSimple(1, Some(defn.ByteType))
+          case 'C' => commitSimple(1, Some(defn.CharType))
+          case 'D' => commitSimple(1, Some(defn.DoubleType))
+          case 'F' => commitSimple(1, Some(defn.FloatType))
+          case 'I' => commitSimple(1, Some(defn.IntType))
+          case 'J' => commitSimple(1, Some(defn.LongType))
+          case 'S' => commitSimple(1, Some(defn.ShortType))
+          case 'Z' => commitSimple(1, Some(defn.BooleanType))
           case _   => None
       else None
 
@@ -172,11 +172,11 @@ private[classfiles] object JavaSignatures:
       if available >= 1 then
         (peek: @switch) match
           case '*' =>
-            commitSimple(1, WildcardTypeBounds(RealTypeBounds(NothingType, AnyType)))
+            commitSimple(1, WildcardTypeBounds(defn.NothingAnyBounds))
           case '+' =>
-            commit(1) { val upper = referenceType(env); WildcardTypeBounds(RealTypeBounds(NothingType, upper)) }
+            commit(1) { val upper = referenceType(env); WildcardTypeBounds(RealTypeBounds(defn.NothingType, upper)) }
           case '-' =>
-            commit(1) { val lower = referenceType(env); WildcardTypeBounds(RealTypeBounds(lower, AnyType)) }
+            commit(1) { val lower = referenceType(env); WildcardTypeBounds(RealTypeBounds(lower, defn.AnyType)) }
           case _ =>
             referenceType(env)
       else abort
@@ -190,10 +190,10 @@ private[classfiles] object JavaSignatures:
         expect(':')
         referenceTypeSignature(env) match
           case Some(tpe) => tpe
-          case _         => AnyType
+          case _         => defn.AnyType
       val interfaceBounds = readWhile(':', referenceType(env))
       if env.withAddedParam(tname) then emptyTypeBounds // shortcut as we will throw away the bounds
-      else RealTypeBounds(NothingType, interfaceBounds.foldLeft(classBound)(AndType(_, _)))
+      else RealTypeBounds(defn.NothingType, interfaceBounds.foldLeft(classBound)(AndType(_, _)))
 
     def typeParamsRest(env: JavaSignature): List[TypeBounds] =
       readUntil('>', typeParameter(env))
@@ -206,11 +206,11 @@ private[classfiles] object JavaSignatures:
     def arrayType(env: JavaSignature): Option[Type] =
       if consume('[') then
         val tpe = javaTypeSignature(env)
-        Some(ArrayTypeOf(tpe))
+        Some(defn.ArrayTypeOf(tpe))
       else None
 
     def result(env: JavaSignature): Type =
-      if consume('V') then UnitType
+      if consume('V') then defn.UnitType
       else javaTypeSignature(env)
 
     def referenceType(env: JavaSignature): Type =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -225,7 +225,7 @@ private[pickles] class PickleReader {
             case tpe =>
               throw AssertionError(s"unexpected type $tpe for $cls, owner is $owner")
           cls.withParentsDirect(parentTypes)
-        val bounds = typeParams.map(_ => RealTypeBounds(NothingType, AnyType)) // TODO Read bounds
+        val bounds = typeParams.map(_ => defn.NothingAnyBounds) // TODO Read bounds
         cls.withTypeParams(typeParams, bounds)
         cls
       case VALsym =>
@@ -453,7 +453,7 @@ private[pickles] class PickleReader {
           val refined = decls.toList.foldLeft(parent)(addRefinement)
           RecType.closeOver(rt => refined.substThis(clazz, rt.recThis))
         }*/
-        AnyType
+        defn.AnyType
       case CLASSINFOtpe =>
         val clazz = readLocalSymbolRef()
         TempClassInfoType(pkl.until(end, () => readTypeRef()))

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -464,7 +464,7 @@ private[tasties] class TreeUnpickler(
       val typeBounds = bounds match
         case bounds: TypeBounds     => bounds
         case bounds: TypeBoundsTree => bounds.toTypeBounds
-        case bounds: TypeLambdaTree => RealTypeBounds(NothingType, AnyType)
+        case bounds: TypeLambdaTree => defn.NothingAnyBounds
       paramSymbol.setBounds(typeBounds)
       skipModifiers(end)
       TypeParam(name, bounds, paramSymbol)(spn).definesTreeOf(paramSymbol)


### PR DESCRIPTION
This way, the `TypeRef`s can be cached, and their resolved `symbol`s as well.