### PR TITLE
strip _root_ from FQN in nameTable

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
@@ -126,11 +126,7 @@ object Contexts {
             rec(next, pathRest)
           case name :: pathRest =>
             throw MemberNotFoundException(owner, name, s"cannot find package member $name of $owner")
-      // strip initial `_root_` if present, which is how user signals qualified from root names.
-      val path0 = fullyQualifiedName.path match
-        case nme.RootPackageName :: path => path
-        case path                        => path
-      rec(RootPackage, path0)
+      rec(RootPackage, fullyQualifiedName.path)
     end findPackageFromRoot
 
     def findSymbolFromRoot(path: List[Name]): Symbol =

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -262,6 +262,10 @@ object Names {
     def mapLast(op: Name => Name): FullyQualifiedName =
       FullyQualifiedName(path.init :+ op(path.last))
 
+    private[tastyquery] def sourceName: Name = path match
+      case Nil  => nme.RootPackageName
+      case path => path.last
+
     def mapLastOption(op: Name => Name): FullyQualifiedName =
       if path.isEmpty then this
       else mapLast(op)

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -297,7 +297,7 @@ object Trees {
 
   /** reference to a package, seen as a term */
   final class ReferencedPackage(val fullyQualifiedName: FullyQualifiedName)(span: Span)
-      extends Ident(fullyQualifiedName.path.last.asSimpleName)(span) {
+      extends Ident(fullyQualifiedName.sourceName.asSimpleName)(span) {
     protected final def calculateType(using Context): Type =
       PackageRef(fullyQualifiedName)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
@@ -49,7 +49,13 @@ private[reader] object TastyUnpickler {
     def fullyQualified(ref: NameRef): FullyQualifiedName =
       apply(ref) match
         case name: FullyQualifiedName =>
-          name
+          name.path match
+            case nme.RootPackageName :: Nil =>
+              FullyQualifiedName.rootPackageName
+            case _ =>
+              name
+        case nme.RootPackageName =>
+          FullyQualifiedName.rootPackageName
         case name: TermName =>
           FullyQualifiedName(name :: Nil)
   }


### PR DESCRIPTION
I think this one is more clean - i.e. by not adding new behaviour to `findPackageFromRoot`