### PR TITLE
Fix #187: getDecl considers no-signature as an identifying feature.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -111,6 +111,10 @@ object Names {
   def termName(s: String): SimpleName =
     NameCache.cache(SimpleName(s))
 
+  /** Creates a type name for a module class from a string. */
+  def moduleClassName(s: String): TypeName =
+    termName(s).withObjectSuffix.toTypeName
+
   sealed abstract class Name derives CanEqual {
 
     /** This name converted to a type name */

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -182,6 +182,11 @@ object Names {
     override def toString: String = s"$underlying[with sig $sig @$target]"
   }
 
+  object SignedName:
+    def apply(underlying: TermName, sig: Signature): SignedName =
+      SignedName(underlying, sig, underlying)
+  end SignedName
+
   final case class ExpandedName(override val tag: Int, prefix: TermName, name: SimpleName) extends DerivedName(prefix) {
     def separator: String = tag match {
       case NameTags.EXPANDED     => "$$"

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -103,7 +103,7 @@ private[tastyquery] object Subtyping:
     case tp1: ThisType =>
       val cls1 = tp1.cls
       tp2 match {
-        case tp2: TermRef if cls1.is(Module) && cls1.eq(tp2.typeSymbol) =>
+        case tp2: TermRef if cls1.is(Module) && tp2.symbol.declaredType.isRef(cls1) =>
           (cls1.isStatic || isSubprefix(cls1.typeRef.prefix, tp2.prefix))
             || level3(tp1, tp2)
         case _ =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -641,6 +641,33 @@ object Symbols {
         case None => None
     end distinguishOverloaded
 
+    final def getDecl(name: TypeName)(using Context): Option[TypeSymbol] =
+      myDeclarations.get(name) match
+        case Some(decls) =>
+          assert(decls.sizeIs == 1, decls)
+          Some(decls.head.asType)
+        case None =>
+          None
+    end getDecl
+
+    final def getDecl(name: TermName)(using Context): Option[TermSymbol] =
+      getDecl(name: Name).map(_.asTerm)
+
+    final def findDecl(name: Name)(using Context): TermOrTypeSymbol =
+      getDecl(name).getOrElse {
+        throw MemberNotFoundException(this, name)
+      }
+
+    final def findDecl(name: TypeName)(using Context): TypeSymbol =
+      getDecl(name).getOrElse {
+        throw MemberNotFoundException(this, name)
+      }
+
+    final def findDecl(name: TermName)(using Context): TermSymbol =
+      getDecl(name).getOrElse {
+        throw MemberNotFoundException(this, name)
+      }
+
     final def declarations(using Context): List[TermOrTypeSymbol] =
       myDeclarations.values.toList.flatten
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -708,11 +708,13 @@ object Symbols {
           end match
 
         case tp: AppliedType =>
-          if tp.tycon.typeSymbol == this then tp
-          else
-            // TODO Also handle TypeLambdas
-            val typeParams = tp.tycon.typeParams
-            recur(tp.tycon).substClassTypeParams(typeParams.asInstanceOf[List[ClassTypeParamSymbol]], tp.args)
+          tp.tycon match
+            case tycon: TypeRef if tycon.symbol == this =>
+              tp
+            case tycon =>
+              // TODO Also handle TypeLambdas
+              val typeParams = tycon.typeParams
+              recur(tycon).substClassTypeParams(typeParams.asInstanceOf[List[ClassTypeParamSymbol]], tp.args)
 
         case tp: TypeProxy =>
           recur(tp.superType)

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -203,8 +203,9 @@ object Types {
             case cls: ClassSymbol              => cls.typeParams
             case typeSym: TypeSymbolWithBounds => typeSym.upperBound.typeParams
         case self: AppliedType =>
-          if (self.tycon.typeSymbol.isClass) Nil
-          else self.superType.typeParams
+          self.tycon match
+            case tycon: TypeRef if tycon.symbol.isClass => Nil
+            case _                                      => self.superType.typeParams
         case _: SingletonType | _: RefinedType =>
           Nil
         case self: WildcardTypeBounds =>
@@ -260,14 +261,6 @@ object Types {
       using Context
     ): Type =
       Substituters.substClassTypeParams(this, from, to)
-
-    private[tastyquery] final def typeSymbol(using Context): Symbol = this match
-      case tpe: TypeRef => tpe.symbol
-      case _            => NoSymbol
-
-    private[tastyquery] final def termSymbol(using Context): Symbol = this match
-      case tpe: TermRef => tpe.symbol
-      case _            => NoSymbol
 
     private[tastyquery] final def widenOverloads(using Context): Type =
       this.widen match

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -136,7 +136,7 @@ object Types {
 
     private def finishErase(typeRef: ErasedTypeRef)(using Context): ErasedTypeRef =
       def valueClass(cls: ClassSymbol): ErasedTypeRef =
-        val ctor = cls.getDecl(nme.Constructor).get.asTerm
+        val ctor = cls.findNonOverloadedDecl(nme.Constructor)
         val List(Left(List(paramRef))) = ctor.paramRefss.dropWhile(_.isRight): @unchecked
         val paramType = paramRef.underlying
         erase(paramType)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -292,7 +292,12 @@ private[tasties] class TreeUnpickler(
     (flags, privateWithin)
   end readModifiers
 
-  private def readWithin(using LocalContext): Symbol = readType.typeSymbol
+  private def readWithin(using LocalContext): Symbol =
+    readType match
+      case typeRef: TypeRef   => typeRef.symbol
+      case pkgRef: PackageRef => pkgRef.symbol
+      case tpe                => throw TastyFormatException(s"unexpected type for readWithin: $tpe")
+  end readWithin
 
   /** Performs the read action as if SHARED tags were transparent:
     *  - follows the SHARED tags to the term or type that is shared

--- a/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
@@ -15,21 +15,19 @@ class ClasspathEntrySuite extends UnrestrictedUnpicklingSuite:
     IArray.from(ctx.findSymbolsByClasspathEntry(entry))
 
   testWithContext("scala-library-by-entry") {
-
-    val MirrorClass = resolve(name"scala" / name"deriving" / tname"Mirror")
-    val JavaLangString = resolve(name"java" / name"lang" / tname"String")
+    val MirrorClass = ctx.findTopLevelClass("scala.deriving.Mirror")
 
     val syms = lookupSyms(scala3ClasspathEntry)
 
     assert(syms.size < 300, s"scala 3 library has unexpected root symbols, found ${syms.size}")
 
     assert(syms.exists(_ == MirrorClass))
-    assert(!syms.exists(_ == JavaLangString))
+    assert(!syms.exists(_ == defn.StringClass))
 
   }
 
   testWithContext("lookup-by-entry-single") {
-    val MirrorClass = resolve(name"scala" / name"deriving" / tname"Mirror")
+    val MirrorClass = ctx.findTopLevelClass("scala.deriving.Mirror")
 
     val syms = lookupSyms(scala3ClasspathEntry)
 
@@ -39,7 +37,7 @@ class ClasspathEntrySuite extends UnrestrictedUnpicklingSuite:
   testWithContext("lookup-by-entry-reentrant") {
     // WHITEBOX: test performance impact of reentrant lookup
 
-    val MirrorClass = resolve(name"scala" / name"deriving" / tname"Mirror")
+    val MirrorClass = ctx.findTopLevelClass("scala.deriving.Mirror")
 
     def lookupMirror() =
       val syms = lookupSyms(scala3ClasspathEntry)

--- a/tasty-query/shared/src/test/scala/tastyquery/Paths.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/Paths.scala
@@ -18,9 +18,6 @@ object Paths:
   opaque type TopLevelClassDeclPath <: TopLevelDeclPath = List[Name] // top level classes
   opaque type MemberDeclPath <: DeclarationPath = List[Name] // local classes / values
 
-  def resolve(path: DeclarationPath)(using Context): Symbol =
-    summon[Context].findSymbolFromRoot(path.toNameList)
-
   extension (sc: StringContext)
     def name(args: Any*): SimpleName =
       SimpleName(sc.parts.mkString)

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -145,7 +145,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     test(testOptions) {
       for ctx <- getUnpicklingContext(path) yield
         given Context = ctx
-        val cls = resolve(path)
+        val cls = ctx.findSymbolFromRoot(path.toNameList)
         val tree = cls.tree.getOrElse {
           fail(s"Missing tasty for ${path.rootClassName}, $cls")
         }

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -28,54 +28,54 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("java.lang.String") {
     val StringClass = defn.StringClass
 
-    val charAt = StringClass.getDecl(name"charAt").get.asTerm
+    val charAt = StringClass.findNonOverloadedDecl(name"charAt")
     assertIsSignedName(charAt.signedName, "charAt", "(scala.Int):scala.Char")
 
-    val contains = StringClass.getDecl(name"contains").get.asTerm
+    val contains = StringClass.findNonOverloadedDecl(name"contains")
     assertIsSignedName(contains.signedName, "contains", "(java.lang.CharSequence):scala.Boolean")
 
-    val length = StringClass.getDecl(name"length").get.asTerm
+    val length = StringClass.findNonOverloadedDecl(name"length")
     assertIsSignedName(length.signedName, "length", "():scala.Int")
   }
 
   testWithContext("GenericClass") {
     val GenericClass = ctx.findTopLevelClass("simple_trees.GenericClass")
 
-    val field = GenericClass.getDecl(name"field").get.asTerm
+    val field = GenericClass.findDecl(name"field")
     assertNotSignedName(field.signedName)
 
-    val getter = GenericClass.getDecl(name"getter").get.asTerm
+    val getter = GenericClass.findDecl(name"getter")
     assertIsSignedName(getter.signedName, "getter", "():java.lang.Object")
 
-    val method = GenericClass.getDecl(name"method").get.asTerm
+    val method = GenericClass.findNonOverloadedDecl(name"method")
     assertIsSignedName(method.signedName, "method", "(java.lang.Object):java.lang.Object")
   }
 
   testWithContext("GenericMethod") {
     val GenericMethod = ctx.findTopLevelClass("simple_trees.GenericMethod")
 
-    val identity = GenericMethod.getDecl(name"identity").get.asTerm
+    val identity = GenericMethod.findNonOverloadedDecl(name"identity")
     assertIsSignedName(identity.signedName, "identity", "(1,java.lang.Object):java.lang.Object")
   }
 
   testWithContext("RichInt") {
     val RichInt = ctx.findTopLevelClass("scala.runtime.RichInt")
 
-    val toHexString = RichInt.getDecl(name"toHexString").get.asTerm
+    val toHexString = RichInt.findDecl(name"toHexString")
     assertIsSignedName(toHexString.signedName, "toHexString", "():java.lang.String")
   }
 
   testWithContext("Product") {
     val Product = ctx.findTopLevelClass("scala.Product")
 
-    val productIterator = Product.getDecl(name"productIterator").get.asTerm
+    val productIterator = Product.findDecl(name"productIterator")
     assertIsSignedName(productIterator.signedName, "productIterator", "():scala.collection.Iterator")
   }
 
   testWithContext("with type") {
     val RefinedTypeTree = ctx.findTopLevelClass("simple_trees.RefinedTypeTree")
 
-    val andType = RefinedTypeTree.getDecl(name"andType").get.asTerm
+    val andType = RefinedTypeTree.findNonOverloadedDecl(name"andType")
     intercept[UnsupportedOperationException](andType.signedName)
   }
 
@@ -84,36 +84,36 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
 
     // TODO The erasure is not actually correct here, but at least we don't crash
 
-    val withArray = TypeRefIn.getDecl(name"withArray").get.asTerm
+    val withArray = TypeRefIn.findNonOverloadedDecl(name"withArray")
     assertIsSignedName(withArray.signedName, "withArray", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayOfSubtype = TypeRefIn.getDecl(name"withArrayOfSubtype").get.asTerm
+    val withArrayOfSubtype = TypeRefIn.findNonOverloadedDecl(name"withArrayOfSubtype")
     assertIsSignedName(withArrayOfSubtype.signedName, "withArrayOfSubtype", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayAnyRef = TypeRefIn.getDecl(name"withArrayAnyRef").get.asTerm
+    val withArrayAnyRef = TypeRefIn.findNonOverloadedDecl(name"withArrayAnyRef")
     assertIsSignedName(withArrayAnyRef.signedName, "withArrayAnyRef", "(1,java.lang.Object[]):scala.Unit")
 
-    val withArrayOfSubtypeAnyRef = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyRef").get.asTerm
+    val withArrayOfSubtypeAnyRef = TypeRefIn.findNonOverloadedDecl(name"withArrayOfSubtypeAnyRef")
     assertIsSignedName(
       withArrayOfSubtypeAnyRef.signedName,
       "withArrayOfSubtypeAnyRef",
       "(1,java.lang.Object[]):scala.Unit"
     )
 
-    val withArrayAnyVal = TypeRefIn.getDecl(name"withArrayAnyVal").get.asTerm
+    val withArrayAnyVal = TypeRefIn.findNonOverloadedDecl(name"withArrayAnyVal")
     assertIsSignedName(withArrayAnyVal.signedName, "withArrayAnyVal", "(1,java.lang.Object):scala.Unit")
 
-    val withArrayOfSubtypeAnyVal = TypeRefIn.getDecl(name"withArrayOfSubtypeAnyVal").get.asTerm
+    val withArrayOfSubtypeAnyVal = TypeRefIn.findNonOverloadedDecl(name"withArrayOfSubtypeAnyVal")
     assertIsSignedName(
       withArrayOfSubtypeAnyVal.signedName,
       "withArrayOfSubtypeAnyVal",
       "(1,java.lang.Object):scala.Unit"
     )
 
-    val withArrayList = TypeRefIn.getDecl(name"withArrayList").get.asTerm
+    val withArrayList = TypeRefIn.findNonOverloadedDecl(name"withArrayList")
     assertIsSignedName(withArrayList.signedName, "withArrayList", "(1,scala.collection.immutable.List[]):scala.Unit")
 
-    val withArrayOfSubtypeList = TypeRefIn.getDecl(name"withArrayOfSubtypeList").get.asTerm
+    val withArrayOfSubtypeList = TypeRefIn.findNonOverloadedDecl(name"withArrayOfSubtypeList")
     assertIsSignedName(
       withArrayOfSubtypeList.signedName,
       "withArrayOfSubtypeList",
@@ -124,127 +124,127 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("type-member") {
     val TypeMember = ctx.findTopLevelClass("simple_trees.TypeMember")
 
-    val mTypeAlias = TypeMember.getDecl(name"mTypeAlias").get.asTerm
+    val mTypeAlias = TypeMember.findNonOverloadedDecl(name"mTypeAlias")
     assertIsSignedName(mTypeAlias.signedName, "mTypeAlias", "(scala.Int):scala.Int")
 
-    val mAbstractType = TypeMember.getDecl(name"mAbstractType").get.asTerm
+    val mAbstractType = TypeMember.findNonOverloadedDecl(name"mAbstractType")
     assertIsSignedName(mAbstractType.signedName, "mAbstractType", "(java.lang.Object):java.lang.Object")
 
-    val mAbstractTypeWithBounds = TypeMember.getDecl(name"mAbstractTypeWithBounds").get.asTerm
+    val mAbstractTypeWithBounds = TypeMember.findNonOverloadedDecl(name"mAbstractTypeWithBounds")
     assertIsSignedName(mAbstractTypeWithBounds.signedName, "mAbstractTypeWithBounds", "(scala.Product):scala.Product")
 
-    val mOpaque = TypeMember.getDecl(name"mOpaque").get.asTerm
+    val mOpaque = TypeMember.findNonOverloadedDecl(name"mOpaque")
     assertIsSignedName(mOpaque.signedName, "mOpaque", "(scala.Int):scala.Int")
 
-    val mOpaqueWithBounds = TypeMember.getDecl(name"mOpaqueWithBounds").get.asTerm
+    val mOpaqueWithBounds = TypeMember.findNonOverloadedDecl(name"mOpaqueWithBounds")
     assertIsSignedName(mOpaqueWithBounds.signedName, "mOpaqueWithBounds", "(scala.Null):scala.Null")
   }
 
   testWithContext("scala2-case-class-varargs") {
     val StringContext = ctx.findTopLevelClass("scala.StringContext")
 
-    val parts = StringContext.getDecl(name"parts").get.asTerm
+    val parts = StringContext.findDecl(name"parts")
     assertIsSignedName(parts.signedName, "parts", "():scala.collection.immutable.Seq")
   }
 
   testWithContext("scala2-method-byname") {
     val StringContext = ctx.findTopLevelClass("scala.Option")
 
-    val getOrElse = StringContext.getDecl(name"getOrElse").get.asTerm
+    val getOrElse = StringContext.findNonOverloadedDecl(name"getOrElse")
     assertIsSignedName(getOrElse.signedName, "getOrElse", "(1,scala.Function0):java.lang.Object")
   }
 
   testWithContext("scala2-existential-type") {
     val ClassTag = ctx.findTopLevelModuleClass("scala.reflect.ClassTag")
 
-    val apply = ClassTag.getDecl(name"apply").get.asTerm
+    val apply = ClassTag.findNonOverloadedDecl(name"apply")
     assertIsSignedName(apply.signedName, "apply", "(1,java.lang.Class):scala.reflect.ClassTag")
   }
 
   testWithContext("iarray") {
     val IArraySig = ctx.findTopLevelClass("simple_trees.IArraySig")
 
-    val from = IArraySig.getDecl(name"from").get.asTerm
+    val from = IArraySig.findNonOverloadedDecl(name"from")
     assertIsSignedName(from.signedName, "from", "():java.lang.String[]")
   }
 
   testWithContext("value-class-arrayOps-generic") {
     val MyArrayOps = ctx.findTopLevelModuleClass("inheritance.MyArrayOps")
-    val genericArrayOps = MyArrayOps.getDecl(name"genericArrayOps").get.asTerm
+    val genericArrayOps = MyArrayOps.findNonOverloadedDecl(name"genericArrayOps")
     assertIsSignedName(genericArrayOps.signedName, "genericArrayOps", "(1,java.lang.Object):java.lang.Object")
   }
 
   testWithContext("value-class-arrayOps-int") {
     val MyArrayOps = ctx.findTopLevelModuleClass("inheritance.MyArrayOps")
-    val intArrayOps = MyArrayOps.getDecl(name"intArrayOps").get.asTerm
+    val intArrayOps = MyArrayOps.findNonOverloadedDecl(name"intArrayOps")
     assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):java.lang.Object")
   }
 
   testWithContext("scala2-value-class-arrayOps-generic") {
     val Predef = ctx.findTopLevelModuleClass("scala.Predef")
-    val genericArrayOps = Predef.getDecl(name"genericArrayOps").get.asTerm
+    val genericArrayOps = Predef.findNonOverloadedDecl(name"genericArrayOps")
     assertIsSignedName(genericArrayOps.signedName, "genericArrayOps", "(1,java.lang.Object):java.lang.Object")
   }
 
   testWithContext("scala2-value-class-arrayOps-int") {
     val Predef = ctx.findTopLevelModuleClass("scala.Predef")
-    val intArrayOps = Predef.getDecl(name"intArrayOps").get.asTerm
+    val intArrayOps = Predef.findNonOverloadedDecl(name"intArrayOps")
     assertIsSignedName(intArrayOps.signedName, "intArrayOps", "(scala.Int[]):java.lang.Object")
   }
 
   testWithContext("value-class-monomorphic") {
     val MyFlags = ctx.findTopLevelClass("inheritance.MyFlags")
-    val merge = MyFlags.getDecl(name"merge").get.asTerm
+    val merge = MyFlags.findNonOverloadedDecl(name"merge")
     assertIsSignedName(merge.signedName, "merge", "(scala.Long):scala.Long")
   }
 
   testWithContext("value-class-monomorphic-arrayOf") {
     val MyFlags = ctx.findTopLevelModuleClass("inheritance.MyFlags")
-    val mergeAll = MyFlags.getDecl(name"mergeAll").get.asTerm
+    val mergeAll = MyFlags.findNonOverloadedDecl(name"mergeAll")
     assertIsSignedName(mergeAll.signedName, "mergeAll", "(inheritance.MyFlags[]):scala.Long")
   }
 
   testWithContext("value-class-polymorphic-arrayOf") {
     val MyArrayOps = ctx.findTopLevelModuleClass("inheritance.MyArrayOps")
-    val arrayOfIntArrayOps = MyArrayOps.getDecl(name"arrayOfIntArrayOps").get.asTerm
+    val arrayOfIntArrayOps = MyArrayOps.findNonOverloadedDecl(name"arrayOfIntArrayOps")
     assertIsSignedName(arrayOfIntArrayOps.signedName, "arrayOfIntArrayOps", "(scala.Int[][]):inheritance.MyArrayOps[]")
   }
 
   testWithContext("package-ref-from-tasty") {
     val LazyVals = ctx.findTopLevelModuleClass("javacompat.LazyVals")
-    val getOffsetStatic = LazyVals.getDecl(name"getOffsetStatic").get.asTerm
+    val getOffsetStatic = LazyVals.findNonOverloadedDecl(name"getOffsetStatic")
     assertIsSignedName(getOffsetStatic.signedName, "getOffsetStatic", "(java.lang.reflect.Field):scala.Long")
   }
 
   testWithContext("Scala 3 special function types") {
     val SpecialFunctionTypes = ctx.findTopLevelClass("simple_trees.SpecialFunctionTypes")
-    val contextFunction = SpecialFunctionTypes.getDecl(name"contextFunction").get.asTerm
+    val contextFunction = SpecialFunctionTypes.findNonOverloadedDecl(name"contextFunction")
     assertIsSignedName(contextFunction.signedName, "contextFunction", "(scala.Function1):scala.Unit")
   }
 
   testWithContext("inherited type member, same tasty") {
     val SubClass = ctx.findStaticClass("inheritance.SameTasty.Sub")
-    val foo3 = SubClass.getDecl(name"foo3").get.asTerm
+    val foo3 = SubClass.findDecl(name"foo3")
     assertIsSignedName(foo3.signedName, "foo3", "():scala.Int")
 
     val SubWithMixinClass = ctx.findStaticClass("inheritance.SameTasty.SubWithMixin")
-    val bar3 = SubWithMixinClass.getDecl(name"bar3").get.asTerm
+    val bar3 = SubWithMixinClass.findDecl(name"bar3")
     assertIsSignedName(bar3.signedName, "bar3", "():scala.Int")
   }
 
   testWithContext("inherited type member, cross tasty") {
     val SubClass = ctx.findTopLevelClass("inheritance.crosstasty.Sub")
-    val foo3 = SubClass.getDecl(name"foo3").get.asTerm
+    val foo3 = SubClass.findDecl(name"foo3")
     assertIsSignedName(foo3.signedName, "foo3", "():scala.Int")
 
     val SubWithMixinClass = ctx.findTopLevelClass("inheritance.crosstasty.SubWithMixin")
-    val bar3 = SubWithMixinClass.getDecl(name"bar3").get.asTerm
+    val bar3 = SubWithMixinClass.findDecl(name"bar3")
     assertIsSignedName(bar3.signedName, "bar3", "():scala.Int")
   }
 
   testWithContext("case class copy method") {
     val CaseClass = ctx.findTopLevelClass("synthetics.CaseClass")
-    val copy = CaseClass.getDecl(name"copy").get.asTerm
+    val copy = CaseClass.findNonOverloadedDecl(name"copy")
     assertIsSignedName(copy.signedName, "copy", "(java.lang.String):synthetics.CaseClass")
   }
 

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -341,7 +341,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     val SimplePathsClass = ctx.findTopLevelClass(s"$paths.SimplePaths")
     val OtherSimplePathsClass = ctx.findTopLevelClass(s"$paths.OtherSimplePaths")
 
-    val setupMethod = ctx.findStaticTerm(s"$paths.Setup.simplePaths")
+    val setupMethod = ctx.findTopLevelModuleClass(s"$paths.Setup").findNonOverloadedDecl(name"simplePaths")
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))
@@ -412,7 +412,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     val SimplePathsClass = ctx.findTopLevelClass(s"$paths.SimplePaths")
     val ConcreteSimplePathsChildClass = ctx.findTopLevelClass(s"$paths.ConcreteSimplePathsChild")
 
-    val setupMethod = ctx.findStaticTerm(s"$paths.Setup.subclassPaths")
+    val setupMethod = ctx.findTopLevelModuleClass(s"$paths.Setup").findNonOverloadedDecl(name"subclassPaths")
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -61,28 +61,28 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       TypeRef(cls.typeRef.prefix, cls)
 
   def ProductClass(using Context): ClassSymbol =
-    resolve(name"scala" / tname"Product").asClass
+    ctx.findTopLevelClass("scala.Product")
 
   def MatchErrorClass(using Context): ClassSymbol =
-    resolve(name"scala" / tname"MatchError").asClass
+    ctx.findTopLevelClass("scala.MatchError")
 
   def ListClass(using Context): ClassSymbol =
-    resolve(name"scala" / name"collection" / name"immutable" / tname"List").asClass
+    ctx.findTopLevelClass("scala.collection.immutable.List")
 
   def PredefModuleClass(using Context): ClassSymbol =
-    resolve(name"scala" / tname"Predef" / obj).asClass
+    ctx.findTopLevelModuleClass("scala.Predef")
 
   def PredefPrefix(using Context): Type =
     PredefModuleClass.accessibleThisType
 
   def ScalaPackageObjectPrefix(using Context): Type =
-    resolve(name"scala" / tname"package" / obj).asClass.accessibleThisType
+    ctx.findTopLevelModuleClass("scala.package").accessibleThisType
 
   def javaLangPrefix(using Context): Type =
     defn.javaLangPackage.packageRef
 
   def javaIOPrefix(using Context): Type =
-    resolve(name"java" / name"io").asPackage.packageRef
+    ctx.findPackage("java.io").packageRef
 
   def scalaPrefix(using Context): Type =
     defn.scalaPackage.packageRef
@@ -91,10 +91,10 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     ListClass.typeRef.appliedTo(tpe)
 
   def genSeqOf(tpe: Type)(using Context): Type =
-    resolve(name"scala" / name"collection" / tname"Seq").asClass.typeRef.appliedTo(tpe)
+    ctx.findTopLevelClass("scala.collection.Seq").typeRef.appliedTo(tpe)
 
   def mutableSeqOf(tpe: Type)(using Context): Type =
-    resolve(name"scala" / name"collection" / name"mutable" / tname"Seq").asClass.typeRef.appliedTo(tpe)
+    ctx.findTopLevelClass("scala.collection.mutable.Seq").typeRef.appliedTo(tpe)
 
   def findLocalValDef(body: Tree, name: TermName)(using Context): TermSymbol =
     var result: Option[TermSymbol] = None
@@ -276,7 +276,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("this-type") {
     // No withRef's in this test because we cannot write code that refers to the `this` of an external class
 
-    val TypeMemberClass = resolve(name"simple_trees" / tname"TypeMember").asClass
+    val TypeMemberClass = ctx.findTopLevelClass("simple_trees.TypeMember")
     val TypeMemberThis = ThisType(TypeMemberClass.typeRef)
 
     assertStrictSubtype(TypeMemberThis, TypeMemberClass.typeRef)
@@ -288,7 +288,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("type-member-this") {
     // No withRef's in this test because we cannot write code that refers to the `this` of an external class
 
-    val TypeMemberClass = resolve(name"simple_trees" / tname"TypeMember").asClass
+    val TypeMemberClass = ctx.findTopLevelClass("simple_trees.TypeMember")
     val TypeMemberThis = ThisType(TypeMemberClass.typeRef)
 
     assertEquiv(TypeMemberThis.select(tname"TypeMember"), defn.IntType)
@@ -307,7 +307,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("type-member-external") {
     import simple_trees.TypeMember
 
-    val TypeMemberClass = resolve(name"simple_trees" / tname"TypeMember").asClass
+    val TypeMemberClass = ctx.findTopLevelClass("simple_trees.TypeMember")
     val TypeMemberRef = TypeMemberClass.typeRef
 
     assertEquiv(TypeMemberRef.select(tname"TypeMember"), defn.IntType).withRef[TypeMember#TypeMember, Int]
@@ -334,14 +334,14 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("simple-paths") {
     import subtyping.paths.{A, B, C, SimplePaths, OtherSimplePaths}
 
-    val paths = name"subtyping" / name"paths"
-    val AClass = resolve(paths / tname"A").asClass
-    val BClass = resolve(paths / tname"B").asClass
-    val CClass = resolve(paths / tname"C").asClass
-    val SimplePathsClass = resolve(paths / tname"SimplePaths").asClass
-    val OtherSimplePathsClass = resolve(paths / tname"OtherSimplePaths").asClass
+    val paths = "subtyping.paths"
+    val AClass = ctx.findTopLevelClass(s"$paths.A")
+    val BClass = ctx.findTopLevelClass(s"$paths.B")
+    val CClass = ctx.findTopLevelClass(s"$paths.C")
+    val SimplePathsClass = ctx.findTopLevelClass(s"$paths.SimplePaths")
+    val OtherSimplePathsClass = ctx.findTopLevelClass(s"$paths.OtherSimplePaths")
 
-    val setupMethod = resolve(paths / tname"Setup" / obj / name"simplePaths").asTerm
+    val setupMethod = ctx.findStaticTerm(s"$paths.Setup.simplePaths")
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))
@@ -405,14 +405,14 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("simple-paths-in-subclasses") {
     import subtyping.paths.{A, B, C, SimplePaths, ConcreteSimplePathsChild}
 
-    val paths = name"subtyping" / name"paths"
-    val AClass = resolve(paths / tname"A").asClass
-    val BClass = resolve(paths / tname"B").asClass
-    val CClass = resolve(paths / tname"C").asClass
-    val SimplePathsClass = resolve(paths / tname"SimplePaths").asClass
-    val ConcreteSimplePathsChildClass = resolve(paths / tname"ConcreteSimplePathsChild").asClass
+    val paths = "subtyping.paths"
+    val AClass = ctx.findTopLevelClass(s"$paths.A")
+    val BClass = ctx.findTopLevelClass(s"$paths.B")
+    val CClass = ctx.findTopLevelClass(s"$paths.C")
+    val SimplePathsClass = ctx.findTopLevelClass(s"$paths.SimplePaths")
+    val ConcreteSimplePathsChildClass = ctx.findTopLevelClass(s"$paths.ConcreteSimplePathsChild")
 
-    val setupMethod = resolve(paths / tname"Setup" / obj / name"subclassPaths").asTerm
+    val setupMethod = ctx.findStaticTerm(s"$paths.Setup.subclassPaths")
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))

--- a/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -48,7 +48,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
       } else {
         Seq(root)
       }
-    symbolsInSubtree(resolve(prefix)).tail // discard prefix
+    symbolsInSubtree(ctx.findSymbolFromRoot(prefix.toNameList)).tail // discard prefix
   }
 
   def assertForallWithPrefix(prefix: DeclarationPath, condition: Symbol => Boolean)(using Context): Unit =
@@ -59,7 +59,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
   def assertContainsExactly(prefix: DeclarationPath, symbolPaths: Set[DeclarationPath])(using Context): Unit = {
     val decls = getDeclsByPrefix(prefix)
-    val expected = symbolPaths.toList.map(p => resolve(p))
+    val expected = symbolPaths.toList.map(p => ctx.findSymbolFromRoot(p.toNameList))
     // each declaration is in the passed set
     assert(
       decls.forall(decls.contains(_)),

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -101,7 +101,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
           case app @ Apply(fooRef @ Select(_, SignedName(SimpleName("foo"), _, _)), _) =>
             callCount += 1
             assert(app.tpe.isRef(defn.UnitClass), clue(app))
-            val fooSym = fooRef.tpe.termSymbol.asTerm
+            val fooSym = fooRef.tpe.asInstanceOf[TermRef].symbol
             val List(Left(List(aRef)), _*) = fooSym.paramRefss: @unchecked
             assert(aRef.isRef(Acls), clues(Acls.fullName, aRef))
           case _ => ()

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -12,19 +12,14 @@ import tastyquery.Types.*
 import Paths.*
 
 class TypeSuite extends UnrestrictedUnpicklingSuite {
-  def assertIsSymbolWithPath(path: DeclarationPath)(actualSymbol: Symbol)(using Context): Unit = {
-    val expectedSymbol = resolve(path)
-    assert(actualSymbol eq expectedSymbol, clues(actualSymbol, expectedSymbol))
-  }
-
   extension [T](elems: List[T])
     def isListOf(tests: (T => Boolean)*)(using Context): Boolean =
       elems.corresponds(tests)((t, test) => test(t))
 
   extension (tpe: Type)
-    def isAny(using Context): Boolean = tpe.isRef(resolve(name"scala" / tname"Any"))
+    def isAny(using Context): Boolean = tpe.isRef(defn.AnyClass)
 
-    def isNothing(using Context): Boolean = tpe.isRef(resolve(name"scala" / tname"Nothing"))
+    def isNothing(using Context): Boolean = tpe.isRef(defn.NothingClass)
 
     def isWildcard(using Context): Boolean =
       isBounded(_.isNothing, _.isAny)
@@ -46,13 +41,13 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         case _ => false
 
     def isArrayOf(arg: Type => Boolean)(using Context): Boolean =
-      isApplied(_.isRef(resolve(name"scala" / tname"Array")), Seq(arg))
+      isApplied(_.isRef(defn.ArrayClass), Seq(arg))
 
   testWithContext("apply-recursive") {
-    val RecApply = name"simple_trees" / tname"RecApply"
+    val RecApplyClass = ctx.findTopLevelClass("simple_trees.RecApply")
 
-    val gcdSym = resolve(RecApply / name"gcd")
-    val NumClass = resolve(RecApply / tname"Num")
+    val gcdSym = RecApplyClass.findDecl(name"gcd")
+    val NumClass = RecApplyClass.findDecl(tname"Num").asClass
 
     val Some(gcdTree @ _: DefDef) = gcdSym.tree: @unchecked
 
@@ -74,32 +69,28 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("java.lang.String") {
-    val StringClass = resolve(name"java" / name"lang" / tname"String").asClass
-    val CharClass = resolve(name"scala" / tname"Char").asClass
-
-    val charAt = StringClass.getDecl(name"charAt").get.asTerm
+    val charAt = defn.StringClass.findDecl(name"charAt")
     val tpe = charAt.declaredType.asInstanceOf[MethodType]
-    assert(clue(tpe.resultType).isRef(CharClass))
+    assert(clue(tpe.resultType).isRef(defn.CharClass))
   }
 
   testWithContext("scala.compiletime.Error parents") {
     // #179 The parents of Error contain a TypeRef(PackageRef(scala), "Serializable")
 
-    val ProductClass = resolve(name"scala" / tname"Product").asClass
-    val SerializableClass = resolve(name"java" / name"io" / tname"Serializable").asClass
-    val CompTimeErrorClass = resolve(name"scala" / name"compiletime" / name"testing" / tname"Error").asClass
+    val ProductClass = ctx.findTopLevelClass("scala.Product")
+    val SerializableClass = ctx.findTopLevelClass("java.io.Serializable")
+    val CompTimeErrorClass = ctx.findTopLevelClass("scala.compiletime.testing.Error")
 
     val parentClasses = CompTimeErrorClass.parentClasses
     assert(clue(parentClasses) == List(defn.ObjectClass, ProductClass, SerializableClass))
   }
 
-  def applyOverloadedTest(name: String)(callMethod: String, paramCls: DeclarationPath)(using munit.Location): Unit =
+  def applyOverloadedTest(name: String)(callMethod: String, paramCls: Context ?=> Symbol)(using munit.Location): Unit =
     testWithContext(name) {
-      val OverloadedApply = name"simple_trees" / tname"OverloadedApply"
+      val OverloadedApplyClass = ctx.findTopLevelClass("simple_trees.OverloadedApply")
 
-      val callSym = resolve(OverloadedApply / termName(callMethod))
-      val Acls = resolve(paramCls)
-      val UnitClass = resolve(name"scala" / tname"Unit")
+      val callSym = OverloadedApplyClass.findDecl(termName(callMethod))
+      val Acls = paramCls
 
       val Some(callTree @ _: DefDef) = callSym.tree: @unchecked
 
@@ -109,7 +100,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         tree match
           case app @ Apply(fooRef @ Select(_, SignedName(SimpleName("foo"), _, _)), _) =>
             callCount += 1
-            assert(app.tpe.isRef(UnitClass), clue(app)) // todo: resolve overloaded
+            assert(app.tpe.isRef(defn.UnitClass), clue(app))
             val fooSym = fooRef.tpe.termSymbol.asTerm
             val List(Left(List(aRef)), _*) = fooSym.paramRefss: @unchecked
             assert(aRef.isRef(Acls), clues(Acls.fullName, aRef))
@@ -119,22 +110,32 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       assert(callCount == 1)
     }
 
-  applyOverloadedTest("apply-overloaded-int")("callA", name"scala" / tname"Int")
-  applyOverloadedTest("apply-overloaded-gen")("callB", name"simple_trees" / tname"OverloadedApply" / tname"Box")
+  applyOverloadedTest("apply-overloaded-int")("callA", defn.IntClass)
+  applyOverloadedTest("apply-overloaded-gen")(
+    "callB",
+    ctx.findTopLevelClass("simple_trees.OverloadedApply").findDecl(tname"Box")
+  )
   applyOverloadedTest("apply-overloaded-nestedObj")(
     "callC",
-    name"simple_trees" / tname"OverloadedApply" / tname"Foo" / obj / name"Bar"
+    ctx
+      .findTopLevelClass("simple_trees.OverloadedApply")
+      .findDecl(moduleClassName("Foo"))
+      .asClass
+      .findDecl(termName("Bar"))
   )
-  // applyOverloadedTest("apply-overloaded-arrayObj")("callD", name"scala" / tname"Array") // TODO: re-enable when we add types to scala 2 symbols
-  applyOverloadedTest("apply-overloaded-byName")("callE", name"simple_trees" / tname"OverloadedApply" / tname"Num")
+  applyOverloadedTest("apply-overloaded-arrayObj")("callD", defn.ArrayClass)
+  applyOverloadedTest("apply-overloaded-byName")(
+    "callE",
+    ctx.findTopLevelClass("simple_trees.OverloadedApply").findDecl(tname"Num")
+  )
 
   testWithContext("typeapply-recursive") {
-    val RecApply = name"simple_trees" / tname"RecApply"
+    val RecApplyClass = ctx.findTopLevelClass("simple_trees.RecApply")
 
-    val evalSym = resolve(RecApply / name"eval").asTerm
-    val ExprClass = resolve(RecApply / tname"Expr")
-    val NumClass = resolve(RecApply / tname"Num")
-    val BoolClass = resolve(RecApply / tname"Bool")
+    val evalSym = RecApplyClass.findDecl(name"eval")
+    val ExprClass = RecApplyClass.findDecl(tname"Expr")
+    val NumClass = RecApplyClass.findDecl(tname"Num")
+    val BoolClass = RecApplyClass.findDecl(tname"Bool")
 
     val evalParamRefss = evalSym.paramRefss
 
@@ -168,20 +169,19 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("basic-local-val") {
-    val AssignPath = name"simple_trees" / tname"Assign"
+    val AssignPathClass = ctx.findTopLevelClass("simple_trees.Assign")
 
-    val fSym = resolve(AssignPath / name"f").asTerm
+    val fSym = AssignPathClass.findDecl(name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
 
     val List(Left(List(xParamDef))) = fTree.paramLists: @unchecked
 
-    val IntClass = resolve(name"scala" / tname"Int")
-    assert(xParamDef.symbol.asTerm.declaredType.isRef(IntClass))
+    assert(xParamDef.symbol.asTerm.declaredType.isRef(defn.IntClass))
 
     fSym.declaredType match
       case mt: MethodType =>
-        assert(mt.paramTypes.sizeIs == 1 && mt.paramTypes.head.isRef(IntClass))
-        assert(mt.resultType.isRef(IntClass))
+        assert(mt.paramTypes.sizeIs == 1 && mt.paramTypes.head.isRef(defn.IntClass))
+        assert(mt.resultType.isRef(defn.IntClass))
       case _ =>
         fail(s"$fSym does not have a MethodType", clues(fSym.declaredType))
 
@@ -195,10 +195,10 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       tree match {
         case Ident(`x`) =>
           xCount += 1
-          assert(tree.tpe.isOfClass(IntClass), clue(tree.tpe))
+          assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
         case Ident(`y`) =>
           yCount += 1
-          assert(tree.tpe.isOfClass(IntClass), clue(tree.tpe))
+          assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
         case _ =>
           ()
       }
@@ -209,9 +209,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("term-ref") {
-    val RepeatedPath = name"simple_trees" / tname"Repeated"
+    val RepeatedPathClass = ctx.findTopLevelClass("simple_trees.Repeated")
 
-    val fSym = resolve(RepeatedPath / name"f")
+    val fSym = RepeatedPathClass.findDecl(name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
 
     var bitSetIdentCount = 0
@@ -232,15 +232,14 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("free-ident") {
-    val MatchPath = name"simple_trees" / tname"Match"
+    val MatchPathClass = ctx.findTopLevelClass("simple_trees.Match")
 
-    val fSym = resolve(MatchPath / name"f")
+    val fSym = MatchPathClass.findDecl(name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
 
     val List(Left(List(xParamDef))) = fTree.paramLists: @unchecked
 
-    val IntClass = resolve(name"scala" / tname"Int")
-    assert(xParamDef.symbol.asTerm.declaredType.isRef(IntClass))
+    assert(xParamDef.symbol.asTerm.declaredType.isRef(defn.IntClass))
 
     var freeIdentCount = 0
 
@@ -249,7 +248,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         case tree: FreeIdent =>
           freeIdentCount += 1
           assert(tree.name == nme.Wildcard, clue(tree.name))
-          assert(tree.tpe.isOfClass(IntClass), clue(tree.tpe))
+          assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
         case _ =>
           ()
       }
@@ -259,9 +258,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("return") {
-    val ReturnPath = name"simple_trees" / tname"Return"
+    val ReturnPathClass = ctx.findTopLevelClass("simple_trees.Return")
 
-    val withReturnSym = resolve(ReturnPath / name"withReturn")
+    val withReturnSym = ReturnPathClass.findDecl(name"withReturn")
     val withReturnTree = withReturnSym.tree.get.asInstanceOf[DefDef]
 
     var returnCount = 0
@@ -271,7 +270,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         case Return(expr, from: Ident) =>
           returnCount += 1
           assert(from.tpe.isRef(withReturnSym), clue(from.tpe))
-          assert(tree.tpe.isRef(resolve(name"scala" / tname"Nothing")))
+          assert(tree.tpe.isNothing)
         case _ =>
           ()
       }
@@ -281,9 +280,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("assign") {
-    val AssignPath = name"simple_trees" / tname"Assign"
+    val AssignPathClass = ctx.findTopLevelClass("simple_trees.Assign")
 
-    val fSym = resolve(AssignPath / name"f")
+    val fSym = AssignPathClass.findDecl(name"f")
     val fTree = fSym.tree.get.asInstanceOf[DefDef]
 
     var assignCount = 0
@@ -292,8 +291,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       tree match {
         case Assign(lhs, rhs) =>
           assignCount += 1
-          val UnitClass = resolve(name"scala" / tname"Unit")
-          assert(tree.tpe.isOfClass(UnitClass), clue(tree.tpe))
+          assert(tree.tpe.isOfClass(defn.UnitClass), clue(tree.tpe))
         case _ =>
           ()
       }
@@ -303,28 +301,23 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("basic-scala2-types") {
-    val ScalaRange = name"scala" / name"collection" / name"immutable" / tname"Range"
-
-    val RangeClass = resolve(ScalaRange).asClass
-
-    val BooleanClass = resolve(name"scala" / tname"Boolean")
-    val IntClass = resolve(name"scala" / tname"Int")
-    val Function1Class = resolve(name"scala" / tname"Function1")
-    val IndexedSeqClass = resolve(name"scala" / name"collection" / name"immutable" / tname"IndexedSeq")
+    val RangeClass = ctx.findTopLevelClass("scala.collection.immutable.Range")
+    val Function1Class = ctx.findTopLevelClass("scala.Function1")
+    val IndexedSeqClass = ctx.findTopLevelClass("scala.collection.immutable.IndexedSeq")
 
     // val start: Int
     val startSym = RangeClass.getDecl(name"start").get.asTerm
-    assert(startSym.declaredType.isOfClass(IntClass), clue(startSym.declaredType))
+    assert(startSym.declaredType.isOfClass(defn.IntClass), clue(startSym.declaredType))
     assert(startSym.declaredType.isInstanceOf[ExprType], clue(startSym.declaredType)) // should this be TypeRef?
 
     // val isEmpty: Boolean
     val isEmptySym = RangeClass.getDecl(name"isEmpty").get.asTerm
-    assert(isEmptySym.declaredType.isOfClass(BooleanClass), clue(isEmptySym.declaredType))
+    assert(isEmptySym.declaredType.isOfClass(defn.BooleanClass), clue(isEmptySym.declaredType))
     assert(isEmptySym.declaredType.isInstanceOf[ExprType], clue(isEmptySym.declaredType)) // should this be TypeRef?
 
     // def isInclusive: Boolean
     val isInclusiveSym = RangeClass.getDecl(name"isInclusive").get.asTerm
-    assert(isInclusiveSym.declaredType.isOfClass(BooleanClass), clue(isInclusiveSym.declaredType))
+    assert(isInclusiveSym.declaredType.isOfClass(defn.BooleanClass), clue(isInclusiveSym.declaredType))
     assert(isInclusiveSym.declaredType.isInstanceOf[ExprType], clue(isInclusiveSym.declaredType))
 
     // def by(step: Int): Range
@@ -333,7 +326,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       val mt = bySym.declaredType.asInstanceOf[MethodType]
       assertEquals(List[TermName](name"step"), mt.paramNames, clue(mt.paramNames))
       assert(mt.paramTypes.sizeIs == 1)
-      assert(mt.paramTypes.head.isOfClass(IntClass), clue(mt.paramTypes.head))
+      assert(mt.paramTypes.head.isOfClass(defn.IntClass), clue(mt.paramTypes.head))
       assert(mt.resultType.isOfClass(RangeClass), clue(mt.resultType))
     }
 
@@ -352,57 +345,54 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("basic-java-class-dependency") {
-    val BoxedJava = name"javacompat" / tname"BoxedJava"
-    val JavaDefined = name"javadefined" / tname"JavaDefined"
+    val BoxedJavaClass = ctx.findTopLevelClass("javacompat.BoxedJava")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
 
-    val boxedSym = resolve(BoxedJava / name"boxed").asTerm
+    val boxedSym = BoxedJavaClass.getDecl(name"boxed").get.asTerm
 
     val (JavaDefinedRef @ _: TypeRef) = boxedSym.declaredType: @unchecked
 
-    assertIsSymbolWithPath(JavaDefined)(JavaDefinedRef.symbol)
+    assert(clue(JavaDefinedRef.symbol) == JavaDefinedClass)
   }
 
   testWithContext("bag-of-java-definitions") {
-    val BagOfJavaDefinitions = name"javadefined" / tname"BagOfJavaDefinitions"
+    val BagOfJavaDefinitionsClass = ctx.findTopLevelClass("javadefined.BagOfJavaDefinitions")
 
-    val IntClass = resolve(name"scala" / tname"Int")
-    val UnitClass = resolve(name"scala" / tname"Unit")
+    def testDef(name: TermName)(op: TermSymbol => Unit): Unit =
+      op(BagOfJavaDefinitionsClass.findDecl(name))
 
-    def testDef(path: DeclarationPath)(op: TermSymbol => Unit): Unit =
-      op(resolve(path).asTerm)
-
-    testDef(BagOfJavaDefinitions / name"x") { x =>
-      assert(x.declaredType.isRef(IntClass))
+    testDef(name"x") { x =>
+      assert(x.declaredType.isRef(defn.IntClass))
     }
 
-    testDef(BagOfJavaDefinitions / name"recField") { recField =>
-      assert(recField.declaredType.isRef(resolve(BagOfJavaDefinitions)))
+    testDef(name"recField") { recField =>
+      assert(recField.declaredType.isRef(BagOfJavaDefinitionsClass))
     }
 
-    testDef(BagOfJavaDefinitions / name"printX") { printX =>
+    testDef(name"printX") { printX =>
       val tpe = printX.declaredType.asInstanceOf[MethodType]
-      assert(tpe.resultType.isRef(UnitClass))
+      assert(tpe.resultType.isRef(defn.UnitClass))
     }
 
-    testDef(BagOfJavaDefinitions / name"<init>") { ctor =>
+    testDef(name"<init>") { ctor =>
       val tpe = ctor.declaredType.asInstanceOf[MethodType]
-      assert(tpe.paramTypes.head.isRef(IntClass))
-      assert(tpe.resultType.isRef(UnitClass))
+      assert(tpe.paramTypes.head.isRef(defn.IntClass))
+      assert(tpe.resultType.isRef(defn.UnitClass))
     }
 
-    testDef(BagOfJavaDefinitions / name"wrapXArray") { wrapXArray =>
+    testDef(name"wrapXArray") { wrapXArray =>
       val tpe = wrapXArray.declaredType.asInstanceOf[MethodType]
-      assert(tpe.resultType.isArrayOf(_.isRef(IntClass)))
+      assert(tpe.resultType.isArrayOf(_.isRef(defn.IntClass)))
     }
 
-    testDef(BagOfJavaDefinitions / name"arrIdentity") { arrIdentity =>
+    testDef(name"arrIdentity") { arrIdentity =>
       val tpe = arrIdentity.declaredType.asInstanceOf[MethodType]
-      val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
+      val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
       assert(tpe.paramInfos.head.isArrayOf(_.isRef(JavaDefinedClass)))
       assert(tpe.resultType.isArrayOf(_.isRef(JavaDefinedClass)))
     }
 
-    testDef(BagOfJavaDefinitions / name"processBuilder") { processBuilder =>
+    testDef(name"processBuilder") { processBuilder =>
       val tpe = processBuilder.declaredType.asInstanceOf[MethodType]
       assert(tpe.resultType.isInstanceOf[TypeRef]) // do not call isRef, as we do not have the java lib
     }
@@ -410,46 +400,46 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("bag-of-generic-java-definitions[signatures]") {
-    val BagOfGenJavaDefinitions = name"javadefined" / tname"BagOfGenJavaDefinitions"
-    val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
-    val GenericJavaClass = resolve(name"javadefined" / tname"GenericJavaClass")
-    val JavaInterface1 = resolve(name"javadefined" / tname"JavaInterface1")
-    val JavaInterface2 = resolve(name"javadefined" / tname"JavaInterface2")
-    val ExceptionClass = resolve(name"java" / name"lang" / tname"Exception")
+    val BagOfGenJavaDefinitionsClass = ctx.findTopLevelClass("javadefined.BagOfGenJavaDefinitions")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
+    val GenericJavaClass = ctx.findTopLevelClass("javadefined.GenericJavaClass")
+    val JavaInterface1 = ctx.findTopLevelClass("javadefined.JavaInterface1")
+    val JavaInterface2 = ctx.findTopLevelClass("javadefined.JavaInterface2")
+    val ExceptionClass = ctx.findTopLevelClass("java.lang.Exception")
 
-    def testDef(path: DeclarationPath)(op: TermSymbol => Unit): Unit =
-      op(resolve(path).asTerm)
+    def testDef(name: TermName)(op: TermSymbol => Unit): Unit =
+      op(BagOfGenJavaDefinitionsClass.findDecl(name))
 
     extension (tpe: Type)
       def isGenJavaClassOf(arg: Type => Boolean)(using Context): Boolean =
         tpe.isApplied(_.isRef(GenericJavaClass), List(arg))
 
-    testDef(BagOfGenJavaDefinitions / name"x") { x =>
+    testDef(name"x") { x =>
       assert(x.declaredType.isGenJavaClassOf(_.isRef(JavaDefinedClass)))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"getX") { getX =>
+    testDef(name"getX") { getX =>
       val tpe = getX.declaredType.asInstanceOf[MethodType]
       assert(tpe.resultType.isGenJavaClassOf(_.isRef(JavaDefinedClass)))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"getXArray") { getXArray =>
+    testDef(name"getXArray") { getXArray =>
       val tpe = getXArray.declaredType.asInstanceOf[MethodType]
       assert(tpe.resultType.isArrayOf(_.isGenJavaClassOf(_.isRef(JavaDefinedClass))))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"printX") { printX =>
+    testDef(name"printX") { printX =>
       val tpe = printX.declaredType.asInstanceOf[PolyType]
       assert(tpe.paramTypeBounds.head.high.isRef(ExceptionClass))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"recTypeParams") { recTypeParams =>
+    testDef(name"recTypeParams") { recTypeParams =>
       val tpe = recTypeParams.declaredType.asInstanceOf[TypeLambdaType]
       val List(tparamRefA, tparamRefY) = tpe.paramRefs: @unchecked
       assert(tparamRefA.bounds.high.isGenJavaClassOf(_ == tparamRefY))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"refInterface") { refInterface =>
+    testDef(name"refInterface") { refInterface =>
       val tpe = refInterface.declaredType.asInstanceOf[TypeLambdaType]
       val List(tparamRefA) = tpe.paramRefs: @unchecked
       assert(
@@ -458,7 +448,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       )
     }
 
-    testDef(BagOfGenJavaDefinitions / name"genraw") { genraw =>
+    testDef(name"genraw") { genraw =>
       /* Raw types are not really supported (see #80). They are read and
        * stored as if they were *monomorphic* class references, i.e., TypeRef's
        * without any AppliedType.
@@ -466,29 +456,29 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       assert(genraw.declaredType.isRef(GenericJavaClass))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"mixgenraw") { mixgenraw =>
+    testDef(name"mixgenraw") { mixgenraw =>
       // Same comment about raw types.
       assert(mixgenraw.declaredType.isGenJavaClassOf(_.isRef(GenericJavaClass)))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"genwild") { genwild =>
+    testDef(name"genwild") { genwild =>
       assert(genwild.declaredType.isGenJavaClassOf(_.isWildcard))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"gencovarient") { gencovarient =>
+    testDef(name"gencovarient") { gencovarient =>
       assert(gencovarient.declaredType.isGenJavaClassOf(_.isBounded(_.isNothing, _.isRef(JavaDefinedClass))))
     }
 
-    testDef(BagOfGenJavaDefinitions / name"gencontravarient") { gencontravarient =>
+    testDef(name"gencontravarient") { gencontravarient =>
       assert(gencontravarient.declaredType.isGenJavaClassOf(_.isBounded(_.isRef(JavaDefinedClass), _.isAny)))
     }
   }
 
   testWithContext("java-class-parents") {
-    val SubJavaDefinedClass = resolve(name"javadefined" / tname"SubJavaDefined").asClass
-    val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
-    val JavaInterface1Class = resolve(name"javadefined" / tname"JavaInterface1")
-    val JavaInterface2Class = resolve(name"javadefined" / tname"JavaInterface2")
+    val SubJavaDefinedClass = ctx.findTopLevelClass("javadefined.SubJavaDefined")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
+    val JavaInterface1Class = ctx.findTopLevelClass("javadefined.JavaInterface1")
+    val JavaInterface2Class = ctx.findTopLevelClass("javadefined.JavaInterface2")
 
     assert(
       SubJavaDefinedClass.parents
@@ -506,16 +496,15 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("java-class-signatures-[RecClass]") {
-    val RecClass = resolve(name"javadefined" / tname"RecClass").asClass
-    val ObjectClass = resolve(name"java" / name"lang" / tname"Object")
+    val RecClass = ctx.findTopLevelClass("javadefined.RecClass")
 
-    assert(RecClass.parents.isListOf(_.isRef(ObjectClass)))
+    assert(RecClass.parents.isListOf(_.isRef(defn.ObjectClass)))
   }
 
   testWithContext("java-class-signatures-[SubRecClass]") {
-    val SubRecClass = resolve(name"javadefined" / tname"SubRecClass").asClass
-    val RecClass = resolve(name"javadefined" / tname"RecClass")
-    val JavaInterface1 = resolve(name"javadefined" / tname"JavaInterface1")
+    val SubRecClass = ctx.findTopLevelClass("javadefined.SubRecClass")
+    val RecClass = ctx.findTopLevelClass("javadefined.RecClass")
+    val JavaInterface1 = ctx.findTopLevelClass("javadefined.JavaInterface1")
 
     val List(tparamT) = SubRecClass.typeParams: @unchecked
 
@@ -528,39 +517,39 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("select-method-from-java-class") {
-    val BoxedJava = name"javacompat" / tname"BoxedJava"
-    val getX = name"javadefined" / tname"JavaDefined" / name"getX"
+    val BoxedJavaClass = ctx.findTopLevelClass("javacompat.BoxedJava")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
 
-    val xMethodSym = resolve(BoxedJava / name"xMethod")
+    val getX = JavaDefinedClass.getDecl(name"getX").get.asTerm
+    val xMethodSym = BoxedJavaClass.getDecl(name"xMethod").get.asTerm
 
     val Some(DefDef(_, _, _, Apply(getXSelection, _), _)) = xMethodSym.tree: @unchecked
 
     val (getXRef @ _: TermRef) = getXSelection.tpe: @unchecked
 
-    assertIsSymbolWithPath(getX)(getXRef.symbol)
+    assert(clue(getXRef.symbol) == getX)
   }
 
   testWithContext("select-field-from-java-class") {
-    val BoxedJava = name"javacompat" / tname"BoxedJava"
-    val x = name"javadefined" / tname"JavaDefined" / name"x"
+    val BoxedJavaClass = ctx.findTopLevelClass("javacompat.BoxedJava")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
 
-    val xFieldSym = resolve(BoxedJava / name"xField")
+    val x = JavaDefinedClass.getDecl(name"x").get.asTerm
+    val xFieldSym = BoxedJavaClass.getDecl(name"xField").get.asTerm
 
     val Some(DefDef(_, _, _, xSelection, _)) = xFieldSym.tree: @unchecked
 
     val (xRef @ _: TermRef) = xSelection.tpe: @unchecked
 
-    assertIsSymbolWithPath(x)(xRef.symbol)
+    assert(clue(xRef.symbol) == x)
   }
 
   testWithContext("basic-scala-2-stdlib-class-dependency") {
-    val BoxedCons = name"scala2compat" / tname"BoxedCons"
-    val :: = name"scala" / name"collection" / name"immutable" / tname"::"
+    val BoxedConsClass = ctx.findTopLevelClass("scala2compat.BoxedCons")
+    val ConsClass = ctx.findTopLevelClass("scala.collection.immutable.::")
+    val JavaDefinedClass = ctx.findTopLevelClass("javadefined.JavaDefined")
 
-    val ConsClass = resolve(::)
-    val JavaDefinedClass = resolve(name"javadefined" / tname"JavaDefined")
-
-    val boxedSym = resolve(BoxedCons / name"boxed").asTerm
+    val boxedSym = BoxedConsClass.findDecl(name"boxed")
 
     val app = boxedSym.declaredType.asInstanceOf[AppliedType]
     assert(clue(app.tycon).isOfClass(ConsClass))
@@ -568,13 +557,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("select-method-from-scala-2-stdlib-class") {
-    val BoxedCons = name"scala2compat" / tname"BoxedCons"
-    val canEqual = name"scala" / name"collection" / tname"Seq" / name"canEqual"
+    val BoxedConsClass = ctx.findTopLevelClass("scala2compat.BoxedCons")
 
-    val AnyClass = resolve(name"scala" / tname"Any")
-    val BooleanClass = resolve(name"scala" / tname"Boolean")
-
-    val fooSym = resolve(BoxedCons / name"foo")
+    val fooSym = BoxedConsClass.findDecl(name"foo")
 
     val Some(DefDef(_, _, _, Apply(canEqualSelection, _), _)) = fooSym.tree: @unchecked
 
@@ -585,97 +570,95 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val mt = underlyingType.asInstanceOf[MethodType]
     assertEquals(List[TermName](name"that"), mt.paramNames, clue(mt.paramNames))
     assert(mt.paramTypes.sizeIs == 1, clue(mt.paramTypes))
-    assert(mt.paramTypes.head.isOfClass(AnyClass), clue(mt.paramTypes.head))
-    assert(mt.resultType.isOfClass(BooleanClass), clue(mt.resultType))
+    assert(mt.paramTypes.head.isOfClass(defn.AnyClass), clue(mt.paramTypes.head))
+    assert(mt.resultType.isOfClass(defn.BooleanClass), clue(mt.resultType))
   }
 
   testWithContext("select-field-from-tasty-in-other-package:dependency-from-class-file") {
-    val BoxedConstants = name"crosspackagetasty" / tname"BoxedConstants"
-    val unitVal = name"simple_trees" / tname"Constants" / name"unitVal"
+    val BoxedConstantsClass = ctx.findTopLevelClass("crosspackagetasty.BoxedConstants")
+    val ConstantsClass = ctx.findTopLevelClass("simple_trees.Constants")
 
-    val boxedUnitValSym = resolve(BoxedConstants / name"boxedUnitVal")
+    val unitVal = ConstantsClass.findDecl(name"unitVal")
+    val boxedUnitValSym = BoxedConstantsClass.findDecl(name"boxedUnitVal")
 
     val Some(DefDef(_, _, _, unitValSelection, _)) = boxedUnitValSym.tree: @unchecked
 
     val (unitValRef @ _: TermRef) = unitValSelection.tpe: @unchecked
 
-    assertIsSymbolWithPath(unitVal)(unitValRef.symbol)
+    assert(clue(unitValRef.symbol) == unitVal)
   }
 
   testWithContext("select-method-from-java-class-same-package-as-tasty") {
-    // This tests reading top level classes in the same package, defined by
+    // This tests reads top-level classes in the same package, defined by
     // both Java and Tasty. If we strictly require that all symbols are defined
     // exactly once, then we must be careful to not redefine `ScalaBox`/`JavaBox`
     // when scanning a package from the classpath.
 
-    val ScalaBox = name"mixjavascala" / tname"ScalaBox"
-    val getX = name"mixjavascala" / tname"JavaBox" / name"getX"
+    val ScalaBoxClass = ctx.findTopLevelClass("mixjavascala.ScalaBox")
+    val JavaBoxClass = ctx.findTopLevelClass("mixjavascala.JavaBox")
 
-    val xMethodSym = resolve(ScalaBox / name"xMethod")
+    val getX = JavaBoxClass.findDecl(name"getX")
+    val xMethodSym = ScalaBoxClass.findDecl(name"xMethod")
 
     val Some(DefDef(_, _, _, Apply(getXSelection, _), _)) = xMethodSym.tree: @unchecked
 
     val (getXRef @ _: TermRef) = getXSelection.tpe: @unchecked
 
-    assertIsSymbolWithPath(getX)(getXRef.symbol)
+    assert(clue(getXRef.symbol) == getX)
   }
 
   testWithContext("select-field-from-generic-class") {
-    val GenClass = resolve(name"simple_trees" / tname"GenericClass").asClass
-    val PolySelect = resolve(name"simple_trees" / tname"PolySelect").asClass
-    val IntClass = resolve(name"scala" / tname"Int")
+    val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
+    val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.getDecl(name"testField").get.tree: @unchecked
+    val Some(DefDef(_, _, _, body, _)) = PolySelect.findDecl(name"testField").tree: @unchecked
 
     val Select(qual, fieldName) = body: @unchecked
 
-    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(IntClass))))
+    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(defn.IntClass))))
     assertEquals(fieldName, name"field")
-    assert(clue(body.tpe).isOfClass(IntClass))
+    assert(clue(body.tpe).isOfClass(defn.IntClass))
   }
 
   testWithContext("select-getter-from-generic-class") {
-    val GenClass = resolve(name"simple_trees" / tname"GenericClass").asClass
-    val PolySelect = resolve(name"simple_trees" / tname"PolySelect").asClass
-    val IntClass = resolve(name"scala" / tname"Int")
+    val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
+    val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.getDecl(name"testGetter").get.tree: @unchecked
+    val Some(DefDef(_, _, _, body, _)) = PolySelect.findDecl(name"testGetter").tree: @unchecked
 
     val Select(qual, getterName) = body: @unchecked
 
-    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(IntClass))))
+    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(defn.IntClass))))
     assertEquals(getterName, name"getter")
-    assert(clue(body.tpe).isOfClass(IntClass))
+    assert(clue(body.tpe).isOfClass(defn.IntClass))
   }
 
   testWithContext("select-and-apply-method-from-generic-class") {
-    val GenClass = resolve(name"simple_trees" / tname"GenericClass").asClass
-    val PolySelect = resolve(name"simple_trees" / tname"PolySelect").asClass
-    val IntClass = resolve(name"scala" / tname"Int")
+    val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
+    val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.getDecl(name"testMethod").get.tree: @unchecked
+    val Some(DefDef(_, _, _, body, _)) = PolySelect.findDecl(name"testMethod").tree: @unchecked
 
     val Apply(fun @ Select(qual, methodName), List(arg)) = body: @unchecked
 
-    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(IntClass))))
+    assert(clue(qual.tpe).isApplied(_.isOfClass(GenClass), List(_.isOfClass(defn.IntClass))))
     methodName match {
       case SignedName(_, _, simpleName) => assertEquals(simpleName, name"method")
     }
     fun.tpe.widen match {
       case mt: MethodType =>
         assert(clue(mt.paramNames) == List(name"x"))
-        assert(clue(mt.paramTypes.head).isOfClass(IntClass))
-        assert(clue(mt.resultType).isOfClass(IntClass))
+        assert(clue(mt.paramTypes.head).isOfClass(defn.IntClass))
+        assert(clue(mt.resultType).isOfClass(defn.IntClass))
     }
-    assert(clue(body.tpe).isOfClass(IntClass))
+    assert(clue(body.tpe).isOfClass(defn.IntClass))
   }
 
   testWithContext("select-and-apply-poly-method") {
-    val GenMethod = resolve(name"simple_trees" / tname"GenericMethod").asClass
-    val PolySelect = resolve(name"simple_trees" / tname"PolySelect").asClass
-    val IntClass = resolve(name"scala" / tname"Int")
+    val GenMethod = ctx.findTopLevelClass("simple_trees.GenericMethod")
+    val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.getDecl(name"testGenericMethod").get.tree: @unchecked
+    val Some(DefDef(_, _, _, body, _)) = PolySelect.findDecl(name"testGenericMethod").tree: @unchecked
 
     val Apply(tapp @ TypeApply(fun @ Select(qual, methodName), List(targ)), List(arg)) = body: @unchecked
 
@@ -686,83 +669,78 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     tapp.tpe.widen match {
       case mt: MethodType =>
         assert(clue(mt.paramNames) == List(name"x"))
-        assert(clue(mt.paramTypes.head).isOfClass(IntClass))
-        assert(clue(mt.resultType).isOfClass(IntClass))
+        assert(clue(mt.paramTypes.head).isOfClass(defn.IntClass))
+        assert(clue(mt.resultType).isOfClass(defn.IntClass))
     }
-    assert(clue(body.tpe).isOfClass(IntClass))
+    assert(clue(body.tpe).isOfClass(defn.IntClass))
   }
 
   testWithContext("console-outvar-issue-78") {
-    val Console = resolve(name"scala" / tname"Console" / obj).asClass
-    val DynamicVariable = resolve(name"scala" / name"util" / tname"DynamicVariable").asClass
+    val Console = ctx.findTopLevelModuleClass("scala.Console")
+    val DynamicVariable = ctx.findTopLevelClass("scala.util.DynamicVariable")
 
-    val outVar = Console.getDecl(name"outVar").get.asTerm
+    val outVar = Console.findDecl(name"outVar")
     assert(clue(outVar.declaredType).isApplied(_.isRef(DynamicVariable), List(_ => true)))
   }
 
   testWithContext("scala-predef-declared-type") {
-    val predef = resolve(name"scala" / name"Predef").asTerm
-    val Predef = resolve(name"scala" / tname"Predef" / obj)
+    val predef = ctx.findStaticTerm("scala.Predef")
+    val Predef = ctx.findTopLevelModuleClass("scala.Predef")
     assert(clue(predef.declaredType).isRef(Predef))
   }
 
   testWithContext("scala.math.Ordering") {
-    val OrderingModClass = resolve(name"scala" / name"math" / tname"Ordering" / obj).asClass
+    val OrderingModClass = ctx.findTopLevelModuleClass("scala.math.Ordering")
     assert(OrderingModClass.getDecl(name"by").isDefined)
   }
 
   testWithContext("scala.math.Ordering.IntOrdering") {
-    val IntOrderingClass = resolve(name"scala" / name"math" / tname"Ordering" / obj / tname"IntOrdering").asClass
-    val IntClass = resolve(name"scala" / tname"Int").asClass
+    val IntOrderingClass = ctx.findStaticClass("scala.math.Ordering.IntOrdering")
 
-    val compare = IntOrderingClass.getDecl(name"compare").get.asTerm
+    val compare = IntOrderingClass.findDecl(name"compare")
     val mt = compare.declaredType.asInstanceOf[MethodType]
-    assert(clue(mt.paramTypes(0)).isRef(IntClass))
-    assert(clue(mt.paramTypes(1)).isRef(IntClass))
-    assert(clue(mt.resultType).isRef(IntClass))
+    assert(clue(mt.paramTypes(0)).isRef(defn.IntClass))
+    assert(clue(mt.paramTypes(1)).isRef(defn.IntClass))
+    assert(clue(mt.resultType).isRef(defn.IntClass))
   }
 
   testWithContext("scala.math.Ordering.Float.TotalOrdering") {
-    val path = name"scala" / name"math" / tname"Ordering" / obj / tname"Float" / obj / tname"TotalOrdering"
-    val FloatTotalOrderingClass = resolve(path).asClass
-    val IntClass = resolve(name"scala" / tname"Int").asClass
-    val FloatClass = resolve(name"scala" / tname"Float").asClass
+    val FloatTotalOrderingClass = ctx.findStaticClass("scala.math.Ordering.Float.TotalOrdering")
 
-    val compare = FloatTotalOrderingClass.getDecl(name"compare").get.asTerm
+    val compare = FloatTotalOrderingClass.findDecl(name"compare")
     val mt = compare.declaredType.asInstanceOf[MethodType]
-    assert(clue(mt.paramTypes(0)).isRef(FloatClass))
-    assert(clue(mt.paramTypes(1)).isRef(FloatClass))
-    assert(clue(mt.resultType).isRef(IntClass))
+    assert(clue(mt.paramTypes(0)).isRef(defn.FloatClass))
+    assert(clue(mt.paramTypes(1)).isRef(defn.FloatClass))
+    assert(clue(mt.resultType).isRef(defn.IntClass))
   }
 
   testWithContext("read-scala2-type-ref-type") {
-    val RichBoolean = resolve(name"scala" / name"runtime" / tname"RichBoolean").asClass
-    val BooleanOrdering = resolve(name"scala" / name"math" / tname"Ordering" / obj / name"Boolean")
-    val ord = RichBoolean.getDecl(name"ord").get.asTerm
+    val RichBoolean = ctx.findTopLevelClass("scala.runtime.RichBoolean")
+    val BooleanOrdering = ctx.findStaticTerm("scala.math.Ordering.Boolean")
+    val ord = RichBoolean.findDecl(name"ord")
     assert(clue(ord.declaredType).isRef(BooleanOrdering))
   }
 
   testWithContext("read-encoded-scala2-type-ref-type") {
-    val Function1Class = resolve(name"scala" / tname"Function1").asClass
-    val SerializableClass = resolve(name"java" / name"io" / tname"Serializable").asClass
-    val TypeEqClass = resolve(name"scala" / tname"=:=").asClass
-    val SubtypeClass = resolve(name"scala" / tname"<:<").asClass
+    val Function1Class = ctx.findTopLevelClass("scala.Function1")
+    val SerializableClass = ctx.findTopLevelClass("java.io.Serializable")
+    val TypeEqClass = ctx.findTopLevelClass("scala.=:=")
+    val SubtypeClass = ctx.findTopLevelClass("scala.<:<")
 
     assert(clue(SubtypeClass.parentClasses) == List(defn.ObjectClass, Function1Class, SerializableClass))
     assert(clue(TypeEqClass.parentClasses) == List(SubtypeClass, SerializableClass))
   }
 
   testWithContext("scala2-type-alias") {
-    val PredefString = resolve(name"scala" / tname"Predef" / obj / tname"String").asType
-    val JLString = resolve(name"java" / name"lang" / tname"String")
+    val PredefString = ctx.findStaticType("scala.Predef.String")
 
     assert(clue(PredefString).isTypeAlias)
-    assert(clue(PredefString.asInstanceOf[TypeMemberSymbol].aliasedType).isRef(JLString))
+    assert(clue(PredefString.asInstanceOf[TypeMemberSymbol].aliasedType).isRef(defn.StringClass))
   }
 
   testWithContext("scala2-module-and-def-with-same-name") {
-    val StringContext = resolve(name"scala" / tname"StringContext").asClass
-    val sModuleClass = resolve(name"scala" / tname"StringContext" / tname"s" / obj)
+    val StringContext = ctx.findTopLevelClass("scala.StringContext")
+    val sModuleClass = StringContext.findDecl(moduleClassName("s")).asClass
 
     val sDecls = StringContext.getDecls(name"s")
     assert(clue(sDecls).sizeIs == 2)
@@ -778,42 +756,40 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("scala2-class-type-params") {
-    val ListClass = resolve(name"scala" / name"collection" / name"immutable" / tname"List").asClass
-    val ArrayClass = resolve(name"scala" / tname"Array").asClass
+    val ListClass = ctx.findTopLevelClass("scala.collection.immutable.List")
 
     val List(targList) = ListClass.typeParams: @unchecked
     // TODO Set flags ClassTypeParam on TypeParams
     //assert(clue(targList.flags).isAllOf(ClassTypeParam))
 
-    val List(targArray) = ArrayClass.typeParams: @unchecked
+    val List(targArray) = defn.ArrayClass.typeParams: @unchecked
     // TODO Set flags ClassTypeParam on TypeParams
     //assert(clue(targArray.flags).isAllOf(ClassTypeParam))
   }
 
   testWithContext("poly-type-in-higher-kinded") {
-    val HigherKindedClass = resolve(name"simple_trees" / tname"HigherKinded").asClass
-    val polyMethod = HigherKindedClass.getDecl(name"m").get.asTerm
+    val HigherKindedClass = ctx.findTopLevelClass("simple_trees.HigherKinded")
+    val polyMethod = HigherKindedClass.findDecl(name"m")
     assert(polyMethod.declaredType.asInstanceOf[PolyType].resultType.isInstanceOf[MethodType])
   }
 
   testWithContext("scala.collection.:+") {
     // type parameter C <: SeqOps[A, CC, C]
-    val `:+` = resolve(name"scala" / name"collection" / tname"package" / obj / tname":+" / obj).asClass
+    ctx.findStaticModuleClass("scala.collection.package.:+")
   }
 
   testWithContext("read-scala.collection.mutable.StringBuilder_after-force-scala-pkg") {
-    val scala = resolve(RootPkg / name"scala").asPackage
-    scala.declarations
+    val scalaPackage = ctx.findPackage("scala")
+    scalaPackage.declarations
 
-    val StringBuilder = resolve(RootPkg / name"scala" / name"collection" / name"mutable" / tname"StringBuilder").asClass
+    ctx.findTopLevelClass("scala.collection.mutable.StringBuilder")
   }
 
   testWithContext("linearization") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperMonoClass = resolve(OverridesPath / tname"SuperMono").asClass
-    val SuperMonoTraitClass = resolve(OverridesPath / tname"SuperMonoTrait").asClass
-    val MidMonoClass = resolve(OverridesPath / tname"MidMono").asClass
-    val ChildMonoClass = resolve(OverridesPath / tname"ChildMono").asClass
+    val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
+    val SuperMonoTraitClass = ctx.findStaticClass("inheritance.Overrides.SuperMonoTrait")
+    val MidMonoClass = ctx.findStaticClass("inheritance.Overrides.MidMono")
+    val ChildMonoClass = ctx.findStaticClass("inheritance.Overrides.ChildMono")
 
     val linTail = defn.ObjectClass :: defn.MatchableClass :: defn.AnyClass :: Nil
 
@@ -826,20 +802,19 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("overrides-mono-no-overloads") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperMonoClass = resolve(OverridesPath / tname"SuperMono").asClass
-    val SuperMonoTraitClass = resolve(OverridesPath / tname"SuperMonoTrait").asClass
-    val MidMonoClass = resolve(OverridesPath / tname"MidMono").asClass
-    val ChildMonoClass = resolve(OverridesPath / tname"ChildMono").asClass
+    val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
+    val SuperMonoTraitClass = ctx.findStaticClass("inheritance.Overrides.SuperMonoTrait")
+    val MidMonoClass = ctx.findStaticClass("inheritance.Overrides.MidMono")
+    val ChildMonoClass = ctx.findStaticClass("inheritance.Overrides.ChildMono")
 
-    val fooInSuper = SuperMonoClass.getDecl(name"foo").get.asTerm
-    val fooInChild = ChildMonoClass.getDecl(name"foo").get.asTerm
+    val fooInSuper = SuperMonoClass.findDecl(name"foo")
+    val fooInChild = ChildMonoClass.findDecl(name"foo")
 
-    val barInSuperTrait = SuperMonoTraitClass.getDecl(name"bar").get.asTerm
-    val barInChild = ChildMonoClass.getDecl(name"bar").get.asTerm
+    val barInSuperTrait = SuperMonoTraitClass.findDecl(name"bar")
+    val barInChild = ChildMonoClass.findDecl(name"bar")
 
-    val foobazInSuper = SuperMonoClass.getDecl(name"foobaz").get.asTerm
-    val foobazInChild = ChildMonoClass.getDecl(name"foobaz").get.asTerm
+    val foobazInSuper = SuperMonoClass.findDecl(name"foobaz")
+    val foobazInChild = ChildMonoClass.findDecl(name"foobaz")
 
     // From fooInSuper
 
@@ -933,11 +908,10 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("overrides-mono-overloads") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperMonoClass = resolve(OverridesPath / tname"SuperMono").asClass
-    val SuperMonoTraitClass = resolve(OverridesPath / tname"SuperMonoTrait").asClass
-    val MidMonoClass = resolve(OverridesPath / tname"MidMono").asClass
-    val ChildMonoClass = resolve(OverridesPath / tname"ChildMono").asClass
+    val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
+    val SuperMonoTraitClass = ctx.findStaticClass("inheritance.Overrides.SuperMonoTrait")
+    val MidMonoClass = ctx.findStaticClass("inheritance.Overrides.MidMono")
+    val ChildMonoClass = ctx.findStaticClass("inheritance.Overrides.ChildMono")
 
     val IntClass = defn.IntClass
     val StringClass = defn.StringClass
@@ -1086,15 +1060,14 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("overrides-cannot-override") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperMonoClass = resolve(OverridesPath / tname"SuperMono").asClass
-    val ChildMonoClass = resolve(OverridesPath / tname"ChildMono").asClass
+    val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
+    val ChildMonoClass = ctx.findStaticClass("inheritance.Overrides.ChildMono")
 
-    val superCtor = SuperMonoClass.getDecl(nme.Constructor).get.asTerm
-    val childCtor = ChildMonoClass.getDecl(nme.Constructor).get.asTerm
+    val superCtor = SuperMonoClass.findDecl(nme.Constructor)
+    val childCtor = ChildMonoClass.findDecl(nme.Constructor)
 
-    val superPrivate = SuperMonoClass.getDecl(name"privateMethod").get.asTerm
-    val childPrivate = ChildMonoClass.getDecl(name"privateMethod").get.asTerm
+    val superPrivate = SuperMonoClass.findDecl(name"privateMethod")
+    val childPrivate = ChildMonoClass.findDecl(name"privateMethod")
 
     // From superCtor
 
@@ -1142,9 +1115,8 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("overrides-poly") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperPolyClass = resolve(OverridesPath / tname"SuperPoly").asClass
-    val ChildPolyClass = resolve(OverridesPath / tname"ChildPoly").asClass
+    val SuperPolyClass = ctx.findStaticClass("inheritance.Overrides.SuperPoly")
+    val ChildPolyClass = ctx.findStaticClass("inheritance.Overrides.ChildPoly")
 
     val List(superPolyA, superPolyB) = SuperPolyClass.typeParams: @unchecked
     val List(childPolyX) = ChildPolyClass.typeParams: @unchecked
@@ -1209,13 +1181,12 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   }
 
   testWithContext("overrides-relaxed") {
-    val OverridesPath = name"inheritance" / tname"Overrides" / obj
-    val SuperMonoClass = resolve(OverridesPath / tname"SuperMono").asClass
-    val ChildMonoClass = resolve(OverridesPath / tname"ChildMono").asClass
+    val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
+    val ChildMonoClass = ctx.findStaticClass("inheritance.Overrides.ChildMono")
 
-    val objectToString = defn.ObjectClass.getDecl(name"toString").get.asTerm
-    val superToString = SuperMonoClass.getDecl(name"toString").get.asTerm
-    val childToString = ChildMonoClass.getDecl(name"toString").get.asTerm
+    val objectToString = defn.ObjectClass.findDecl(name"toString")
+    val superToString = SuperMonoClass.findDecl(name"toString")
+    val childToString = ChildMonoClass.findDecl(name"toString")
 
     // From objectToString
 
@@ -1257,24 +1228,24 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(clue(childToString.nextOverriddenSymbol) == Some(superToString))
   }
 
-  def companionClassFullCycle(path: DeclarationPath)(using Context, munit.Location): Unit = {
-    val cls: ClassSymbol = resolve(path).asClass
-    val moduleClass: ClassSymbol = resolve(path.asObj).asClass
+  def companionClassFullCycle(owner: DeclaringSymbol, baseName: String)(using Context, munit.Location): Unit = {
+    val cls: ClassSymbol = owner.getDecl(typeName(baseName)).get.asClass
+    val moduleClass: ClassSymbol = owner.getDecl(moduleClassName(baseName)).get.asClass
 
     assert(cls == moduleClass.companionClass.get)
     assert(moduleClass.companionClass.get == cls)
   }
 
   testWithContext("companion-tests-module-value") {
-    companionClassFullCycle(name"companions" / tname"CompanionObject")
+    companionClassFullCycle(ctx.findPackage("companions"), "CompanionObject")
   }
 
   testWithContext("companion-tests-nested-module-value") {
-    companionClassFullCycle(name"companions" / tname"CompanionObject" / obj / tname"NestedObject")
+    companionClassFullCycle(ctx.findTopLevelModuleClass("companions.CompanionObject"), "NestedObject")
   }
 
   testWithContext("companion-tests-class-nested-module-value") {
-    companionClassFullCycle(name"companions" / tname"CompanionObject" / tname"ClassNestedObject")
+    companionClassFullCycle(ctx.findTopLevelClass("companions.CompanionObject"), "ClassNestedObject")
   }
 
 }

--- a/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
+++ b/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
@@ -13,13 +13,13 @@ class OverloadedApply {
   def foo(a: Int): Unit = ()
   def foo(a: Box[Num]): Unit = ()
   def foo(a: Foo.Bar.type): Unit = ()
-  // def foo(a: Array[Foo.type]): Unit = () // TODO: re-enable when we add types to scala 2 symbols
+  def foo(a: Array[Foo.type]): Unit = ()
   def foo(a: => Num): Unit = ()
 
   def callA = foo(1)
   def callB = foo(Box())
   def callC = foo(Foo.Bar)
-  // def callD = foo(Array(Foo)) // TODO: re-enable when we add types to scala 2 symbols
+  def callD = foo(Array(Foo))
   def callE = foo(Num())
 
 }

--- a/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
+++ b/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
@@ -15,11 +15,13 @@ class OverloadedApply {
   def foo(a: Foo.Bar.type): Unit = ()
   def foo(a: Array[Foo.type]): Unit = ()
   def foo(a: => Num): Unit = ()
+  def foo: String = "foo"
 
   def callA = foo(1)
   def callB = foo(Box())
   def callC = foo(Foo.Bar)
   def callD = foo(Array(Foo))
   def callE = foo(Num())
+  def callF = foo
 
 }


### PR DESCRIPTION
With some cleanups before we get there.