### PR TITLE
Lock down any access to the `designator` of `NamedType`s.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -501,7 +501,7 @@ object Symbols {
       if local == null then throw new IllegalStateException(s"expected type params for $this")
       else local
 
-    private[tastyquery] final def typeParamSymsNoInitialize(using Context): List[Symbol] =
+    private[tastyquery] final def typeParamSymsNoInitialize(using Context): List[ClassTypeParamSymbol] =
       typeParamsInternal.map(_(0))
 
     private[tastyquery] final def withParentsDirect(parents: List[Type]): this.type =

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -272,7 +272,7 @@ object TypeMaps {
       */
     def expandParam(tp: NamedType, pre: Type): Type =
       tp.argForParam(pre) match {
-        case arg @ TypeRef(pre, _) if pre.isArgPrefixOf(arg.symbol) =>
+        case arg: TypeRef if arg.prefix.isArgPrefixOf(arg.symbol) =>
           expandBounds(arg.symbol.asInstanceOf[ClassTypeParamSymbol].bounds)
         case WildcardTypeBounds(arg) => expandBounds(arg)
         case arg                     => reapply(arg)

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
@@ -121,7 +121,7 @@ object TypeTrees {
       extends TypeTree(span)
       with DefTree(symbol) {
     override protected def calculateType(using Context): Type =
-      TermRef(NoType, symbol)
+      TypeRef(NoType, symbol)
 
     override final def withSpan(span: Span): TypeTreeBind = TypeTreeBind(name, body, symbol)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -793,7 +793,7 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val end = reader.readEnd()
       val trtSpan = spn
-      val from = readSymRef
+      val from = readSymRef.asTerm
       val expr = reader.ifBefore(end)(readTerm, EmptyTree)
       // TODO: always just taking the name?
       // return always returns from a method, i.e. something with a TermName
@@ -840,17 +840,15 @@ private[tasties] class TreeUnpickler(
     case TERMREFdirect =>
       val spn = span
       reader.readByte()
-      val sym = readSymRef
-      assert(sym.name.isInstanceOf[TermName], posErrorMsg)
+      val sym = readSymRef.asTerm
       val tpe = TermRef(NoPrefix, sym)
-      TermRefTree(sym.name.asInstanceOf[TermName], tpe)(spn)
+      TermRefTree(sym.name, tpe)(spn)
     case TERMREFsymbol =>
       val spn = span
       reader.readByte()
-      val sym = readSymRef
+      val sym = readSymRef.asTerm
       val pre = readType
-      assert(sym.name.isInstanceOf[TermName], posErrorMsg)
-      TermRefTree(sym.name.asInstanceOf[TermName], TermRef(pre, sym))(spn)
+      TermRefTree(sym.name, TermRef(pre, sym))(spn)
     case SHAREDtype =>
       val spn = span
       reader.readByte()
@@ -924,11 +922,11 @@ private[tasties] class TreeUnpickler(
       TypeRef(prefix, name)
     case TYPEREFdirect =>
       reader.readByte()
-      val sym = readSymRef
+      val sym = readSymRef.asType
       TypeRef(NoPrefix, sym)
     case TYPEREFsymbol =>
       reader.readByte()
-      val sym = readSymRef
+      val sym = readSymRef.asType
       TypeRef(readType, sym)
     case TYPEREFpkg =>
       reader.readByte()
@@ -939,11 +937,11 @@ private[tasties] class TreeUnpickler(
       recursiveTypeAtAddr.getOrElse(addr, sharedTypesCache.getOrElseUpdate(addr, forkAt(addr).readType))
     case TERMREFdirect =>
       reader.readByte()
-      val sym = readSymRef
+      val sym = readSymRef.asTerm
       TermRef(NoPrefix, sym)
     case TERMREFsymbol =>
       reader.readByte()
-      val sym = readSymRef
+      val sym = readSymRef.asTerm
       TermRef(readType, sym)
     case TERMREFpkg =>
       reader.readByte()


### PR DESCRIPTION
The designator is not a stable value. Only `name` and `symbol` should be accessed from the outside.

To hide the `designator`, we have to make `TermRef` and `TypeRef` non-case classes.

For testing purposes, we expose a `private[tastyquery]` access to the designator with a scary name.

These changes also allow to make `LookupIn` and `Scala2ExternalSymRef` `private[tastyquery]`, which furthers hide implementation details of the library.