### PR TITLE
Refactor Trees and TypeTrees.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -90,8 +90,8 @@ object Trees {
       case Return(expr, from)                     => expr :: Nil
       case Inlined(expr, caller, bindings)        => expr :: bindings
 
-      case _: ImportIdent | _: TypeMember | _: TypeParam | _: Ident | _: ReferencedPackage | _: This | _: New |
-          _: Literal | _: SelfDef | EmptyTree =>
+      case _: ImportIdent | _: TypeMember | _: TypeParam | _: Ident | _: This | _: New | _: Literal | _: SelfDef |
+          EmptyTree =>
         Nil
     }
 
@@ -268,40 +268,11 @@ object Trees {
   }
 
   /** name */
-  abstract case class Ident(name: TermName)(span: Span) extends Tree(span)
-
-  /** A free identifier, that has no defining symbol.
-    *
-    * This seems to always be a wildcard.
-    */
-  final class FreeIdent(name: TermName, tpe: Type)(span: Span) extends Ident(name)(span) {
+  final case class Ident(name: TermName)(tpe: Type)(span: Span) extends Tree(span):
     protected final def calculateType(using Context): Type = tpe
 
-    override final def withSpan(span: Span): FreeIdent = FreeIdent(name, tpe)(span)
-  }
-
-  abstract class SimpleRef(name: TermName, tpe: Type)(span: Span) extends Ident(name)(span) {
-    protected final def calculateType(using Context): Type = tpe
-  }
-
-  final class TermRefTree(name: TermName, tpe: Type)(span: Span) extends SimpleRef(name, tpe)(span) {
-    override final def withSpan(span: Span): TermRefTree = TermRefTree(name, tpe)(span)
-  }
-
-  /** reference to a package, seen as a term */
-  final class ReferencedPackage(val fullyQualifiedName: FullyQualifiedName)(span: Span)
-      extends Ident(fullyQualifiedName.sourceName.asSimpleName)(span) {
-    protected final def calculateType(using Context): Type =
-      PackageRef(fullyQualifiedName)
-
-    override final def withSpan(span: Span): ReferencedPackage = ReferencedPackage(fullyQualifiedName)(span)
-
-    override def toString: String = s"ReferencedPackage($fullyQualifiedName)"
-  }
-
-  object ReferencedPackage {
-    def unapply(r: ReferencedPackage): Option[TermName] = Some(r.name)
-  }
+    override final def withSpan(span: Span): Ident = Ident(name)(tpe)(span)
+  end Ident
 
   /** qualifier.termName */
   case class Select(qualifier: Tree, name: TermName)(span: Span) extends Tree(span) {

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -87,7 +87,7 @@ object Trees {
       case While(cond, body)                      => cond :: body :: Nil
       case Throw(expr)                            => expr :: Nil
       case Try(expr, cases, finalizer)            => (expr :: cases) :+ finalizer
-      case Return(expr, from)                     => expr :: from :: Nil
+      case Return(expr, from)                     => expr :: Nil
       case Inlined(expr, caller, bindings)        => expr :: bindings
 
       case _: ImportIdent | _: TypeMember | _: TypeParam | _: Ident | _: ReferencedPackage | _: This | _: New |
@@ -557,7 +557,7 @@ object Trees {
     override final def withSpan(span: Span): Literal = Literal(constant)(span)
   }
 
-  case class Return(expr: Tree, from: Tree)(span: Span) extends Tree(span) {
+  case class Return(expr: Tree, from: TermSymbol)(span: Span) extends Tree(span) {
     protected final def calculateType(using Context): Type =
       defn.NothingType
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -542,7 +542,7 @@ object Trees {
     *
     * { bindings; expr }
     */
-  final case class Inlined(expr: Tree, caller: TypeIdent, bindings: List[Tree])(span: Span) extends Tree(span) {
+  final case class Inlined(expr: Tree, caller: Option[TypeIdent], bindings: List[Tree])(span: Span) extends Tree(span) {
     protected final def calculateType(using Context): Type =
       // TODO? Do we need to do type avoidance on expr using the bindings, like dotc does?
       expr.tpe

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -109,7 +109,7 @@ object Trees {
       case TypeApply(fun, args)                   => args
       case New(tpt)                               => tpt :: Nil
       case Typed(expr, tpt)                       => tpt :: Nil
-      case Lambda(meth, tpt)                      => tpt :: Nil
+      case Lambda(meth, tpt)                      => tpt.toList
       case SeqLiteral(elems, elemtpt)             => elemtpt :: Nil
 
       // no type tree inside
@@ -412,13 +412,14 @@ object Trees {
   }
 
   /**  @param meth   A reference to the method.
-    *  @param tpt    Not an EmptyTree only if the lambda's type is a SAMtype rather than a function type.
+    *  @param tpt    Defined only if the lambda's type is a SAMtype rather than a function type.
     */
-  final case class Lambda(meth: Tree, tpt: TypeTree)(span: Span) extends Tree(span) {
-    protected final def calculateType(using Context): Type =
-      if tpt == EmptyTypeTree then
+  final case class Lambda(meth: Tree, tpt: Option[TypeTree])(span: Span) extends Tree(span) {
+    protected final def calculateType(using Context): Type = tpt match
+      case Some(tpt) =>
+        tpt.toType
+      case None =>
         ??? // TODO Resolve the method's type to construct the appropriate scala.FunctionN type
-      else tpt.toType
 
     override final def withSpan(span: Span): Lambda = Lambda(meth, tpt)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
@@ -99,7 +99,7 @@ object TypeTrees {
   }
 
   /** [bound] selector match { cases } */
-  final case class MatchTypeTree(bound: TypeTree, selector: TypeTree, cases: List[TypeCaseDef])(span: Span)
+  final case class MatchTypeTree(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef])(span: Span)
       extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
       defn.NothingType // TODO
@@ -118,13 +118,6 @@ object TypeTrees {
     override final def withSpan(span: Span): TypeTreeBind = TypeTreeBind(name, body, symbol)(span)
   }
 
-  case object EmptyTypeTree extends TypeTree(NoSpan) {
-    override protected def calculateType(using Context): Type =
-      NoType
-
-    override final def withSpan(span: Span): TypeTree = EmptyTypeTree
-  }
-
   final case class TypeBoundsTree(low: TypeTree, high: TypeTree) {
     def toTypeBounds(using Context): TypeBounds =
       RealTypeBounds(low.toType, high.toType)
@@ -133,9 +126,9 @@ object TypeTrees {
   /** >: lo <: hi
     *  >: lo <: hi = alias  for RHS of bounded opaque type
     */
-  final case class BoundedTypeTree(bounds: TypeBoundsTree, alias: TypeTree)(span: Span) extends TypeTree(span) {
+  final case class BoundedTypeTree(bounds: TypeBoundsTree, alias: Option[TypeTree])(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
-      BoundedType(bounds.toTypeBounds, alias.toType)
+      BoundedType(bounds.toTypeBounds, alias.map(_.toType))
 
     override final def withSpan(span: Span): BoundedTypeTree = BoundedTypeTree(bounds, alias)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
@@ -32,8 +32,6 @@ object TypeTrees {
     override final def withSpan(span: Span): TypeIdent = TypeIdent(name)(tpe)(span)
   }
 
-  object EmptyTypeIdent extends TypeIdent(nme.EmptyTypeName)(NoType)(NoSpan)
-
   case class TypeWrapper(tp: Type)(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type = tp
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -1389,7 +1389,7 @@ object Types {
     override def toString(): String = s"TypeAlias($alias)"
   }
 
-  final class BoundedType(val bounds: TypeBounds, val alias: Type) extends Type {
+  final class BoundedType(val bounds: TypeBounds, val alias: Option[Type]) extends Type {
     private[tastyquery] def findMember(name: Name, pre: Type)(using Context): Symbol =
       bounds.high.findMember(name, pre)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -646,7 +646,7 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val name = readName
       val typ = readType
-      FreeIdent(name, typ)(spn)
+      Ident(name)(typ)(spn)
     case APPLY =>
       val spn = span
       reader.readByte()
@@ -837,25 +837,26 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val name = readName
       val prefix = readType
-      TermRefTree(name, TermRef(prefix, name))(spn)
+      Ident(name)(TermRef(prefix, name))(spn)
     case TERMREFpkg =>
       val spn = span
       reader.readByte()
-      val name = readFullyQualifiedName
-      // TODO: create a termref and store as a tpe
-      new ReferencedPackage(name)(spn)
+      val fullyQualifiedName = readFullyQualifiedName
+      val simpleName = fullyQualifiedName.sourceName.asSimpleName
+      val tpe = PackageRef(fullyQualifiedName)
+      Ident(simpleName)(tpe)(span)
     case TERMREFdirect =>
       val spn = span
       reader.readByte()
       val sym = readSymRef.asTerm
       val tpe = TermRef(NoPrefix, sym)
-      TermRefTree(sym.name, tpe)(spn)
+      Ident(sym.name)(tpe)(spn)
     case TERMREFsymbol =>
       val spn = span
       reader.readByte()
       val sym = readSymRef.asTerm
       val pre = readType
-      TermRefTree(sym.name, TermRef(pre, sym))(spn)
+      Ident(sym.name)(TermRef(pre, sym))(spn)
     case SHAREDtype =>
       val spn = span
       reader.readByte()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -669,7 +669,7 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val name = readName
       val qual = readTerm
-      Select(qual, name)(spn)
+      Select(qual, name)(selectOwner = None)(spn)
     case QUALTHIS =>
       val spn = span
       reader.readByte()
@@ -689,7 +689,7 @@ private[tasties] class TreeUnpickler(
       val name = readSignedName()
       val qual = readTerm
       val owner = readTypeRef()
-      SelectIn(qual, name, owner)(spn)
+      Select(qual, name)(Some(owner))(spn)
     case NEW =>
       val spn = span
       reader.readByte()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -810,14 +810,14 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val end = reader.readEnd()
       val expr = readTerm
-      val caller: TypeIdent =
+      val caller: Option[TypeIdent] =
         reader.ifBefore(end)(
           tagFollowShared match {
             // The caller is not specified, this is a binding (or next val or def)
-            case VALDEF | DEFDEF => EmptyTypeIdent
-            case _               => readTypeTree.asInstanceOf[TypeIdent]
+            case VALDEF | DEFDEF => None
+            case _               => Some(readTypeTree.asInstanceOf[TypeIdent])
           },
-          EmptyTypeIdent
+          None
         )
       val bindings = reader.until(end)(readValOrDefDef)
       Inlined(expr, caller, bindings)(spn)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -577,15 +577,15 @@ private[tasties] class TreeUnpickler(
     acc.toList
   }
 
-  private def readSelf(using LocalContext): SelfDef =
+  private def readSelf(using LocalContext): Option[SelfDef] =
     if (reader.nextByte != SELFDEF) {
-      SelfDef.ReusableEmpty
+      None
     } else {
       val spn = span
       reader.readByte()
       val name = readName
       val tpt = readTypeTree
-      SelfDef(name, tpt)(tpt.span)
+      Some(SelfDef(name, tpt)(tpt.span))
     }
 
   private def readValOrDefDef(using LocalContext): Tree = {

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -804,9 +804,7 @@ private[tasties] class TreeUnpickler(
       val trtSpan = spn
       val from = readSymRef.asTerm
       val expr = reader.ifBefore(end)(readTerm, EmptyTree)
-      // TODO: always just taking the name?
-      // return always returns from a method, i.e. something with a TermName
-      Return(expr, TermRefTree(from.name.asInstanceOf[TermName], TermRef(NoPrefix, from))(trtSpan))(spn)
+      Return(expr, from)(spn)
     case INLINED =>
       val spn = span
       reader.readByte()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -356,13 +356,14 @@ private[tasties] class TreeUnpickler(
             val renamedSpan = span
             reader.readByte()
             val renamed = ImportIdent(readName)(renamedSpan)
-            ImportSelector(name, renamed)(nameSpan.union(renamedSpan))
+            ImportSelector(name, Some(renamed), bound = None)(nameSpan.union(renamedSpan))
           case BOUNDED =>
             reader.readByte()
             val boundSpan = span
             val bound = readTypeTree
-            ImportSelector(name, EmptyTree, bound)(nameSpan.union(boundSpan))
-          case _ => ImportSelector(name)(nameSpan)
+            ImportSelector(name, renamed = None, Some(bound))(nameSpan.union(boundSpan))
+          case _ =>
+            ImportSelector(name, renamed = None, bound = None)(nameSpan)
         }
       }
       val spn = span

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -442,7 +442,7 @@ private[tasties] class TreeUnpickler(
         assert(reader.readByte() == TYPEBOUNDStpt, posErrorMsg)
         val end = reader.readEnd()
         val low = readTypeTree
-        val high = reader.ifBefore(end)(readTypeTree, EmptyTypeTree)
+        val high = readTypeTree
         // assert atEnd: no alias for type parameters
         assert(reader.currentAddr == end, posErrorMsg)
         TypeBoundsTree(low, high)
@@ -494,7 +494,7 @@ private[tasties] class TreeUnpickler(
     val spn = span
     val end = reader.readEnd()
     val low = readTypeTree
-    val high = reader.ifBefore(end)(readTypeTree, EmptyTypeTree)
+    val high = readTypeTree
     val alias = reader.ifBefore(end)(readTypeTree, EmptyTypeTree)
     BoundedTypeTree(TypeBoundsTree(low, high), alias)(spn)
   }
@@ -505,7 +505,7 @@ private[tasties] class TreeUnpickler(
       reader.readByte()
       val end = reader.readEnd()
       val low = readTypeTree
-      val high = reader.ifBefore(end)(readTypeTree, EmptyTypeTree)
+      val high = readTypeTree
       TypeBoundsTree(low, high)
     })
   }

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1271,14 +1271,11 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Inlined(
             // 0 + HasInlinedMethod_this.externalVal
             Apply(
-              Select(Inlined(Literal(Constant(0)), EmptyTypeIdent, Nil), SignedName(SimpleName("+"), _, _)),
-              Select(
-                Inlined(Ident(SimpleName("HasInlinedMethod_this")), EmptyTypeIdent, Nil),
-                SimpleName("externalVal")
-              ) :: Nil
+              Select(Inlined(Literal(Constant(0)), None, Nil), SignedName(SimpleName("+"), _, _)),
+              Select(Inlined(Ident(SimpleName("HasInlinedMethod_this")), None, Nil), SimpleName("externalVal")) :: Nil
             ),
             // the _toplevel_ class, method inside which is inlined
-            TypeIdent(TypeName(SimpleName("HasInlinedMethod"))),
+            Some(TypeIdent(TypeName(SimpleName("HasInlinedMethod")))),
             ValDef(
               SimpleName("HasInlinedMethod_this"),
               _,

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -940,7 +940,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickle("return", simple_trees / tname"Return") { tree =>
-    val returnMatch: StructureCheck = { case Return(Literal(Constant(1)), Ident(SimpleName("withReturn"))) =>
+    val returnMatch: StructureCheck = {
+      case Return(Literal(Constant(1)), from) if from.name == SimpleName("withReturn") =>
     }
     assert(containsSubtree(returnMatch)(clue(tree)))
   }

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -216,7 +216,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   testUnpickleTopLevel("multiple-imports", imports / tname"MultipleImports") { tree =>
     val importMatch: StructureCheck = {
       case Import(
-            ReferencedPackage(SimpleName("imported_files")),
+            Ident(SimpleName("imported_files")),
             List(
               ImportSelector(ImportIdent(SimpleName("A")), None, None),
               ImportSelector(ImportIdent(SimpleName("B")), None, None)
@@ -229,7 +229,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   testUnpickleTopLevel("renamed-import", imports / tname"RenamedImport") { tree =>
     val importMatch: StructureCheck = {
       case Import(
-            ReferencedPackage(SimpleName("imported_files")),
+            Ident(SimpleName("imported_files")),
             List(ImportSelector(ImportIdent(SimpleName("A")), Some(ImportIdent(SimpleName("ClassA"))), None))
           ) =>
     }
@@ -241,7 +241,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       // A given import selector has an empty name
       case Import(
             // TODO: SELECTtpt?
-            Select(ReferencedPackage(SimpleName("imported_files")), SimpleName("Givens")),
+            Select(Ident(SimpleName("imported_files")), SimpleName("Givens")),
             List(ImportSelector(ImportIdent(nme.EmptyTermName), None, None))
           ) =>
     }
@@ -253,7 +253,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       // A given import selector has an empty name
       case Import(
             // TODO: SELECTtpt?
-            Select(ReferencedPackage(SimpleName("imported_files")), SimpleName("Givens")),
+            Select(Ident(SimpleName("imported_files")), SimpleName("Givens")),
             ImportSelector(ImportIdent(nme.EmptyTermName), None, Some(TypeIdent(TypeName(SimpleName("A"))))) :: Nil
           ) =>
     }

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -799,9 +799,9 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             _,
             Block(
               List(DefDef(SimpleName("$anonfun"), List(Left(List(ValDef(SimpleName("x"), _, _, _)))), _, _, _)),
-              // a lambda is simply a wrapper around a DefDef, defined in the same block. Its type is a function type,
-              // therefore not specified (left as EmptyTree)
-              Lambda(Ident(SimpleName("$anonfun")), EmptyTypeTree)
+              // A lambda is simply a wrapper around a DefDef, defined in the same block.
+              // Its type is a function type, therefore not specified.
+              Lambda(Ident(SimpleName("$anonfun")), None)
             ),
             _
           ) =>
@@ -817,10 +817,12 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               // the lambda's type is not just a function type, therefore specified
               Lambda(
                 Ident(SimpleName("$anonfun")),
-                TypeWrapper(
-                  TypeRefInternal(
-                    ty.PackageRef(FullyQualifiedName(List(SimpleName("java"), SimpleName("lang")))),
-                    TypeName(SimpleName("Runnable"))
+                Some(
+                  TypeWrapper(
+                    TypeRefInternal(
+                      ty.PackageRef(FullyQualifiedName(List(SimpleName("java"), SimpleName("lang")))),
+                      TypeName(SimpleName("Runnable"))
+                    )
                   )
                 )
               )
@@ -859,7 +861,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                   _
                 )
               ),
-              Lambda(Ident(SimpleName("$anonfun")), EmptyTypeTree)
+              Lambda(Ident(SimpleName("$anonfun")), None)
             ) :: Nil
           ) =>
     }
@@ -893,7 +895,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                   _
                 )
               ),
-              Lambda(Ident(SimpleName("$anonfun")), EmptyTypeTree)
+              Lambda(Ident(SimpleName("$anonfun")), None)
             ),
             _
           ) =>
@@ -986,7 +988,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
                 TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
               ),
-              EmptyTypeTree
+              None
             ),
             _
           ) =>
@@ -999,7 +1001,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             TypeName(SimpleName("AbstractWithBounds")),
             BoundedTypeTree(
               TypeBoundsTree(TypeIdent(TypeName(SimpleName("Null"))), TypeIdent(TypeName(SimpleName("Product")))),
-              EmptyTypeTree
+              None
             ),
             _
           ) =>
@@ -1018,7 +1020,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             TypeName(SimpleName("OpaqueWithBounds")),
             BoundedTypeTree(
               TypeBoundsTree(TypeIdent(TypeName(SimpleName("Null"))), TypeIdent(TypeName(SimpleName("Product")))),
-              TypeIdent(TypeName(SimpleName("Null")))
+              Some(TypeIdent(TypeName(SimpleName("Null"))))
             ),
             _
           ) =>
@@ -1581,7 +1583,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               ),
               MatchTypeTree(
                 // No bound on the match result
-                EmptyTypeTree,
+                None,
                 TypeIdent(TypeName(SimpleName("X"))),
                 List(TypeCaseDef(TypeIdent(TypeName(SimpleName("Int"))), TypeIdent(TypeName(SimpleName("String")))))
               )
@@ -1606,7 +1608,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 )
               ),
               MatchTypeTree(
-                TypeIdent(TypeName(SimpleName("Nothing"))),
+                Some(TypeIdent(TypeName(SimpleName("Nothing")))),
                 TypeIdent(TypeName(SimpleName("X"))),
                 List(TypeCaseDef(TypeIdent(TypeName(SimpleName("Int"))), TypeIdent(TypeName(SimpleName("Nothing")))))
               )
@@ -1632,7 +1634,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               ),
               MatchTypeTree(
                 // No bound on the match result
-                EmptyTypeTree,
+                None,
                 TypeIdent(TypeName(SimpleName("X"))),
                 List(
                   TypeCaseDef(
@@ -1643,7 +1645,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                           TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
                           TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
                         ),
-                        EmptyTypeTree
+                        None
                       ),
                       _
                     ),
@@ -1673,7 +1675,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               ),
               MatchTypeTree(
                 // No bound on the match result
-                EmptyTypeTree,
+                None,
                 TypeIdent(TypeName(SimpleName("X"))),
                 List(
                   TypeCaseDef(

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -208,7 +208,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickleTopLevel("basic-import", imports / tname"Import") { tree =>
     val importMatch: StructureCheck = {
-      case Import(_, List(ImportSelector(Ident(SimpleName("A")), EmptyTree, EmptyTypeTree))) =>
+      case Import(_, List(ImportSelector(ImportIdent(SimpleName("A")), None, None))) =>
     }
     assert(containsSubtree(clue(importMatch))(clue(tree)))
   }
@@ -218,8 +218,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Import(
             ReferencedPackage(SimpleName("imported_files")),
             List(
-              ImportSelector(Ident(SimpleName("A")), EmptyTree, EmptyTypeTree),
-              ImportSelector(Ident(SimpleName("B")), EmptyTree, EmptyTypeTree)
+              ImportSelector(ImportIdent(SimpleName("A")), None, None),
+              ImportSelector(ImportIdent(SimpleName("B")), None, None)
             )
           ) =>
     }
@@ -230,7 +230,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val importMatch: StructureCheck = {
       case Import(
             ReferencedPackage(SimpleName("imported_files")),
-            List(ImportSelector(Ident(SimpleName("A")), Ident(SimpleName("ClassA")), EmptyTypeTree))
+            List(ImportSelector(ImportIdent(SimpleName("A")), Some(ImportIdent(SimpleName("ClassA"))), None))
           ) =>
     }
     assert(containsSubtree(importMatch)(clue(tree)))
@@ -242,7 +242,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Import(
             // TODO: SELECTtpt?
             Select(ReferencedPackage(SimpleName("imported_files")), SimpleName("Givens")),
-            List(ImportSelector(Ident(nme.EmptyTermName), EmptyTree, EmptyTypeTree))
+            List(ImportSelector(ImportIdent(nme.EmptyTermName), None, None))
           ) =>
     }
     assert(containsSubtree(importMatch)(clue(tree)))
@@ -254,7 +254,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Import(
             // TODO: SELECTtpt?
             Select(ReferencedPackage(SimpleName("imported_files")), SimpleName("Givens")),
-            ImportSelector(Ident(nme.EmptyTermName), EmptyTree, TypeIdent(TypeName(SimpleName("A")))) :: Nil
+            ImportSelector(ImportIdent(nme.EmptyTermName), None, Some(TypeIdent(TypeName(SimpleName("A"))))) :: Nil
           ) =>
     }
     assert(containsSubtree(importMatch)(clue(tree)))
@@ -264,7 +264,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val simpleExport: StructureCheck = {
       case Export(
             Select(This(Some(TypeIdent(TypeName(SimpleName("Export"))))), SimpleName("first")),
-            ImportSelector(Ident(SimpleName("status")), EmptyTree, EmptyTypeTree) :: Nil
+            ImportSelector(ImportIdent(SimpleName("status")), None, None) :: Nil
           ) =>
     }
     assert(containsSubtree(simpleExport)(clue(tree)))
@@ -273,8 +273,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Export(
             Select(This(Some(TypeIdent(TypeName(SimpleName("Export"))))), SimpleName("second")),
             // An omitting selector is simply a rename to _
-            ImportSelector(Ident(SimpleName("status")), Ident(nme.Wildcard), EmptyTypeTree) ::
-            ImportSelector(Ident(nme.Wildcard), EmptyTree, EmptyTypeTree) :: Nil
+            ImportSelector(ImportIdent(SimpleName("status")), Some(ImportIdent(nme.Wildcard)), None) ::
+            ImportSelector(ImportIdent(nme.Wildcard), None, None) :: Nil
           ) =>
     }
     assert(containsSubtree(omittedAndWildcardExport)(clue(tree)))
@@ -283,7 +283,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case Export(
             Select(This(Some(TypeIdent(TypeName(SimpleName("Export"))))), SimpleName("givens")),
             // A given selector has an empty name
-            ImportSelector(Ident(nme.EmptyTermName), EmptyTree, TypeIdent(TypeName(SimpleName("AnyRef")))) :: Nil
+            ImportSelector(ImportIdent(nme.EmptyTermName), None, Some(TypeIdent(TypeName(SimpleName("AnyRef"))))) :: Nil
           ) =>
     }
     assert(containsSubtree(givenExport)(clue(tree)))

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -173,7 +173,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                     // a single parent -- java.lang.Object
                     List(parent: Apply),
                     // self not specified
-                    SelfDef(nme.Wildcard, EmptyTypeTree),
+                    None,
                     // empty body
                     List()
                   ),

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -167,7 +167,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                       SimpleName("<init>"),
                       Left(Nil) :: Nil,
                       TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Unit")))),
-                      EmptyTree,
+                      None,
                       _
                     ),
                     // a single parent -- java.lang.Object
@@ -294,9 +294,9 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case DefDef(
             SimpleName("id"),
             // no type params, one param -- x: Int
-            List(Left(List(ValDef(SimpleName("x"), TypeIdent(TypeName(SimpleName("Int"))), EmptyTree, valSymbol)))),
+            List(Left(List(ValDef(SimpleName("x"), TypeIdent(TypeName(SimpleName("Int"))), None, valSymbol)))),
             TypeIdent(TypeName(SimpleName("Int"))),
-            Ident(SimpleName("x")),
+            Some(Ident(SimpleName("x"))),
             defSymbol
           ) if valSymbol.tree.exists(_.isInstanceOf[ValDef]) && defSymbol.tree.exists(_.isInstanceOf[DefDef]) =>
     }
@@ -321,51 +321,53 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickle("constants", simple_trees / tname"Constants") { tree =>
-    val unitConstMatch: StructureCheck = { case ValDef(SimpleName("unitVal"), _, Literal(Constant(())), _) =>
+    val unitConstMatch: StructureCheck = { case ValDef(SimpleName("unitVal"), _, Some(Literal(Constant(()))), _) =>
     }
     assert(containsSubtree(unitConstMatch)(clue(tree)))
 
-    val falseConstMatch: StructureCheck = { case ValDef(SimpleName("falseVal"), _, Literal(Constant(false)), _) =>
+    val falseConstMatch: StructureCheck = { case ValDef(SimpleName("falseVal"), _, Some(Literal(Constant(false))), _) =>
     }
     assert(containsSubtree(falseConstMatch)(clue(tree)))
 
-    val trueConstMatch: StructureCheck = { case ValDef(SimpleName("trueVal"), _, Literal(Constant(true)), _) =>
+    val trueConstMatch: StructureCheck = { case ValDef(SimpleName("trueVal"), _, Some(Literal(Constant(true))), _) =>
     }
     assert(containsSubtree(trueConstMatch)(clue(tree)))
 
-    val byteConstMatch: StructureCheck = { case ValDef(SimpleName("byteVal"), _, Literal(Constant(1)), _) =>
+    val byteConstMatch: StructureCheck = { case ValDef(SimpleName("byteVal"), _, Some(Literal(Constant(1))), _) =>
     }
     assert(containsSubtree(byteConstMatch)(clue(tree)))
 
-    val shortConstMatch: StructureCheck = { case ValDef(SimpleName("shortVal"), _, Literal(Constant(1)), _) =>
+    val shortConstMatch: StructureCheck = { case ValDef(SimpleName("shortVal"), _, Some(Literal(Constant(1))), _) =>
     }
     assert(containsSubtree(shortConstMatch)(clue(tree)))
 
-    val charConstMatch: StructureCheck = { case ValDef(SimpleName("charVal"), _, Literal(Constant('a')), _) =>
+    val charConstMatch: StructureCheck = { case ValDef(SimpleName("charVal"), _, Some(Literal(Constant('a'))), _) =>
     }
     assert(containsSubtree(charConstMatch)(clue(tree)))
 
-    val intConstMatch: StructureCheck = { case ValDef(SimpleName("intVal"), _, Literal(Constant(1)), _) =>
+    val intConstMatch: StructureCheck = { case ValDef(SimpleName("intVal"), _, Some(Literal(Constant(1))), _) =>
     }
     assert(containsSubtree(intConstMatch)(clue(tree)))
 
-    val longConstMatch: StructureCheck = { case ValDef(SimpleName("longVal"), _, Literal(Constant(1)), _) =>
+    val longConstMatch: StructureCheck = { case ValDef(SimpleName("longVal"), _, Some(Literal(Constant(1))), _) =>
     }
     assert(containsSubtree(longConstMatch)(clue(tree)))
 
-    val floatConstMatch: StructureCheck = { case ValDef(SimpleName("floatVal"), _, Literal(Constant(1.1f)), _) =>
+    val floatConstMatch: StructureCheck = { case ValDef(SimpleName("floatVal"), _, Some(Literal(Constant(1.1f))), _) =>
     }
     assert(containsSubtree(floatConstMatch)(clue(tree)))
 
-    val doubleConstMatch: StructureCheck = { case ValDef(SimpleName("doubleVal"), _, Literal(Constant(1.1d)), _) =>
+    val doubleConstMatch: StructureCheck = {
+      case ValDef(SimpleName("doubleVal"), _, Some(Literal(Constant(1.1d))), _) =>
     }
     assert(containsSubtree(doubleConstMatch)(clue(tree)))
 
-    val stringConstMatch: StructureCheck = { case ValDef(SimpleName("stringVal"), _, Literal(Constant("string")), _) =>
+    val stringConstMatch: StructureCheck = {
+      case ValDef(SimpleName("stringVal"), _, Some(Literal(Constant("string"))), _) =>
     }
     assert(containsSubtree(stringConstMatch)(clue(tree)))
 
-    val nullConstMatch: StructureCheck = { case ValDef(SimpleName("nullVal"), _, Literal(Constant(null)), _) =>
+    val nullConstMatch: StructureCheck = { case ValDef(SimpleName("nullVal"), _, Some(Literal(Constant(null))), _) =>
     }
     assert(containsSubtree(nullConstMatch)(clue(tree)))
   }
@@ -385,8 +387,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val blockMatch: StructureCheck = {
       case Block(
             List(
-              ValDef(SimpleName("a"), _, Literal(Constant(1)), _),
-              ValDef(SimpleName("b"), _, Literal(Constant(2)), _)
+              ValDef(SimpleName("a"), _, Some(Literal(Constant(1))), _),
+              ValDef(SimpleName("b"), _, Some(Literal(Constant(2))), _)
             ),
             Literal(Constant(()))
           ) =>
@@ -406,14 +408,14 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     }
     assert(containsSubtree(matchStructure)(clue(tree)))
 
-    val simpleGuard: StructureCheck = { case CaseDef(Literal(Constant(0)), EmptyTree, body: Block) =>
+    val simpleGuard: StructureCheck = { case CaseDef(Literal(Constant(0)), None, body: Block) =>
     }
     assert(containsSubtree(simpleGuard)(clue(tree)))
 
     val guardWithAlternatives: StructureCheck = {
       case CaseDef(
             Alternative(List(Literal(Constant(1)), Literal(Constant(-1)), Literal(Constant(2)))),
-            EmptyTree,
+            None,
             body: Block
           ) =>
     }
@@ -422,7 +424,9 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val guardAndCondition: StructureCheck = {
       case CaseDef(
             Literal(Constant(7)),
-            Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("=="), _, _)), Literal(Constant(7)) :: Nil),
+            Some(
+              Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("=="), _, _)), Literal(Constant(7)) :: Nil)
+            ),
             body: Block
           ) =>
     }
@@ -431,7 +435,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val alternativesAndCondition: StructureCheck = {
       case CaseDef(
             Alternative(List(Literal(Constant(3)), Literal(Constant(4)), Literal(Constant(5)))),
-            Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("<"), _, _)), Literal(Constant(5)) :: Nil),
+            Some(Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("<"), _, _)), Literal(Constant(5)) :: Nil)),
             body: Block
           ) =>
     }
@@ -440,19 +444,21 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val defaultWithCondition: StructureCheck = {
       case CaseDef(
             Ident(nme.Wildcard),
-            Apply(
-              Select(
-                Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("%"), _, _)), Literal(Constant(2)) :: Nil),
-                SignedName(SimpleName("=="), _, _)
-              ),
-              Literal(Constant(0)) :: Nil
+            Some(
+              Apply(
+                Select(
+                  Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("%"), _, _)), Literal(Constant(2)) :: Nil),
+                  SignedName(SimpleName("=="), _, _)
+                ),
+                Literal(Constant(0)) :: Nil
+              )
             ),
             body: Block
           ) =>
     }
     assert(containsSubtree(defaultWithCondition)(clue(tree)))
 
-    val default: StructureCheck = { case CaseDef(Ident(nme.Wildcard), EmptyTree, body: Block) =>
+    val default: StructureCheck = { case CaseDef(Ident(nme.Wildcard), None, body: Block) =>
     }
     assert(containsSubtree(default)(clue(tree)))
   }
@@ -468,7 +474,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               ),
               _
             ),
-            EmptyTree,
+            None,
             body: Block
           ) if bindSymbol.tree.exists(_.isInstanceOf[Bind]) =>
     }
@@ -479,7 +485,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val assignBlockMatch: StructureCheck = {
       case Block(
             List(
-              ValDef(SimpleName("y"), tpt, Literal(Constant(0)), _),
+              ValDef(SimpleName("y"), tpt, Some(Literal(Constant(0))), _),
               Assign(Ident(SimpleName("y")), Ident(SimpleName("x")))
             ),
             Ident(SimpleName("x"))
@@ -507,8 +513,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val tryMatch: StructureCheck = {
       case Try(
             _,
-            CaseDef(Ident(nme.Wildcard), EmptyTree, Block(Nil, Literal(Constant(0)))) :: Nil,
-            Block(Nil, Literal(Constant(())))
+            CaseDef(Ident(nme.Wildcard), None, Block(Nil, Literal(Constant(0)))) :: Nil,
+            Some(Block(Nil, Literal(Constant(()))))
           ) =>
     }
     assert(containsSubtree(tryMatch)(clue(tree)))
@@ -520,7 +526,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("singletonReturnType"),
             List(Left(List(_))),
             SingletonTypeTree(Ident(SimpleName("x"))),
-            Ident(SimpleName("x")),
+            Some(Ident(SimpleName("x"))),
             _
           ) =>
     }
@@ -546,12 +552,12 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("fields", simple_trees / tname"Field") { tree =>
     val classFieldMatch: StructureCheck = {
-      case ValDef(SimpleName("x"), TypeIdent(TypeName(SimpleName("Field"))), Literal(c), _) if c.tag == NullTag =>
+      case ValDef(SimpleName("x"), TypeIdent(TypeName(SimpleName("Field"))), Some(Literal(c)), _) if c.tag == NullTag =>
     }
     assert(containsSubtree(classFieldMatch)(clue(tree)))
 
     val intFieldMatch: StructureCheck = {
-      case ValDef(SimpleName("y"), TypeIdent(TypeName(SimpleName("Int"))), Literal(c), _)
+      case ValDef(SimpleName("y"), TypeIdent(TypeName(SimpleName("Int"))), Some(Literal(c)), _)
           if c.value == 0 && c.tag == IntTag =>
     }
     assert(containsSubtree(intFieldMatch)(clue(tree)))
@@ -606,7 +612,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case ValDef(
             SimpleName("x"),
             AppliedTypeTree(TypeIdent(TypeName(SimpleName("Option"))), TypeIdent(TypeName(SimpleName("Int"))) :: Nil),
-            Ident(SimpleName("None")),
+            Some(Ident(SimpleName("None"))),
             _
           ) =>
     }
@@ -626,7 +632,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 SymbolWithName(TypeName(SimpleName("Inner")))
               )
             ),
-            Apply(Select(New(TypeIdent(TypeName(SimpleName("Inner")))), _), Nil),
+            Some(Apply(Select(New(TypeIdent(TypeName(SimpleName("Inner")))), _), Nil)),
             _
           ) =>
     }
@@ -649,7 +655,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("final", simple_trees / tname"Final") { tree =>
     val constTypeMatch: StructureCheck = {
-      case ValDef(SimpleName("Const"), TypeWrapper(ty.ConstantType(Constant(1))), Literal(Constant(1)), _) =>
+      case ValDef(SimpleName("Const"), TypeWrapper(ty.ConstantType(Constant(1))), Some(Literal(Constant(1))), _) =>
     }
     assert(containsSubtree(constTypeMatch)(clue(tree)))
   }
@@ -660,7 +666,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case ValDef(
             SimpleName("x"),
             TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int")))),
-            Literal(Constant(1)),
+            Some(Literal(Constant(1))),
             symbol
           )
           if symbol.tree.exists(_.isInstanceOf[ValDef])
@@ -673,7 +679,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("x_="),
             Left((ValDef(SimpleName("x$1"), _, _, _): Matchable) :: Nil) :: Nil,
             TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Unit")))),
-            Literal(Constant(())),
+            Some(Literal(Constant(()))),
             symbol
           ) if symbol.flags.isAllOf(Accessor | Method | Mutable) =>
     }
@@ -768,7 +774,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               SimpleName("<init>"),
               List(Left((ValDef(SimpleName("param"), _, _, _): Matchable) :: Nil)),
               _,
-              EmptyTree,
+              None,
               _
             ),
             TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Object")))) :: Nil,
@@ -797,11 +803,13 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case ValDef(
             SimpleName("functionLambda"),
             _,
-            Block(
-              List(DefDef(SimpleName("$anonfun"), List(Left(List(ValDef(SimpleName("x"), _, _, _)))), _, _, _)),
-              // A lambda is simply a wrapper around a DefDef, defined in the same block.
-              // Its type is a function type, therefore not specified.
-              Lambda(Ident(SimpleName("$anonfun")), None)
+            Some(
+              Block(
+                List(DefDef(SimpleName("$anonfun"), List(Left(List(ValDef(SimpleName("x"), _, _, _)))), _, _, _)),
+                // A lambda is simply a wrapper around a DefDef, defined in the same block.
+                // Its type is a function type, therefore not specified.
+                Lambda(Ident(SimpleName("$anonfun")), None)
+              )
             ),
             _
           ) =>
@@ -812,16 +820,18 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case ValDef(
             SimpleName("samLambda"),
             _,
-            Block(
-              List(DefDef(SimpleName("$anonfun"), List(Left(Nil)), _, _, _)),
-              // the lambda's type is not just a function type, therefore specified
-              Lambda(
-                Ident(SimpleName("$anonfun")),
-                Some(
-                  TypeWrapper(
-                    TypeRefInternal(
-                      ty.PackageRef(FullyQualifiedName(List(SimpleName("java"), SimpleName("lang")))),
-                      TypeName(SimpleName("Runnable"))
+            Some(
+              Block(
+                List(DefDef(SimpleName("$anonfun"), List(Left(Nil)), _, _, _)),
+                // the lambda's type is not just a function type, therefore specified
+                Lambda(
+                  Ident(SimpleName("$anonfun")),
+                  Some(
+                    TypeWrapper(
+                      TypeRefInternal(
+                        ty.PackageRef(FullyQualifiedName(List(SimpleName("java"), SimpleName("lang")))),
+                        TypeName(SimpleName("Runnable"))
+                      )
                     )
                   )
                 )
@@ -851,12 +861,14 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                   SimpleName("$anonfun"),
                   Left(List(ValDef(SimpleName("x"), _, _, _))) :: Nil,
                   _,
-                  Apply(
-                    Select(
-                      This(Some(TypeIdent(TypeName(SimpleName("EtaExpansion"))))),
-                      SignedName(SimpleName("intMethod"), _, _)
-                    ),
-                    List(Ident(SimpleName("x")))
+                  Some(
+                    Apply(
+                      Select(
+                        This(Some(TypeIdent(TypeName(SimpleName("EtaExpansion"))))),
+                        SignedName(SimpleName("intMethod"), _, _)
+                      ),
+                      List(Ident(SimpleName("x")))
+                    )
                   ),
                   _
                 )
@@ -876,26 +888,30 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("partiallyApplied"),
             Nil,
             _,
-            Block(
-              List(
-                DefDef(
-                  SimpleName("$anonfun"),
-                  Left((ValDef(SimpleName("second"), _, _, _): Matchable) :: Nil) :: Nil,
-                  _,
-                  Apply(
-                    Apply(
-                      Select(
-                        This(Some(TypeIdent(TypeName(SimpleName("PartialApplication"))))),
-                        SignedName(SimpleName("withManyParams"), _, _)
-                      ),
-                      Literal(Constant(0)) :: Nil
+            Some(
+              Block(
+                List(
+                  DefDef(
+                    SimpleName("$anonfun"),
+                    Left((ValDef(SimpleName("second"), _, _, _): Matchable) :: Nil) :: Nil,
+                    _,
+                    Some(
+                      Apply(
+                        Apply(
+                          Select(
+                            This(Some(TypeIdent(TypeName(SimpleName("PartialApplication"))))),
+                            SignedName(SimpleName("withManyParams"), _, _)
+                          ),
+                          Literal(Constant(0)) :: Nil
+                        ),
+                        Ident(SimpleName("second")) :: Nil
+                      )
                     ),
-                    Ident(SimpleName("second")) :: Nil
-                  ),
-                  _
-                )
-              ),
-              Lambda(Ident(SimpleName("$anonfun")), None)
+                    _
+                  )
+                ),
+                Lambda(Ident(SimpleName("$anonfun")), None)
+              )
             ),
             _
           ) =>
@@ -907,20 +923,22 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val partialFunction: StructureCheck = {
       case DefDef(
             SimpleName("$anonfun"),
-            Left(List(ValDef(SimpleName("x$1"), _, EmptyTree, _))) :: Nil,
+            Left(List(ValDef(SimpleName("x$1"), _, None, _))) :: Nil,
             _,
             // match x$1 with type x$1
-            Match(
-              Typed(
-                Ident(SimpleName("x$1")),
-                TypeWrapper(
-                  ty.AnnotatedType(
-                    TermRefInternal(NoPrefix, SymbolWithName(SimpleName("x$1"))),
-                    New(TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("unchecked")))))
+            Some(
+              Match(
+                Typed(
+                  Ident(SimpleName("x$1")),
+                  TypeWrapper(
+                    ty.AnnotatedType(
+                      TermRefInternal(NoPrefix, SymbolWithName(SimpleName("x$1"))),
+                      New(TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("unchecked")))))
+                    )
                   )
-                )
-              ),
-              cases
+                ),
+                cases
+              )
             ),
             _
           ) =>
@@ -943,7 +961,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
   testUnpickle("return", simple_trees / tname"Return") { tree =>
     val returnMatch: StructureCheck = {
-      case Return(Literal(Constant(1)), from) if from.name == SimpleName("withReturn") =>
+      case Return(Some(Literal(Constant(1))), from) if from.name == SimpleName("withReturn") =>
     }
     assert(containsSubtree(returnMatch)(clue(tree)))
   }
@@ -1053,9 +1071,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                       )
                     )
                   ),
-                  Left(
-                    List(ValDef(SimpleName("value"), TypeIdent(TypeName(SimpleName("T"))), EmptyTree, valueParamSymbol))
-                  )
+                  Left(List(ValDef(SimpleName("value"), TypeIdent(TypeName(SimpleName("T"))), None, valueParamSymbol)))
                 ),
                 _,
                 _,
@@ -1116,7 +1132,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case DefDef(
             SimpleName("genericExtension"),
             List(
-              Left(List(ValDef(SimpleName("i"), TypeIdent(TypeName(SimpleName("Int"))), EmptyTree, _))),
+              Left(List(ValDef(SimpleName("i"), TypeIdent(TypeName(SimpleName("Int"))), None, _))),
               Right(
                 List(
                   TypeParam(
@@ -1129,7 +1145,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                   )
                 )
               ),
-              Left(List(ValDef(SimpleName("genericArg"), TypeIdent(TypeName(SimpleName("T"))), EmptyTree, _)))
+              Left(List(ValDef(SimpleName("genericArg"), TypeIdent(TypeName(SimpleName("T"))), None, _)))
             ),
             _,
             _,
@@ -1281,7 +1297,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             ValDef(
               SimpleName("HasInlinedMethod_this"),
               _,
-              Select(This(Some(TypeIdent(TypeName(SimpleName("InlinedCall"))))), SimpleName("withInlineMethod")),
+              Some(Select(This(Some(TypeIdent(TypeName(SimpleName("InlinedCall"))))), SimpleName("withInlineMethod"))),
               _
             ) :: Nil
           ) =>
@@ -1299,18 +1315,20 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 TypeName(SimpleName("Random"))
               )
             ),
-            Apply(
-              // select scala.util.Random
-              Select(
-                New(
-                  SelectTypeTree(
-                    TypeWrapper(ty.PackageRef(FullyQualifiedName(List(SimpleName("scala"), SimpleName("util"))))),
-                    TypeName(SimpleName("Random"))
-                  )
+            Some(
+              Apply(
+                // select scala.util.Random
+                Select(
+                  New(
+                    SelectTypeTree(
+                      TypeWrapper(ty.PackageRef(FullyQualifiedName(List(SimpleName("scala"), SimpleName("util"))))),
+                      TypeName(SimpleName("Random"))
+                    )
+                  ),
+                  SignedName(SimpleName("<init>"), _, _)
                 ),
-                SignedName(SimpleName("<init>"), _, _)
-              ),
-              Nil
+                Nil
+              )
             ),
             _
           ) =>
@@ -1322,9 +1340,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val byName: StructureCheck = {
       case DefDef(
             SimpleName("withByName"),
-            List(
-              Left(List(ValDef(SimpleName("x"), ByNameTypeTree(TypeIdent(TypeName(SimpleName("Int")))), EmptyTree, _)))
-            ),
+            List(Left(List(ValDef(SimpleName("x"), ByNameTypeTree(TypeIdent(TypeName(SimpleName("Int")))), None, _)))),
             _,
             _,
             _
@@ -1338,7 +1354,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case ValDef(
             SimpleName("byNameParam"),
             TypeWrapper(ty.ExprType(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int"))))),
-            EmptyTree,
+            None,
             _
           ) =>
     }
@@ -1359,7 +1375,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                       TypeIdent(TypeName(SimpleName("|"))),
                       List(TypeIdent(TypeName(SimpleName("Int"))), TypeIdent(TypeName(SimpleName("String"))))
                     ),
-                    EmptyTree,
+                    None,
                     _
                   )
                 )
@@ -1398,7 +1414,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                         TypeIdent(TypeName(SimpleName("UnionType")))
                       )
                     ),
-                    EmptyTree,
+                    None,
                     _
                   )
                 )
@@ -1499,7 +1515,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                         Nil
                       )
                     ),
-                    EmptyTree,
+                    None,
                     _
                   ): Matchable
                 )
@@ -1533,12 +1549,14 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("innerRefVal"),
             RefinedTypeTree(
               TypeIdent(TypeName(SimpleName("C"))),
-              DefDef(SimpleName("c1"), Nil, TypeIdent(TypeName(SimpleName("C1"))), EmptyTree, _) :: Nil,
+              DefDef(SimpleName("c1"), Nil, TypeIdent(TypeName(SimpleName("C1"))), None, _) :: Nil,
               _
             ),
-            Block(
-              ClassDef(anonType1, _, _) :: Nil,
-              Typed(Apply(Select(New(TypeIdent(anonType2)), _), Nil), TypeWrapper(rt: RecType))
+            Some(
+              Block(
+                ClassDef(anonType1, _, _) :: Nil,
+                Typed(Apply(Select(New(TypeIdent(anonType2)), _), Nil), TypeWrapper(rt: RecType))
+              )
             ),
             _
           ) if anonType1 == anonType2 =>
@@ -1698,23 +1716,25 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("castMatchResult"),
             List(Right(List(X @ _)), _),
             _,
-            TypeApply(
-              Select(rhs, SignedName(SimpleName("$asInstanceOf$"), _, _)),
-              TypeWrapper(
-                ty.MatchType(
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))),
-                  TypeRefInternal(_, xRef),
-                  List(
-                    ty.MatchTypeCase(
-                      TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int"))),
-                      TypeRefInternal(
-                        TermRefInternal(ScalaPackageRef(), SimpleName("Predef")),
-                        TypeName(SimpleName("String"))
+            Some(
+              TypeApply(
+                Select(rhs, SignedName(SimpleName("$asInstanceOf$"), _, _)),
+                TypeWrapper(
+                  ty.MatchType(
+                    TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))),
+                    TypeRefInternal(_, xRef),
+                    List(
+                      ty.MatchTypeCase(
+                        TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int"))),
+                        TypeRefInternal(
+                          TermRefInternal(ScalaPackageRef(), SimpleName("Predef")),
+                          TypeName(SimpleName("String"))
+                        )
                       )
                     )
                   )
-                )
-              ) :: Nil
+                ) :: Nil
+              )
             ),
             _
           ) if xRef == X.symbol =>
@@ -1726,26 +1746,28 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("castMatchResultWithBind"),
             List(Right(List(X @ _)), _),
             _,
-            TypeApply(
-              Select(rhs, SignedName(SimpleName("$asInstanceOf$"), _, _)),
-              TypeWrapper(
-                ty.MatchType(
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))),
-                  TypeRefInternal(_, xRef),
-                  List(
-                    ty.TypeLambda(
-                      List(tRef),
-                      ty.MatchTypeCase(
-                        ty.AppliedType(
-                          TypeRefInternal(ScalaCollImmutablePackageRef(), TypeName(SimpleName("List"))),
-                          tRef2 :: Nil
-                        ),
-                        tRef3
+            Some(
+              TypeApply(
+                Select(rhs, SignedName(SimpleName("$asInstanceOf$"), _, _)),
+                TypeWrapper(
+                  ty.MatchType(
+                    TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))),
+                    TypeRefInternal(_, xRef),
+                    List(
+                      ty.TypeLambda(
+                        List(tRef),
+                        ty.MatchTypeCase(
+                          ty.AppliedType(
+                            TypeRefInternal(ScalaCollImmutablePackageRef(), TypeName(SimpleName("List"))),
+                            tRef2 :: Nil
+                          ),
+                          tRef3
+                        )
                       )
                     )
                   )
-                )
-              ) :: Nil
+                ) :: Nil
+              )
             ),
             _
           ) if xRef == X.symbol && tRef == tRef2 && tRef == tRef3 =>
@@ -1783,7 +1805,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 ) :: Nil
               )
             ),
-            EmptyTree,
+            None,
             _
           ) =>
     }
@@ -1802,7 +1824,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                 )
               ) :: Nil
             ),
-            EmptyTree,
+            None,
             _
           ) =>
     }
@@ -1866,7 +1888,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("m"),
             _ :: Nil,
             SingletonTypeTree(This(Some(TypeIdent(TypeName(SimpleName("ThisType")))))),
-            This(Some(TypeIdent(TypeName(SimpleName("ThisType"))))),
+            Some(This(Some(TypeIdent(TypeName(SimpleName("ThisType")))))),
             _
           ) =>
     }

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -345,7 +345,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))
-    val xAlias = TermRef(NoPrefix, findLocalValDef(setupMethodDef.rhs, name"xAlias"))
+    val xAlias = TermRef(NoPrefix, findLocalValDef(setupMethodDef.rhs.get, name"xAlias"))
 
     val refx: SimplePaths = new SimplePaths
     val refy: SimplePaths = new SimplePaths
@@ -416,7 +416,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     val setupMethodDef = setupMethod.tree.get.asInstanceOf[DefDef]
     val Left(valDefs) = setupMethodDef.paramLists.head: @unchecked
     val List(x, y, z) = valDefs.map(valDef => TermRef(NoPrefix, valDef.symbol))
-    val yAlias = TermRef(NoPrefix, findLocalValDef(setupMethodDef.rhs, name"yAlias"))
+    val yAlias = TermRef(NoPrefix, findLocalValDef(setupMethodDef.rhs.get, name"yAlias"))
 
     val refx: SimplePaths = new SimplePaths
     val refy: ConcreteSimplePathsChild = new ConcreteSimplePathsChild

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -543,7 +543,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val getX = JavaDefinedClass.findNonOverloadedDecl(name"getX")
     val xMethodSym = BoxedJavaClass.findNonOverloadedDecl(name"xMethod")
 
-    val Some(DefDef(_, _, _, Apply(getXSelection, _), _)) = xMethodSym.tree: @unchecked
+    val Some(DefDef(_, _, _, Some(Apply(getXSelection, _)), _)) = xMethodSym.tree: @unchecked
 
     val (getXRef @ _: TermRef) = getXSelection.tpe: @unchecked
 
@@ -557,7 +557,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val x = JavaDefinedClass.findDecl(name"x")
     val xFieldSym = BoxedJavaClass.findDecl(name"xField")
 
-    val Some(DefDef(_, _, _, xSelection, _)) = xFieldSym.tree: @unchecked
+    val Some(DefDef(_, _, _, Some(xSelection), _)) = xFieldSym.tree: @unchecked
 
     val (xRef @ _: TermRef) = xSelection.tpe: @unchecked
 
@@ -581,7 +581,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     val fooSym = BoxedConsClass.findDecl(name"foo")
 
-    val Some(DefDef(_, _, _, Apply(canEqualSelection, _), _)) = fooSym.tree: @unchecked
+    val Some(DefDef(_, _, _, Some(Apply(canEqualSelection, _)), _)) = fooSym.tree: @unchecked
 
     val underlyingType = canEqualSelection.tpe match
       case termRef: TermRef => termRef.underlying
@@ -601,7 +601,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val unitVal = ConstantsClass.findDecl(name"unitVal")
     val boxedUnitValSym = BoxedConstantsClass.findDecl(name"boxedUnitVal")
 
-    val Some(DefDef(_, _, _, unitValSelection, _)) = boxedUnitValSym.tree: @unchecked
+    val Some(DefDef(_, _, _, Some(unitValSelection), _)) = boxedUnitValSym.tree: @unchecked
 
     val (unitValRef @ _: TermRef) = unitValSelection.tpe: @unchecked
 
@@ -620,7 +620,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val getX = JavaBoxClass.findNonOverloadedDecl(name"getX")
     val xMethodSym = ScalaBoxClass.findNonOverloadedDecl(name"xMethod")
 
-    val Some(DefDef(_, _, _, Apply(getXSelection, _), _)) = xMethodSym.tree: @unchecked
+    val Some(DefDef(_, _, _, Some(Apply(getXSelection, _)), _)) = xMethodSym.tree: @unchecked
 
     val (getXRef @ _: TermRef) = getXSelection.tpe: @unchecked
 
@@ -631,7 +631,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
     val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.findNonOverloadedDecl(name"testField").tree: @unchecked
+    val Some(DefDef(_, _, _, Some(body), _)) = PolySelect.findNonOverloadedDecl(name"testField").tree: @unchecked
 
     val Select(qual, fieldName) = body: @unchecked
 
@@ -644,7 +644,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
     val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.findNonOverloadedDecl(name"testGetter").tree: @unchecked
+    val Some(DefDef(_, _, _, Some(body), _)) = PolySelect.findNonOverloadedDecl(name"testGetter").tree: @unchecked
 
     val Select(qual, getterName) = body: @unchecked
 
@@ -657,7 +657,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val GenClass = ctx.findTopLevelClass("simple_trees.GenericClass")
     val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.findNonOverloadedDecl(name"testMethod").tree: @unchecked
+    val Some(DefDef(_, _, _, Some(body), _)) = PolySelect.findNonOverloadedDecl(name"testMethod").tree: @unchecked
 
     val Apply(fun @ Select(qual, methodName), List(arg)) = body: @unchecked
 
@@ -678,7 +678,8 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val GenMethod = ctx.findTopLevelClass("simple_trees.GenericMethod")
     val PolySelect = ctx.findTopLevelClass("simple_trees.PolySelect")
 
-    val Some(DefDef(_, _, _, body, _)) = PolySelect.findNonOverloadedDecl(name"testGenericMethod").tree: @unchecked
+    val Some(DefDef(_, _, _, Some(body), _)) =
+      PolySelect.findNonOverloadedDecl(name"testGenericMethod").tree: @unchecked
 
     val Apply(tapp @ TypeApply(fun @ Select(qual, methodName), List(targ)), List(arg)) = body: @unchecked
 

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -266,10 +266,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     fTree.walkTree { tree =>
       tree match {
-        case tree: FreeIdent =>
+        case tree @ Ident(nme.Wildcard) =>
           freeIdentCount += 1
-          assert(tree.name == nme.Wildcard, clue(tree.name))
-          assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
+          assert(tree.tpe.isRef(defn.IntClass), clue(tree.tpe))
         case _ =>
           ()
       }

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -288,9 +288,9 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     withReturnTree.walkTree { tree =>
       tree match {
-        case Return(expr, from: Ident) =>
+        case Return(expr, from) =>
           returnCount += 1
-          assert(from.tpe.isRef(withReturnSym), clue(from.tpe))
+          assert(from == withReturnSym, clue(from))
           assert(tree.tpe.isNothing)
         case _ =>
           ()


### PR DESCRIPTION
Highlighted outcomes:

* `EmptyTree`, `EmptyTypeTree` and `EmptyTypeIdent` are gone.
* `Tree` and `TypeTree` are `sealed`.
* All `case class`es are `final`; no more `abstract case class`es.