### PR TITLE
Check that all symbols are fully initialized

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -336,7 +336,12 @@ object Symbols {
   end LocalTypeParamSymbol
 
   final class TypeMemberSymbol private (name: TypeName, owner: Symbol) extends TypeSymbolWithBounds(name, owner):
+    // Reference fields (checked in doCheckCompleted)
     private var myDefinition: TypeMemberDefinition | Null = null
+
+    protected[this] override def doCheckCompleted(): Unit =
+      super.doCheckCompleted()
+      if myDefinition == null then failNotCompleted("type member definition not initialized")
 
     private[tastyquery] final def withDefinition(definition: TypeMemberDefinition): this.type =
       if myDefinition != null then throw IllegalStateException(s"Reassignment of the definition of $this")

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -213,9 +213,16 @@ object Symbols {
   final class TermSymbol private (val name: TermName, override val owner: Symbol) extends Symbol(owner):
     type ThisNameType = TermName
 
+    // Reference fields (checked in doCheckCompleted)
     private var myDeclaredType: Type | Null = null
+
+    // Cache fields
     private var mySignature: Option[Signature] | Null = null
     private var myParamRefss: List[Either[List[TermParamRef], List[TypeParamRef]]] | Null = null
+
+    protected[this] override def doCheckCompleted(): Unit =
+      super.doCheckCompleted()
+      if myDeclaredType == null then failNotCompleted("declaredType was not initialized")
 
     private[tastyquery] final def withDeclaredType(tpe: Type): this.type =
       if myDeclaredType != null then throw new IllegalStateException(s"reassignment of declared type to $this")

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -294,7 +294,12 @@ object Symbols {
 
   sealed abstract class TypeParamSymbol protected (name: TypeName, owner: Symbol)
       extends TypeSymbolWithBounds(name, owner):
+    // Reference fields (checked in doCheckCompleted)
     private var myBounds: TypeBounds | Null = null
+
+    protected[this] override def doCheckCompleted(): Unit =
+      super.doCheckCompleted()
+      if myBounds == null then failNotCompleted("bounds are not initialized")
 
     private[tastyquery] final def setBounds(bounds: TypeBounds): this.type =
       if myBounds != null then throw IllegalStateException(s"Trying to re-set the bounds of $this")

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
@@ -57,12 +57,12 @@ private[tastyquery] object Loaders {
     private def completeRoots(root: Loader.Root, entry: Entry)(using Context): Boolean =
 
       def inspectClass(root: Loader.Root, classData: ClassData, entry: Entry): Boolean =
-        ClassfileParser.readKind(classData).toTry.get match
+        ClassfileParser.readKind(classData) match
           case ClassKind.Scala2(structure, runtimeAnnotStart) =>
-            ClassfileParser.loadScala2Class(structure, runtimeAnnotStart).toTry.get
+            ClassfileParser.loadScala2Class(structure, runtimeAnnotStart)
             Contexts.initialisedRoot(root)
           case ClassKind.Java(structure, sig) =>
-            ClassfileParser.loadJavaClass(root.pkg, root.rootName, structure, sig).toTry.get
+            ClassfileParser.loadJavaClass(root.pkg, root.rootName, structure, sig)
             Contexts.initialisedRoot(root)
           case ClassKind.TASTy =>
             entry match

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
@@ -482,10 +482,6 @@ private[classfiles] object ClassfileReader {
       forked
   }
 
-  def read[T](op: => T): Either[ClassfileFormatException, T] =
-    try Right(op)
-    catch { case e: ClassfileFormatException => Left(e) }
-
   def unpickle[T](classRoot: ClassData)(op: ClassfileReader => DataStream ?=> T): T =
     ClassfileBuffer.Root(classRoot.bytes, 0).use { s ?=>
       op(ClassfileReader())

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -3,6 +3,7 @@ package tastyquery.reader.classfiles
 import scala.annotation.switch
 
 import scala.collection.mutable
+import scala.collection.mutable.Growable
 
 import tastyquery.Contexts.*
 import tastyquery.Exceptions.*
@@ -16,7 +17,9 @@ private[classfiles] object JavaSignatures:
   private type JavaSignature = Null | Binders | Map[TypeName, ClassTypeParamSymbol] | mutable.ListBuffer[TypeName]
 
   @throws[ClassfileFormatException]
-  def parseSignature(member: Symbol { val owner: Symbol }, signature: String)(using Context): Type =
+  def parseSignature(member: Symbol { val owner: Symbol }, signature: String, allRegisteredSymbols: Growable[Symbol])(
+    using Context
+  ): Type =
     var offset = 0
     var end = signature.length
     val isClass = member.isClass
@@ -255,7 +258,12 @@ private[classfiles] object JavaSignatures:
         interfaces(env, mutable.ListBuffer(superTpe))
       if consume('<') then
         val tparamNames = lookaheadTypeParamNames
-        val tparams = tparamNames.map(tname => ClassTypeParamSymbol.create(tname, cls))
+        val tparams = tparamNames.map { tname =>
+          val paramSym = ClassTypeParamSymbol.create(tname, cls)
+          allRegisteredSymbols += paramSym
+          paramSym.withFlags(ClassTypeParam)
+          paramSym
+        }
         val lookup = tparamNames.lazyZip(tparams).toMap
         cls.withTypeParams(tparams, typeParamsRest(lookup))
         classRest(lookup)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -265,7 +265,9 @@ private[classfiles] object JavaSignatures:
           paramSym
         }
         val lookup = tparamNames.lazyZip(tparams).toMap
-        cls.withTypeParams(tparams, typeParamsRest(lookup))
+        val tparamBounds = typeParamsRest(lookup)
+        tparams.lazyZip(tparamBounds).foreach((tparam, bounds) => tparam.setBounds(bounds))
+        cls.withTypeParams(tparams, tparamBounds)
         classRest(lookup)
       else
         cls.withTypeParams(Nil, Nil)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -227,7 +227,8 @@ private[pickles] class PickleReader {
           module.foreach(m => m.asTerm.withDeclaredType(cls.typeRef))
         val tpe = readSymType()
         val typeParams = atNoCache(infoRef)(readTypeParams())
-        if !isRefinementClass(cls) then
+        if isRefinementClass(cls) then cls.withParentsDirect(defn.ObjectType :: Nil)
+        else
           val parentTypes = tpe match
             case TempPolyType(tparams, restpe: TempClassInfoType) =>
               assert(tparams.corresponds(typeParams)(_ eq _)) // should reuse the class type params

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -20,7 +20,12 @@ private[pickles] class PickleReader {
   opaque type Entries = Array[AnyRef | Null]
   opaque type Index = IArray[Int]
 
-  class Structure(using val myEntries: Entries, val myIndex: Index)
+  final class Structure(using val myEntries: Entries, val myIndex: Index):
+    def allRegisteredSymbols: Iterator[Symbol] =
+      myEntries.iterator.collect { case sym: Symbol =>
+        sym
+      }
+  end Structure
 
   extension (i: Index)
     inline def loopWithIndices(inline op: (Int, Int) => Unit): Unit = {
@@ -245,6 +250,7 @@ private[pickles] class PickleReader {
           .asInstanceOf[DeclaringSymbol]
           .getModuleDeclInternal(name.toTermName.withObjectSuffix.toTypeName)
         val sym = TermSymbol.create(name.toTermName, owner)
+        storeResultInEntries(sym)
         moduleClass.foreach(cls => sym.withDeclaredType(cls.asClass.typeRef))
         sym
       case _ =>

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -7,7 +7,7 @@ import tastyquery.Exceptions.*
 import tastyquery.Symbols.Symbol
 
 private[reader] object Unpickler {
-  def loadInfo(sigBytes: IArray[Byte])(using Context): Either[Scala2PickleFormatException, Unit] = {
+  def loadInfo(sigBytes: IArray[Byte])(using Context): Unit = {
 
     def run(reader: PickleReader, structure: reader.Structure)(using PklStream): Unit = {
       import structure.given
@@ -40,8 +40,7 @@ private[reader] object Unpickler {
 
     PklStream.read(sigBytes) {
       val reader = PickleReader()
-      try Right(run(reader, reader.readStructure()))
-      catch case e: Scala2PickleFormatException => Left(e)
+      run(reader, reader.readStructure())
     }
   }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -36,6 +36,9 @@ private[reader] object Unpickler {
           // }
         }
       }
+
+      // Check that all the Symbols we created have been completed
+      for sym <- structure.allRegisteredSymbols do sym.checkCompleted()
     }
 
     PklStream.read(sigBytes) {

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -759,11 +759,11 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val end = reader.readEnd()
       val name = readName
-      // TODO: use type
       val typ = readType
       val term = readTerm
       skipModifiers(end)
       val symbol = localCtx.getSymbol[TermSymbol](start)
+      symbol.withDeclaredType(typ)
       Bind(name, term, symbol)(spn).definesTreeOf(symbol)
     case ALTERNATIVE =>
       reader.readByte()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -1148,8 +1148,7 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val end = reader.readEnd()
       val name = readName.toTypeName
-      // TODO: use type bounds
-      val typ = readTypeBounds
+      val bounds = readTypeBounds
       /* This is a workaround: consider a BIND inside a MATCHtpt
        * example: case List[t] => t
        * Such a bind has IDENT(_) as its body, which is not a type tree and therefore not expected.
@@ -1163,6 +1162,7 @@ private[tasties] class TreeUnpickler(
       } else readTypeTree
       skipModifiers(end)
       val sym = localCtx.getSymbol[LocalTypeParamSymbol](start)
+      sym.setBounds(bounds)
       TypeTreeBind(name, body, sym)(spn).definesTreeOf(sym)
     // Type tree for a type member (abstract or bounded opaque)
     case TYPEBOUNDStpt => readBoundedTypeTree


### PR DESCRIPTION
We introduce a generic method `Symbol.checkCompleted()`, which checks that all fields of a `Symbol` have been properly initialized.

We call that method at the end of reading a file, for all the symbols that were created while reading that file. This makes sure that by the time a `Symbol` gets in the hand of a user, it has been completely initialized.