### PR TITLE
Make `NoPrefix` and `Type` direct, exclusive subcases of `Prefix`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Exceptions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Exceptions.scala
@@ -18,9 +18,9 @@ object Exceptions:
   final class NonMethodReferenceException(kind: String)
       extends InvalidProgramStructureException(s"reference to non method type in $kind")
 
-  final class MemberNotFoundException(val prefix: Symbol | Type, val name: Name, msg: String)
+  final class MemberNotFoundException(val prefix: Symbol | Prefix, val name: Name, msg: String)
       extends InvalidProgramStructureException(msg):
-    def this(prefix: Symbol | Type, name: Name) =
+    def this(prefix: Symbol | Prefix, name: Name) =
       this(prefix, name, s"Member ${name.toDebugString} not found in $prefix")
 
   sealed abstract class UnpickleFormatException(msg: String, cause: Throwable | Null) extends Exception(msg, cause)

--- a/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
@@ -28,8 +28,9 @@ private[tastyquery] object Substituters:
         case tp: BoundType =>
           if tp.binders eq from then tp.copyBoundType(to.asInstanceOf[tp.BindersType]) else tp
         case tp: NamedType =>
-          if tp.prefix eq NoPrefix then tp
-          else tp.derivedSelect(apply(tp.prefix))
+          tp.prefix match
+            case NoPrefix     => tp
+            case prefix: Type => tp.derivedSelect(apply(prefix))
         case _: ThisType =>
           tp
         case tp: AppliedType =>
@@ -45,8 +46,9 @@ private[tastyquery] object Substituters:
         case tp: ParamRef =>
           if tp.binders eq from then to(tp.paramNum) else tp
         case tp: NamedType =>
-          if tp.prefix eq NoPrefix then tp
-          else tp.derivedSelect(apply(tp.prefix))
+          tp.prefix match
+            case NoPrefix     => tp
+            case prefix: Type => tp.derivedSelect(apply(prefix))
         case _: ThisType =>
           tp
         case tp: AppliedType =>
@@ -61,15 +63,17 @@ private[tastyquery] object Substituters:
     def apply(tp: Type): Type =
       tp match
         case tp: NamedType =>
-          if tp.prefix eq NoPrefix then
-            var fs = from
-            var ts = to
-            while fs.nonEmpty && ts.nonEmpty do
-              if tp.isLocalRef(fs.head) then return ts.head
-              fs = fs.tail
-              ts = ts.tail
-            tp
-          else tp.normalizedDerivedSelect(apply(tp.prefix))
+          tp.prefix match
+            case NoPrefix =>
+              var fs = from
+              var ts = to
+              while fs.nonEmpty && ts.nonEmpty do
+                if tp.isLocalRef(fs.head) then return ts.head
+                fs = fs.tail
+                ts = ts.tail
+              tp
+            case prefix: Type =>
+              tp.normalizedDerivedSelect(apply(prefix))
         case _: ThisType | _: BoundType =>
           tp
         case _ =>
@@ -81,15 +85,17 @@ private[tastyquery] object Substituters:
     def apply(tp: Type): Type =
       tp match
         case tp: NamedType =>
-          if tp.prefix == NoPrefix then
-            var fs = from
-            var ts = to
-            while fs.nonEmpty && ts.nonEmpty do
-              if tp.isLocalRef(fs.head) then return ts.head
-              fs = fs.tail
-              ts = ts.tail
-            tp
-          else tp.derivedSelect(this(tp.prefix))
+          tp.prefix match
+            case NoPrefix =>
+              var fs = from
+              var ts = to
+              while fs.nonEmpty && ts.nonEmpty do
+                if tp.isLocalRef(fs.head) then return ts.head
+                fs = fs.tail
+                ts = ts.tail
+              tp
+            case prefix: Type =>
+              tp.derivedSelect(this(prefix))
         case _: ThisType | _: BoundType =>
           tp
         case _ =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -292,7 +292,7 @@ private[tastyquery] object Subtyping:
       false
   end isNullable
 
-  private def isSubprefix(pre1: Type, pre2: Type)(using Context): Boolean =
+  private def isSubprefix(pre1: Prefix, pre2: Prefix)(using Context): Boolean =
     pre1 match
       case NoPrefix =>
         pre2 eq NoPrefix
@@ -301,8 +301,10 @@ private[tastyquery] object Subtyping:
         pre2 match
           case pre2: PackageRef => pre1.symbol == pre2.symbol
           case _                => false
-      case _ =>
-        (pre2 ne NoPrefix) && isSubtype(pre1, pre2)
+      case pre1: Type =>
+        pre2 match
+          case pre2: Type => isSubtype(pre1, pre2)
+          case NoPrefix   => false
   end isSubprefix
 
   private def isBottom(tp: Type)(using Context): Boolean =

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -311,7 +311,7 @@ object Symbols {
       if is(Module) then declaredType.classSymbol
       else None
 
-    private[tastyquery] final def declaredTypeAsSeenFrom(prefix: Type)(using Context): Type =
+    private[tastyquery] final def declaredTypeAsSeenFrom(prefix: Prefix)(using Context): Type =
       declaredType.asSeenFrom(prefix, owner)
 
     private def isConstructor: Boolean =
@@ -446,7 +446,7 @@ object Symbols {
     final def aliasedType(using Context): Type =
       typeDef.asInstanceOf[TypeMemberDefinition.TypeAlias].alias
 
-    private[tastyquery] def aliasedTypeAsSeenFrom(pre: Type)(using Context): Type =
+    private[tastyquery] def aliasedTypeAsSeenFrom(pre: Prefix)(using Context): Type =
       aliasedType.asSeenFrom(pre, owner)
 
     final def bounds(using Context): TypeBounds = typeDef match

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -36,6 +36,8 @@ private[tastyquery] object TypeMaps {
         case tp2: TypeBounds =>
           val result: tp2.ThisTypeMappableType = apply(tp2)
           result.asInstanceOf[tp.ThisTypeMappableType]
+        case NoPrefix =>
+          tp.asInstanceOf[tp.ThisTypeMappableType]
 
     def apply(tp: Type): Type
 
@@ -86,8 +88,12 @@ private[tastyquery] object TypeMaps {
           // By contrast, covariance does translate to the prefix, since we have that
           // if `p <: q` then `p.A <: q.A`, and well-formedness requires that `A` is a member
           // of `p`'s upper bound.
-          val prefix1 = atVariance(variance max 0)(this(tp.prefix))
-          derivedSelect(tp, prefix1)
+          tp.prefix match
+            case NoPrefix =>
+              tp
+            case prefix: Type =>
+              val prefix1 = atVariance(variance max 0)(this(prefix))
+              derivedSelect(tp, prefix1)
 
         case tp: AppliedType =>
           tp.map(this)
@@ -104,7 +110,7 @@ private[tastyquery] object TypeMaps {
         case tp: AnnotatedType =>
           derivedAnnotatedType(tp, this(tp.typ), tp.annotation) // tp.annotation.mapWith(this)
 
-        case _: ThisType | NoPrefix =>
+        case _: ThisType =>
           tp
 
         case tp: RefinedType =>

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
@@ -6,11 +6,11 @@ import tastyquery.Types.*
 import tastyquery.TypeMaps.*
 
 private[tastyquery] object TypeOps:
-  def asSeenFrom(tp: Type, pre: Type, cls: Symbol)(using Context): Type =
+  def asSeenFrom(tp: Type, pre: Prefix, cls: Symbol)(using Context): Type =
     new AsSeenFromMap(pre, cls).apply(tp)
 
   /** The TypeMap handling the asSeenFrom */
-  class AsSeenFromMap(pre: Type, cls: Symbol)(using Context) extends ApproximatingTypeMap {
+  class AsSeenFromMap(pre: Prefix, cls: Symbol)(using Context) extends ApproximatingTypeMap {
 
     /** Set to true when the result of `apply` was approximated to avoid an unstable prefix. */
     var approximated: Boolean = false
@@ -23,36 +23,36 @@ private[tastyquery] object TypeOps:
         *  @param  cls     The class in which the `C.this` type occurs
         *  @param  thiscls The prefix `C` of the `C.this` type.
         */
-      def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type =
-        if ((pre eq NoType) || (pre eq NoPrefix) || (cls.isPackage))
-          tp
-        else
-          pre match {
-            //case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
-            case _ =>
-              cls match
-                case cls: ClassSymbol =>
-                  if (thiscls.isSubclass(cls) && pre.baseType(thiscls) != NoType)
-                    /*if (variance <= 0 && !isLegalPrefix(pre)) // isLegalPrefix always true?
-                    if (variance < 0) {
-                      approximated = true
-                      NothingType
-                    }
-                    else
-                      // Don't set the `approximated` flag yet: if this is a prefix
-                      // of a path, we might be able to dealias the path instead
-                      // (this is handled in `ApproximatingTypeMap`). If dealiasing
-                      // is not possible, then `expandBounds` will end up being
-                      // called which we override to set the `approximated` flag.
-                      range(NothingType, pre)
-                  else*/ pre
-                  /*else if (pre.termSymbol.isPackage && !thiscls.isPackage)
-                  toPrefix(pre.select(nme.PACKAGE), cls, thiscls)*/
+      def toPrefix(pre: Prefix, cls: Symbol, thiscls: ClassSymbol): Type =
+        pre match
+          case NoPrefix | NoType =>
+            tp
+          case _ if cls.isPackage =>
+            tp
+          //case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
+          case pre: Type =>
+            cls match
+              case cls: ClassSymbol =>
+                if (thiscls.isSubclass(cls) && pre.baseType(thiscls) != NoType)
+                  /*if (variance <= 0 && !isLegalPrefix(pre)) // isLegalPrefix always true?
+                  if (variance < 0) {
+                    approximated = true
+                    NothingType
+                  }
                   else
-                    toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner.nn, thiscls)
-                case _ =>
-                  NoType
-          }
+                    // Don't set the `approximated` flag yet: if this is a prefix
+                    // of a path, we might be able to dealias the path instead
+                    // (this is handled in `ApproximatingTypeMap`). If dealiasing
+                    // is not possible, then `expandBounds` will end up being
+                    // called which we override to set the `approximated` flag.
+                    range(NothingType, pre)
+                else*/ pre
+                /*else if (pre.termSymbol.isPackage && !thiscls.isPackage)
+                toPrefix(pre.select(nme.PACKAGE), cls, thiscls)*/
+                else
+                  toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner.nn, thiscls)
+              case _ =>
+                NoType
       end toPrefix
 
       tp match {

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -163,7 +163,53 @@ object Types {
     type ThisTypeMappableType >: this.type <: TypeMappable
   end TypeMappable
 
-  abstract class Type extends TypeMappable {
+  sealed abstract class Prefix extends TypeMappable:
+    type ThisTypeMappableType >: this.type <: Prefix
+
+    final def memberType(member: TermSymbol)(using Context): Type =
+      member.declaredType.asSeenFrom(this, member.owner)
+
+    final def memberTypeBoundsLow(member: TypeSymbolWithBounds)(using Context): Type =
+      member.lowerBound.asSeenFrom(this, member.owner)
+
+    final def memberTypeBoundsHigh(member: TypeSymbolWithBounds)(using Context): Type =
+      member.upperBound.asSeenFrom(this, member.owner)
+
+    final def select(sym: TermOrTypeSymbol)(using Context): Type =
+      NamedType(this, sym) // dotc also calls reduceProjection here, should we do it?
+
+    final def select(name: Name)(using Context): NamedType =
+      NamedType(this, name)
+
+    final def select(name: TermName)(using Context): TermRef =
+      TermRef(this, name)
+
+    final def select(name: TypeName)(using Context): TypeRef =
+      TypeRef(this, name)
+
+    /** True iff `sym` is a symbol of a class type parameter and the reference
+      * `<pre> . <sym>` is an actual argument reference, i.e., `pre` is not the
+      * ThisType of `sym`'s owner, or a reference to `sym`'s owner.'
+      */
+    private[tastyquery] final def isArgPrefixOf(sym: Symbol)(using Context): Boolean =
+      sym match
+        case sym: ClassTypeParamSymbol =>
+          this match
+            case tp: ThisType => tp.cls != sym.owner
+            case tp: TypeRef  => tp.symbol != sym.owner
+            case _            => true
+        case _ =>
+          false
+    end isArgPrefixOf
+  end Prefix
+
+  object NoPrefix extends Prefix:
+    type ThisTypeMappableType = this.type
+
+    override def toString(): String = "NoPrefix"
+  end NoPrefix
+
+  abstract class Type extends Prefix {
     type ThisTypeMappableType = Type
 
     final def isSubtype(that: Type)(using Context): Boolean =
@@ -321,7 +367,7 @@ object Types {
       * - Inherited by all other type proxies.
       * - `NoType` for all other types.
       */
-    @tailrec final def normalizedPrefix(using Context): Type = this match {
+    @tailrec final def normalizedPrefix(using Context): Prefix = this match {
       case tp: TypeRef =>
         tp.symbol match
           case sym: TypeMemberSymbol =>
@@ -357,31 +403,8 @@ object Types {
     private[Types] def lookupRefined(name: Name)(using Context): Type =
       NoType
 
-    /** True iff `sym` is a symbol of a class type parameter and the reference
-      * `<pre> . <sym>` is an actual argument reference, i.e., `pre` is not the
-      * ThisType of `sym`'s owner, or a reference to `sym`'s owner.'
-      */
-    private[tastyquery] final def isArgPrefixOf(sym: Symbol)(using Context): Boolean =
-      sym match
-        case sym: ClassTypeParamSymbol =>
-          this match
-            case tp: ThisType => tp.cls != sym.owner
-            case tp: TypeRef  => tp.symbol != sym.owner
-            case _            => true
-        case _ =>
-          false
-
-    final def asSeenFrom(pre: Type, cls: Symbol)(using Context): Type =
+    final def asSeenFrom(pre: Prefix, cls: Symbol)(using Context): Type =
       TypeOps.asSeenFrom(this, pre, cls)
-
-    final def memberType(member: TermSymbol)(using Context): Type =
-      member.declaredType.asSeenFrom(this, member.owner)
-
-    final def memberTypeBoundsLow(member: TypeSymbolWithBounds)(using Context): Type =
-      member.lowerBound.asSeenFrom(this, member.owner)
-
-    final def memberTypeBoundsHigh(member: TypeSymbolWithBounds)(using Context): Type =
-      member.upperBound.asSeenFrom(this, member.owner)
 
     final def isRef(sym: Symbol)(using Context): Boolean =
       this match {
@@ -465,18 +488,6 @@ object Types {
     final def |(that: Type)(using Context): Type =
       // TypeCompare.lub(this, that)
       OrType.make(this, that)
-
-    final def select(sym: TermOrTypeSymbol)(using Context): Type =
-      NamedType(this, sym) // dotc also calls reduceProjection here, should we do it?
-
-    final def select(name: Name)(using Context): NamedType =
-      NamedType(this, name)
-
-    final def select(name: TermName)(using Context): TermRef =
-      TermRef(this, name)
-
-    final def select(name: TypeName)(using Context): TypeRef =
-      TypeRef(this, name)
 
     final def appliedTo(tpe: Type)(using Context): Type =
       this.appliedTo(tpe :: Nil)
@@ -580,7 +591,7 @@ object Types {
     type ThisNamedType >: this.type <: NamedType
     protected type ThisDesignatorType >: ThisSymbolType <: TermOrTypeSymbol | Name | LookupIn | Scala2ExternalSymRef
 
-    val prefix: Type
+    val prefix: Prefix
 
     protected def designator: ThisDesignatorType
 
@@ -653,9 +664,11 @@ object Types {
           }
         }
       case name: Name =>
-        if prefix == NoPrefix then
-          throw new MemberNotFoundException(prefix, name, s"reference by name $name to a local symbol")
-        prefix.member(name)
+        prefix match
+          case prefix: Type =>
+            prefix.member(name)
+          case NoPrefix =>
+            throw new MemberNotFoundException(prefix, name, s"reference by name $name to a local symbol")
     end computeSymbol
 
     /** The argument corresponding to class type parameter `tparam` as seen from
@@ -744,19 +757,19 @@ object Types {
       }
     end normalizedDerivedSelect
 
-    private[tastyquery] final def derivedSelect(prefix: Type): ThisNamedType =
+    private[tastyquery] final def derivedSelect(prefix: Prefix): ThisNamedType =
       if prefix eq this.prefix then this
       else withPrefix(prefix)
 
-    private final def withPrefix(prefix: Type): ThisNamedType =
+    private final def withPrefix(prefix: Prefix): ThisNamedType =
       withPrefix(prefix, cachedSymbol = mySymbol)
 
-    protected def withPrefix(prefix: Type, cachedSymbol: ThisSymbolType | Null): ThisNamedType
+    protected def withPrefix(prefix: Prefix, cachedSymbol: ThisSymbolType | Null): ThisNamedType
   }
 
   object NamedType {
 
-    private[tastyquery] def possibleSelFromPackage(prefix: Type, name: TermName)(using Context): Type = prefix match
+    private[tastyquery] def possibleSelFromPackage(prefix: Prefix, name: TermName)(using Context): Type = prefix match
       case prefix: PackageRef if name.isInstanceOf[SimpleName] =>
         prefix.symbol.getPackageDecl(name.asSimpleName) match
           case Some(nested) => PackageRef(nested)
@@ -764,17 +777,17 @@ object Types {
       case prefix =>
         apply(prefix, name)
 
-    def apply(prefix: Type, sym: TermOrTypeSymbol)(using Context): NamedType =
+    def apply(prefix: Prefix, sym: TermOrTypeSymbol)(using Context): NamedType =
       sym match
         case sym: TypeSymbol => TypeRef(prefix, sym)
         case sym: TermSymbol => TermRef(prefix, sym)
 
-    def apply(prefix: Type, name: Name)(using Context): NamedType =
+    def apply(prefix: Prefix, name: Name)(using Context): NamedType =
       name match
         case name: TypeName => TypeRef(prefix, name)
         case name: TermName => TermRef(prefix, name)
 
-    private[tastyquery] def apply(prefix: Type, external: Scala2ExternalSymRef)(using Context): NamedType =
+    private[tastyquery] def apply(prefix: Prefix, external: Scala2ExternalSymRef)(using Context): NamedType =
       external.name match
         case _: TypeName => TypeRef(prefix, external)
         case _: TermName => TermRef(prefix, external)
@@ -782,7 +795,7 @@ object Types {
 
   /** The singleton type for path prefix#myDesignator. */
   final class TermRef private (
-    val prefix: Type,
+    val prefix: Prefix,
     private var myDesignator: TermSymbol | TermName | LookupIn | Scala2ExternalSymRef
   ) extends NamedType
       with SingletonType {
@@ -832,15 +845,18 @@ object Types {
         case tp =>
           tp.findMember(name, pre)
 
-    protected def withPrefix(prefix: Type, cachedSymbol: ThisSymbolType | Null): TermRef =
+    protected def withPrefix(prefix: Prefix, cachedSymbol: ThisSymbolType | Null): TermRef =
       new TermRef(prefix, if cachedSymbol != null then cachedSymbol else designator)
   }
 
   object TermRef:
-    def apply(prefix: Type, name: TermName): TermRef = new TermRef(prefix, name)
-    def apply(prefix: Type, symbol: TermSymbol): TermRef = new TermRef(prefix, symbol)
-    private[tastyquery] def apply(prefix: Type, designator: LookupIn): TermRef = new TermRef(prefix, designator)
-    private[tastyquery] def apply(prefix: Type, external: Scala2ExternalSymRef): TermRef = new TermRef(prefix, external)
+    def apply(prefix: Prefix, name: TermName): TermRef = new TermRef(prefix, name)
+    def apply(prefix: Prefix, symbol: TermSymbol): TermRef = new TermRef(prefix, symbol)
+
+    private[tastyquery] def apply(prefix: Prefix, designator: LookupIn): TermRef = new TermRef(prefix, designator)
+
+    private[tastyquery] def apply(prefix: Prefix, external: Scala2ExternalSymRef): TermRef =
+      new TermRef(prefix, external)
   end TermRef
 
   final class PackageRef(val fullyQualifiedName: FullyQualifiedName) extends Type {
@@ -877,8 +893,10 @@ object Types {
     override def toString(): String = s"PackageRef($fullyQualifiedName)"
   }
 
-  final class TypeRef private (val prefix: Type, private var myDesignator: TypeName | TypeSymbol | Scala2ExternalSymRef)
-      extends NamedType {
+  final class TypeRef private (
+    val prefix: Prefix,
+    private var myDesignator: TypeName | TypeSymbol | Scala2ExternalSymRef
+  ) extends NamedType {
 
     type ThisName = TypeName
     type ThisSymbolType = TypeSymbol
@@ -911,22 +929,17 @@ object Types {
         case sym: TypeSymbolWithBounds =>
           sym.upperBound.findMember(name, pre)
 
-    protected def withPrefix(prefix: Type, cachedSymbol: ThisSymbolType | Null): TypeRef =
+    protected def withPrefix(prefix: Prefix, cachedSymbol: ThisSymbolType | Null): TypeRef =
       new TypeRef(prefix, if cachedSymbol != null then cachedSymbol else designator)
   }
 
   object TypeRef:
-    def apply(prefix: Type, name: TypeName): TypeRef = new TypeRef(prefix, name)
-    def apply(prefix: Type, symbol: TypeSymbol): TypeRef = new TypeRef(prefix, symbol)
-    private[tastyquery] def apply(prefix: Type, external: Scala2ExternalSymRef): TypeRef = new TypeRef(prefix, external)
+    def apply(prefix: Prefix, name: TypeName): TypeRef = new TypeRef(prefix, name)
+    def apply(prefix: Prefix, symbol: TypeSymbol): TypeRef = new TypeRef(prefix, symbol)
+
+    private[tastyquery] def apply(prefix: Prefix, external: Scala2ExternalSymRef): TypeRef =
+      new TypeRef(prefix, external)
   end TypeRef
-
-  object NoPrefix extends Type {
-    private[tastyquery] def findMember(name: Name, pre: Type)(using Context): Symbol =
-      throw new AssertionError(s"Cannot find member in NoPrefix")
-
-    override def toString(): String = "NoPrefix"
-  }
 
   final class ThisType(val tref: TypeRef) extends PathType with SingletonType {
     override def underlying(using Context): Type =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -353,10 +353,11 @@ private[pickles] class PickleReader {
     *  Package references should be TermRefs or ThisTypes but it was observed that
     *  nsc sometimes pickles them as TypeRefs instead.
     */
-  private def readPrefix()(using Context, PklStream, Entries, Index): Type = readTypeRef() match {
-    //case pre: TypeRef if pre.symbol.is(Package) => pre.symbol.thisType
-    case pre => pre
-  }
+  private def readPrefixRef()(using Context, PklStream, Entries, Index): Prefix =
+    at(pkl.readNat())(readTypeOrPrefix()) match
+      //case pre: TypeRef if pre.symbol.is(Package) => pre.symbol.thisType
+      case pre => pre
+  end readPrefixRef
 
   private def readTypeRef()(using Context, PklStream, Entries, Index): Type =
     at(pkl.readNat())(readType())
@@ -367,8 +368,13 @@ private[pickles] class PickleReader {
     *        the flag say that a type of kind * is expected, so that PolyType(tps, restpe) can be disambiguated to PolyType(tps, NullaryMethodType(restpe))
     *        (if restpe is not a ClassInfoType, a MethodType or a NullaryMethodType, which leaves TypeRef/SingletonType -- the latter would make the polytype a type constructor)
     */
-  private def readType()(using Context, PklStream, Entries, Index): Type = {
-    def select(pre: Type, sym: TermOrTypeSymbol): Type =
+  private def readType()(using Context, PklStream, Entries, Index): Type =
+    readTypeOrPrefix() match
+      case tpe: Type => tpe
+      case NoPrefix  => errorBadSignature("unexpected NoPrefix")
+
+  private def readTypeOrPrefix()(using Context, PklStream, Entries, Index): Prefix = {
+    def select(pre: Prefix, sym: TermOrTypeSymbol): Type =
       // structural members need to be selected by name, their symbols are only
       // valid in the synthetic refinement class that defines them.
       /*TODO if !pre.isInstanceOf[ThisType] && isRefinementClass(sym.owner) then pre.select(sym.name)
@@ -394,7 +400,7 @@ private[pickles] class PickleReader {
               case termRef: TermRef => termRef // necessary for package refs?
               case typeRef: TypeRef => ThisType(typeRef)
       case SINGLEtpe =>
-        val pre = readPrefix()
+        val pre = readPrefixRef()
         val designator = readMaybeExternalSymbolRef()
         designator match
           case sym: PackageSymbol          => sym.packageRef
@@ -410,7 +416,7 @@ private[pickles] class PickleReader {
           case c: Constant => ConstantType(c)
           case tp: TermRef => tp
       case TYPEREFtpe =>
-        var pre = readPrefix()
+        var pre = readPrefixRef()
         val designator = readMaybeExternalSymbolRef()
         /*pre match {
           case thispre: ThisType =>
@@ -691,13 +697,13 @@ private[reader] object PickleReader {
   }
 
   final class ExternalSymbolRef(owner: MaybeExternalSymbol, name: Name) {
-    def toTypeRef(pre: Type)(using Context): TypeRef =
+    def toTypeRef(pre: Prefix)(using Context): TypeRef =
       toNamedType(pre).asInstanceOf[TypeRef]
 
-    def toTermRef(pre: Type)(using Context): TermRef =
+    def toTermRef(pre: Prefix)(using Context): TermRef =
       toNamedType(pre).asInstanceOf[TermRef]
 
-    def toNamedType(pre: Type)(using Context): NamedType =
+    def toNamedType(pre: Prefix)(using Context): NamedType =
       NamedType(pre, toScala2ExternalSymRef)
 
     private def toScala2ExternalSymRef: Scala2ExternalSymRef =

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -50,10 +50,10 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   private type AnyDesignator = Symbol | Name | LookupIn | Scala2ExternalSymRef
 
   private object TypeRefInternal:
-    def unapply(tpe: TypeRef): Some[(Type, AnyDesignator)] = Some((tpe.prefix, tpe.designatorInternal))
+    def unapply(tpe: TypeRef): Some[(Prefix, AnyDesignator)] = Some((tpe.prefix, tpe.designatorInternal))
 
   private object TermRefInternal:
-    def unapply(tpe: TermRef): Some[(Type, AnyDesignator)] = Some((tpe.prefix, tpe.designatorInternal))
+    def unapply(tpe: TermRef): Some[(Prefix, AnyDesignator)] = Some((tpe.prefix, tpe.designatorInternal))
 
   /** Extractors for `Type`s.
     *

--- a/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -222,7 +222,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
     assert(simpleTreesNestedPkg.fullName.toString == "simple_trees.nested")
 
-    assert(PackageRef(simpleTreesPkg).findMember(name"nested", NoPrefix) == simpleTreesNestedPkg)
+    assert(simpleTreesPkg.packageRef.member(name"nested") == simpleTreesNestedPkg)
   }
 
   testWithContext("basic-inheritance-same-root", inheritance / tname"SameTasty" / obj, fundamentalClasses*) {


### PR DESCRIPTION
This allows to more safely manipulate `NoPrefix`, as we can be sure that it is never used where a proper `Type` is needed.