### PR TITLE
support java 45.3, multiple throws on method

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
@@ -60,7 +60,7 @@ private[tastyquery] object Loaders {
       */
     private def completeRoot(root: Loader.Root, entry: Entry)(using Context): Unit =
       def inspectClass(root: Loader.Root, classData: ClassData, entry: Entry): Unit =
-        ClassfileParser.readKind(classData) match
+        ClassfileParser.readKind(root.pkg, classData) match
           case ClassKind.Scala2(structure, runtimeAnnotStart) =>
             ClassfileParser.loadScala2Class(structure, runtimeAnnotStart)
           case ClassKind.Java(structure, sig) =>

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -192,16 +192,16 @@ private[reader] object ClassfileParser {
     )
   }
 
-  private def toplevel(classRoot: ClassData)(using Context): Structure = {
+  private def toplevel(classOwner: DeclaringSymbol, classRoot: ClassData)(using Context): Structure = {
     def headerAndStructure(reader: ClassfileReader)(using DataStream) = {
-      reader.acceptHeader()
+      reader.acceptHeader(classOwner, classRoot)
       structure(reader)(using reader.readConstantPool())
     }
 
     ClassfileReader.unpickle(classRoot)(headerAndStructure)
   }
 
-  def readKind(classRoot: ClassData)(using Context): ClassKind =
-    parse(classRoot, toplevel(classRoot))
+  def readKind(classOwner: DeclaringSymbol, classRoot: ClassData)(using Context): ClassKind =
+    parse(classRoot, toplevel(classOwner, classRoot))
 
 }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -247,8 +247,7 @@ private[classfiles] object JavaSignatures:
         if consume('(') then // must have '(', ')', and return type
           val params = termParamsRest(env)
           val ret = result(env)
-          if consume('^') then
-            val _ = throwsSignatureRest(env) // ignored
+          val _ = readWhile('^', throwsSignatureRest(env)) // ignore throws clauses
           MethodType((0 until params.size).map(i => termName(s"x$$$i")).toList, params, ret)
         else abort
       if consume('<') then
@@ -293,7 +292,7 @@ private[classfiles] object JavaSignatures:
 
     def unconsumed: Nothing =
       throw ClassfileFormatException(
-        s"Expected end of descriptor but found $"${signature.slice(offset, end)}$", [is method? $isMethod]"
+        s"Expected end of descriptor but found $"${signature.slice(offset, end)}$", original: `$signature` [is method? $isMethod]"
       )
 
     def abort: Nothing =

--- a/test-sources/src/main/scala/javadefined/BagOfGenJavaDefinitions.java
+++ b/test-sources/src/main/scala/javadefined/BagOfGenJavaDefinitions.java
@@ -21,8 +21,8 @@ public class BagOfGenJavaDefinitions {
     return new GenericJavaClass[] { x };
   }
 
-  public <X extends Exception> void printX(X x) throws X {
-    // <X:Ljava/lang/Exception;>(TX;)V^TX;
+  public <X extends Exception, Y extends Exception> void printX(X x) throws X, Y {
+    // <X:Ljava/lang/Exception;Y:Ljava/lang/Exception;>(TX;)V^TX;^TY;
     throw x;
   }
 


### PR DESCRIPTION
I ran a test case that forced all root symbols in the `jre/lib` jars - this exposed that multiple throws clauses are not supported, and also some classes shipped in rt.jar are compiled by java 1.1 (i.e. have classfile version 45.3)