### PR TITLE
Fix #193: Replace all uses of accessibleThisType by thisType.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -803,13 +803,6 @@ object Symbols {
       }
     end findMember
 
-    /** Get the self type of this class, as if viewed from an external package */
-    private[tastyquery] final def accessibleThisType: TypeRef =
-      owner match
-        case pre: PackageSymbol => TypeRef(pre.packageRef, this)
-        case pre: ClassSymbol   => TypeRef(pre.accessibleThisType, this)
-        case _                  => TypeRef(NoPrefix, this)
-
     private var myTypeRef: TypeRef | Null = null
 
     private[tastyquery] final def typeRef(using Context): TypeRef =
@@ -818,7 +811,7 @@ object Symbols {
       else
         val pre = owner match
           case owner: PackageSymbol => owner.packageRef
-          case owner: ClassSymbol   => owner.accessibleThisType
+          case owner: ClassSymbol   => owner.thisType
           case _                    => NoPrefix
         val typeRef = TypeRef(pre, this)
         myTypeRef = typeRef

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -824,9 +824,7 @@ object Symbols {
       val local = myThisType
       if local != null then local
       else
-        val computed = owner match
-          case owner: ClassSymbol => ThisType(TypeRef(owner.thisType, this))
-          case _                  => ThisType(typeRef)
+        val computed = ThisType(typeRef)
         myThisType = computed
         computed
     end thisType

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -525,7 +525,7 @@ object Symbols {
       * - for `object class C[$]` => `object val C`
       */
     final def moduleValue(using Context): Option[TermSymbol] = owner match
-      case scope: PackageSymbol if this.is(ModuleClass) =>
+      case scope: DeclaringSymbol if this.is(ModuleClass) =>
         scope.getDecl(this.name.sourceObjectName).collect { case sym: TermSymbol =>
           sym
         }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -268,7 +268,7 @@ private[pickles] class PickleReader {
         storeResultInEntries(sym)
         val ownerPrefix = owner.asInstanceOf[DeclaringSymbol] match
           case owner: PackageSymbol => owner.packageRef
-          case owner: ClassSymbol   => owner.accessibleThisType
+          case owner: ClassSymbol   => owner.thisType
         sym.withDeclaredType(TypeRef(ownerPrefix, sym.name.withObjectSuffix.toTypeName))
         sym
       case _ =>
@@ -407,7 +407,7 @@ private[pickles] class PickleReader {
       case THIStpe =>
         readMaybeExternalSymbolRef() match
           case sym: ClassSymbol =>
-            sym.accessibleThisType
+            sym.thisType
           case sym: PackageSymbol =>
             sym.packageRef
           case sym: Symbol =>

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -469,4 +469,15 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     assertEquiv(yAlias.select(tname"AliasOfAbstractType"), defn.StringType)
       .withRef[refyAlias.AliasOfAbstractType, JString]
   }
+
+  testWithContext("simple-paths-in-subclasses") {
+    import subtyping.paths.NestedClasses
+
+    val paths = "subtyping.paths"
+    val ParentClass = ctx.findStaticClass(s"$paths.NestedClasses.Parent")
+    val inner = ctx.findStaticTerm(s"$paths.NestedClasses.inner")
+
+    assertNeitherSubtype(inner.declaredType, defn.IntType).withRef[NestedClasses.inner.type, Int]
+    assertStrictSubtype(inner.declaredType, ParentClass.typeRef).withRef[NestedClasses.inner.type, NestedClasses.Parent]
+  }
 end SubtypingSuite

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -73,10 +73,10 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     ctx.findTopLevelModuleClass("scala.Predef")
 
   def PredefPrefix(using Context): Type =
-    PredefModuleClass.accessibleThisType
+    ctx.findStaticTerm("scala.Predef").staticRef
 
   def ScalaPackageObjectPrefix(using Context): Type =
-    ctx.findTopLevelModuleClass("scala.package").accessibleThisType
+    ctx.findStaticTerm("scala.package").staticRef
 
   def javaLangPrefix(using Context): Type =
     defn.javaLangPackage.packageRef

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -1252,9 +1252,13 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   def companionClassFullCycle(owner: DeclaringSymbol, baseName: String)(using Context, munit.Location): Unit = {
     val cls: ClassSymbol = owner.getDecl(typeName(baseName)).get.asClass
     val moduleClass: ClassSymbol = owner.getDecl(moduleClassName(baseName)).get.asClass
+    val moduleValue: TermSymbol = owner.getDecl(termName(baseName)).get.asTerm
 
-    assert(cls == moduleClass.companionClass.get)
-    assert(moduleClass.companionClass.get == cls)
+    assert(clue(cls.companionClass) == Some(moduleClass))
+    assert(clue(moduleClass.companionClass) == Some(cls))
+
+    assert(clue(cls.moduleValue) == None)
+    assert(clue(moduleClass.moduleValue) == Some(moduleValue))
   }
 
   testWithContext("companion-tests-module-value") {

--- a/test-sources/src/main/scala/subtyping/paths/NestedClasses.scala
+++ b/test-sources/src/main/scala/subtyping/paths/NestedClasses.scala
@@ -1,0 +1,11 @@
+package subtyping.paths
+
+object NestedClasses:
+  class Parent
+
+  class Outer(x: Int):
+    class Inner(y: Int) extends Parent
+
+  val outer = new Outer(5)
+  val inner = new outer.Inner(6)
+end NestedClasses


### PR DESCRIPTION
It turns out that all the places where we used `accessibleThisType` were supposed to use the (internal) `thisType` instead. We replace them all, and remove the now-dead-code `accessibleThisType`.