### PR TITLE
Fix #195: Handle Private and ParamAccessor in `findMember`.

### DIFF
--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -18,6 +18,7 @@ import tastyquery.Trees.*
 import tastyquery.Types.*
 
 import Paths.*
+import TestUtils.*
 
 class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   object EquivResult:
@@ -95,17 +96,6 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
 
   def mutableSeqOf(tpe: Type)(using Context): Type =
     ctx.findTopLevelClass("scala.collection.mutable.Seq").typeRef.appliedTo(tpe)
-
-  def findLocalValDef(body: Tree, name: TermName)(using Context): TermSymbol =
-    var result: Option[TermSymbol] = None
-    body.walkTree {
-      case vd: ValDef if vd.name == name => result = Some(vd.symbol)
-      case _                             => ()
-    }
-    result.getOrElse {
-      throw new AssertionError(s"Could not find a local `val $name` in body\n$body")
-    }
-  end findLocalValDef
 
   testWithContext("same-monomorphic-class") {
     assertEquiv(defn.IntType, defn.IntClass.typeRef).withRef[Int, scala.Int]

--- a/tasty-query/shared/src/test/scala/tastyquery/TestUtils.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TestUtils.scala
@@ -1,0 +1,26 @@
+package tastyquery
+
+import tastyquery.Contexts.*
+import tastyquery.Names.*
+import tastyquery.Symbols.*
+import tastyquery.Trees.*
+
+object TestUtils:
+  def findLocalValDef(body: Tree, name: TermName)(using Context): TermSymbol =
+    findTree(body) {
+      case vd: ValDef if vd.name == name => vd.symbol
+    }
+  end findLocalValDef
+
+  def findTree[A](body: Tree)(test: PartialFunction[Tree, A])(using Context): A =
+    var result: Option[A] = None
+    body.walkTree { tree =>
+      tree match
+        case test(res) => result = Some(res)
+        case _         => ()
+    }
+    result.getOrElse {
+      throw new AssertionError(s"Could not find the right tree in body\n$body")
+    }
+  end findTree
+end TestUtils

--- a/test-sources/src/main/scala/inheritance/PrivateOverrides.scala
+++ b/test-sources/src/main/scala/inheritance/PrivateOverrides.scala
@@ -1,0 +1,13 @@
+package inheritance
+
+object PrivateOverrides:
+  class Parent:
+    val y = 2
+
+  class Child(y: Int) extends Parent:
+    def readLocalY: Int = y + this.y
+
+  def testSetup(): Int =
+    val child = new Child(4)
+    child.y
+end PrivateOverrides

--- a/test-sources/src/main/scala/inheritance/SameTasty.scala
+++ b/test-sources/src/main/scala/inheritance/SameTasty.scala
@@ -6,13 +6,16 @@ object SameTasty:
     type FooType
     def foo: FooType
     def getFoo(): FooType = foo
+    //def maybePrivateMember: Int = 5
 
   class Child extends Parent:
     type FooType = Int
     def foo: FooType = 23
+    private def maybePrivateMember: Int = 6
 
   class Sub extends Child:
     def foo3: FooType = foo
+    def maybePrivateMember: Int = 7
 
   trait Mixin:
     type BarType


### PR DESCRIPTION
When looking directly at a class, we should find its `Private` members, but not ones inherited from superclasses.

Even for the class itself, we should never find `ParamAccessor`s. If a `ParamAccessor` is actually meant, it will be a symbol-based `TermRef`, not a name-based one.