### PR TITLE
Remove `ClassInfo`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
@@ -39,7 +39,7 @@ private[tastyquery] object Substituters:
     end apply
   end SubstBindingMap
 
-  private final class SubstParamsMap(from: Binders, to: List[Type])(using Context) extends DeepTypeMap:
+  private final class SubstParamsMap(from: Binders, to: List[Type])(using Context) extends NormalizingTypeMap:
     def apply(tp: Type): Type =
       tp match
         case tp: ParamRef =>
@@ -57,7 +57,7 @@ private[tastyquery] object Substituters:
   end SubstParamsMap
 
   private final class SubstClassTypeParamsMap(from: List[ClassTypeParamSymbol], to: List[Type])(using Context)
-      extends DeepTypeMap:
+      extends NormalizingTypeMap:
     def apply(tp: Type): Type =
       tp match
         case tp: NamedType =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -416,7 +416,6 @@ object Symbols {
       mutable.HashMap[Name, mutable.HashSet[Symbol]]()
 
     // Cache fields
-    private[tastyquery] val classInfo: ClassInfo = ClassInfo(this: @unchecked)
     private var myLinearization: List[ClassSymbol] | Null = null
 
     protected override def doCheckCompleted(): Unit =

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -56,8 +56,6 @@ private[tastyquery] object TypeMaps {
       tp.derivedOrType(tp1, tp2)
     protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Tree): Type =
       tp.derivedAnnotatedType(underlying, annot)
-    protected def derivedClassInfo(tp: ClassInfo, pre: Type): Type =
-      tp.derivedClassInfo(pre)
     protected def derivedExprType(tp: ExprType, restpe: Type): Type =
       tp.derivedExprType(restpe)
     protected def derivedLambdaType(tp: LambdaType, formals: List[tp.PInfo], restpe: Type): Type =
@@ -112,9 +110,6 @@ private[tastyquery] object TypeMaps {
         case tp: RefinedType =>
           derivedRefinedType(tp, this(tp.parent), this(tp.refinedInfo))
 
-        case tp: ClassInfo =>
-          mapClassInfo(tp)
-
         case tp: AndType =>
           derivedAndType(tp, this(tp.first), this(tp.second))
 
@@ -139,11 +134,6 @@ private[tastyquery] object TypeMaps {
     end mapOver
 
     //def mapOver(syms: List[Symbol]): List[Symbol] = mapSymbols(syms, treeTypeMap)
-
-    /** Can be overridden. By default, only the prefix is mapped. */
-    protected def mapClassInfo(tp: ClassInfo): Type =
-      // TODO Should we even have prefixes in our ClassInfo?
-      tp
 
     def andThen(f: Type => Type): TypeMap = new TypeMap {
       def apply(tp: Type): Type = f(thisMap(tp))
@@ -448,9 +438,6 @@ private[tastyquery] object TypeMaps {
 
     protected def reapply(tp: Type): Type = apply(tp)
   }
-
-  /** A type map that maps also parents and self type of a ClassInfo */
-  abstract class DeepTypeMap(using Context) extends NormalizingTypeMap
 
   /** A range of possible types between lower bound `lo` and upper bound `hi`.
     * Only used internally in `ApproximatingTypeMap`.


### PR DESCRIPTION
All the code paths involving `ClassInfo` were dead code. Now that we have a significant portion of subtyping, I am confident that its need will not resurface later.

This introduces an `AssertionError` path in `TypeRef.underlying`, which is not nice, but it also removes some `???` code paths in other places.

It would be worth investigating whether we could make `TypeRef` not a `TypeProxy`, but a cursory attempt met other issues.