### PR TITLE
resolve _root_ package ref

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
@@ -126,7 +126,11 @@ object Contexts {
             rec(next, pathRest)
           case name :: pathRest =>
             throw MemberNotFoundException(owner, name, s"cannot find package member $name of $owner")
-      rec(RootPackage, fullyQualifiedName.path)
+      // strip initial `_root_` if present, which is how user signals qualified from root names.
+      val path0 = fullyQualifiedName.path match
+        case nme.RootPackageName :: path => path
+        case path                        => path
+      rec(RootPackage, path0)
     end findPackageFromRoot
 
     def findSymbolFromRoot(path: List[Name]): Symbol =

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -242,4 +242,10 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertIsSignedName(bar3.signedName, "bar3", "():scala.Int")
   }
 
+  testWithContext("case class copy method") {
+    val CaseClass = resolve(name"synthetics" / tname"CaseClass").asClass
+    val copy = CaseClass.getDecl(name"copy").get.asTerm
+    assertIsSignedName(copy.signedName, "copy", "(java.lang.String):synthetics.CaseClass")
+  }
+
 end SignatureSuite

--- a/test-sources/src/main/scala/synthetics/CaseClass.scala
+++ b/test-sources/src/main/scala/synthetics/CaseClass.scala
@@ -1,0 +1,3 @@
+package synthetics
+
+case class CaseClass(x: String)


### PR DESCRIPTION
in tasty, trees that point to the Root package are stored as `TERMREFpkg _root_`, so have a fully qualified name of `FullyQualifiedName(name"_root_" :: Nil)`. I adjust the method `findPackageFromRoot` to drop an initial `_root_`, so its optional to add it.

For context, the crash in #154 comes from reading the `_root_.scala.Product` parent of the case class, when determining if it is a value class in erasure

fixes #154 