### PR TITLE
Fix #125: Create the scala.ContextFunctionN special classes.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -65,6 +65,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     cls
 
   val AnyClass = createSpecialClass(typeName("Any"), Nil, Abstract)
+    .withSpecialErasure(() => ErasedTypeRef.ClassRef(ObjectClass))
 
   val NullClass = createSpecialClass(typeName("Null"), AnyClass.typeRef :: Nil, Abstract | Final)
 
@@ -123,9 +124,11 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   val ByNameParamClass2x: ClassSymbol =
     createSpecialPolyClass(tpnme.ByNameParamClassMagic, Covariant, _ => List(AnyType))
+      .withSpecialErasure(() => ErasedTypeRef.ClassRef(Function0Class))
 
   val RepeatedParamClass: ClassSymbol =
     createSpecialPolyClass(tpnme.RepeatedParamClassMagic, Covariant, tp => List(ObjectType, SeqTypeOf(tp)))
+      .withSpecialErasure(() => ErasedTypeRef.ClassRef(SeqClass))
 
   // Derived symbols, found on the classpath
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -286,6 +286,8 @@ object Symbols {
       with TypeParamInfo:
     private[tastyquery] def paramVariance(using Context): Variance =
       Variance.fromFlags(flags)
+
+    final def typeRef(using Context): TypeRef = TypeRef(ThisType(owner.typeRef), this)
   end ClassTypeParamSymbol
 
   object ClassTypeParamSymbol:

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -435,12 +435,13 @@ object Symbols {
     private var myTypeParams: List[(ClassTypeParamSymbol, TypeBounds)] | Null = null
     private var myParentsInit: (() => List[Type]) | Null = null
     private var myParents: List[Type] | Null = null
+    private var mySpecialErasure: Option[() => ErasedTypeRef] = None
 
     private[tastyquery] val classInfo: ClassInfo = ClassInfo(this: @unchecked)
 
     private[tastyquery] def isDerivedValueClass(using Context): Boolean =
       val isValueClass =
-        parents.head.classSymbol.exists(_ == defn.AnyValClass)
+        parents.nonEmpty && parents.head.classSymbol.exists(_ == defn.AnyValClass)
       isValueClass && !defn.isPrimitiveValueClass(this)
 
     /** Get the companion class of this class, if it exists:
@@ -506,6 +507,14 @@ object Symbols {
           parents
         else throw IllegalStateException(s"$this was not assigned parents")
     end parents
+
+    private[tastyquery] final def withSpecialErasure(specialErasure: () => ErasedTypeRef): this.type =
+      if mySpecialErasure.isDefined then throw IllegalStateException(s"reassignment of the special erasure of $this")
+      mySpecialErasure = Some(specialErasure)
+      this
+
+    private[tastyquery] final def specialErasure(using Context): Option[() => ErasedTypeRef] =
+      mySpecialErasure
 
     protected[this] final def ensureDeclsInitialized()(using Context): Unit =
       // ClassSymbols are always initialized when created

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -143,11 +143,9 @@ object Types {
 
       typeRef match
         case ClassRef(cls) =>
-          if cls == defn.AnyClass || cls == defn.AnyValClass then ClassRef(defn.ObjectClass)
-          else if cls == defn.RepeatedParamClass then ClassRef(defn.SeqClass)
-          else if cls == defn.ByNameParamClass2x then ClassRef(defn.Function0Class)
+          if cls == defn.AnyValClass then ClassRef(defn.ObjectClass)
           else if cls.isDerivedValueClass then valueClass(cls)
-          else typeRef
+          else cls.specialErasure.fold(typeRef)(f => f())
         case ArrayTypeRef(_, _) =>
           typeRef
     end finishErase

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -615,7 +615,7 @@ object Types {
                      |Perhaps the classpath is out of date.""".stripMargin
                 case _ =>
                   val possible = declaring.declarations.map(_.name.toDebugString).mkString("[", ", ", "]")
-                  s"not a member of $prefixSym, found possible members: $possible."
+                  s"$name is not a member of $prefixSym, found possible members: $possible."
               throw MemberNotFoundException(prefixSym, name, msg)
             }
           case _ =>

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -216,4 +216,10 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(getOffsetStatic.signedName, "getOffsetStatic", "(java.lang.reflect.Field):scala.Long")
   }
 
+  testWithContext("Scala 3 special function types") {
+    val SpecialFunctionTypes = resolve(name"simple_trees" / tname"SpecialFunctionTypes").asClass
+    val contextFunction = SpecialFunctionTypes.getDecl(name"contextFunction").get.asTerm
+    assertIsSignedName(contextFunction.signedName, "contextFunction", "(scala.Function1):scala.Unit")
+  }
+
 end SignatureSuite

--- a/test-sources/src/main/scala/simple_trees/SpecialFunctionTypes.scala
+++ b/test-sources/src/main/scala/simple_trees/SpecialFunctionTypes.scala
@@ -1,0 +1,5 @@
+package simple_trees
+
+class SpecialFunctionTypes:
+  def contextFunction(f: String ?=> Unit): Unit = f(using "Hello")
+end SpecialFunctionTypes


### PR DESCRIPTION
Currently, only for N up to 22.

For higher arities, as well as for higher arities of `FunctionN`s, we will need to create declarations on-demand in the `scala` package, so this will need something more in the future.