### PR TITLE
Add tree categories for term trees and pattern trees.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeTrees.scala
@@ -39,7 +39,7 @@ object TypeTrees {
   }
 
   /** ref.type */
-  final case class SingletonTypeTree(ref: Tree)(span: Span) extends TypeTree(span) {
+  final case class SingletonTypeTree(ref: TermTree)(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
       ref.tpe
 
@@ -83,7 +83,7 @@ object TypeTrees {
   }
 
   /** qualifier.name */
-  final case class TermRefTypeTree(qualifier: Tree, name: TermName)(span: Span) extends TypeTree(span) {
+  final case class TermRefTypeTree(qualifier: TermTree, name: TermName)(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
       NamedType.possibleSelFromPackage(qualifier.tpe, name)
 

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -408,13 +408,19 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     }
     assert(containsSubtree(matchStructure)(clue(tree)))
 
-    val simpleGuard: StructureCheck = { case CaseDef(Literal(Constant(0)), None, body: Block) =>
+    val simpleGuard: StructureCheck = { case CaseDef(ExprPattern(Literal(Constant(0))), None, body: Block) =>
     }
     assert(containsSubtree(simpleGuard)(clue(tree)))
 
     val guardWithAlternatives: StructureCheck = {
       case CaseDef(
-            Alternative(List(Literal(Constant(1)), Literal(Constant(-1)), Literal(Constant(2)))),
+            Alternative(
+              List(
+                ExprPattern(Literal(Constant(1))),
+                ExprPattern(Literal(Constant(-1))),
+                ExprPattern(Literal(Constant(2)))
+              )
+            ),
             None,
             body: Block
           ) =>
@@ -423,7 +429,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
     val guardAndCondition: StructureCheck = {
       case CaseDef(
-            Literal(Constant(7)),
+            ExprPattern(Literal(Constant(7))),
             Some(
               Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("=="), _, _)), Literal(Constant(7)) :: Nil)
             ),
@@ -434,7 +440,13 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
     val alternativesAndCondition: StructureCheck = {
       case CaseDef(
-            Alternative(List(Literal(Constant(3)), Literal(Constant(4)), Literal(Constant(5)))),
+            Alternative(
+              List(
+                ExprPattern(Literal(Constant(3))),
+                ExprPattern(Literal(Constant(4))),
+                ExprPattern(Literal(Constant(5)))
+              )
+            ),
             Some(Apply(Select(Ident(SimpleName("x")), SignedName(SimpleName("<"), _, _)), Literal(Constant(5)) :: Nil)),
             body: Block
           ) =>
@@ -443,7 +455,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
     val defaultWithCondition: StructureCheck = {
       case CaseDef(
-            Ident(nme.Wildcard),
+            WildcardPattern(_),
             Some(
               Apply(
                 Select(
@@ -458,7 +470,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     }
     assert(containsSubtree(defaultWithCondition)(clue(tree)))
 
-    val default: StructureCheck = { case CaseDef(Ident(nme.Wildcard), None, body: Block) =>
+    val default: StructureCheck = { case CaseDef(WildcardPattern(_), None, body: Block) =>
     }
     assert(containsSubtree(default)(clue(tree)))
   }
@@ -466,11 +478,11 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   testUnpickle("match-case-class", simple_trees / tname"PatternMatchingOnCaseClass") { tree =>
     val guardWithAlternatives: StructureCheck = {
       case CaseDef(
-            Typed(
+            TypeTest(
               Unapply(
                 Select(Ident(SimpleName("FirstCase")), SignedName(SimpleName("unapply"), _, _)),
                 Nil,
-                List(Bind(SimpleName("x"), Ident(nme.Wildcard), bindSymbol))
+                List(Bind(SimpleName("x"), WildcardPattern(_), bindSymbol))
               ),
               _
             ),
@@ -513,7 +525,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val tryMatch: StructureCheck = {
       case Try(
             _,
-            CaseDef(Ident(nme.Wildcard), None, Block(Nil, Literal(Constant(0)))) :: Nil,
+            CaseDef(WildcardPattern(_), None, Block(Nil, Literal(Constant(0)))) :: Nil,
             Some(Block(Nil, Literal(Constant(()))))
           ) =>
     }

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -215,10 +215,10 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     fTree.walkTree { tree =>
       tree match {
-        case Ident(`x`) =>
+        case tree @ Ident(`x`) =>
           xCount += 1
           assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
-        case Ident(`y`) =>
+        case tree @ Ident(`y`) =>
           yCount += 1
           assert(tree.tpe.isOfClass(defn.IntClass), clue(tree.tpe))
         case _ =>
@@ -240,7 +240,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     fTree.walkTree { tree =>
       tree match {
-        case Ident(SimpleName("BitSet")) =>
+        case tree @ Ident(SimpleName("BitSet")) =>
           bitSetIdentCount += 1
           val sym = tree.tpe.asInstanceOf[TermRef].symbol
           assert(sym.name == name"BitSet", clue(sym.name.toDebugString))
@@ -253,7 +253,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(bitSetIdentCount == 1, clue(bitSetIdentCount))
   }
 
-  testWithContext("free-ident") {
+  testWithContext("wildcard-pattern") {
     val MatchPathClass = ctx.findTopLevelClass("simple_trees.Match")
 
     val fSym = MatchPathClass.findNonOverloadedDecl(name"f")
@@ -263,19 +263,19 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     assert(xParamDef.symbol.asTerm.declaredType.isRef(defn.IntClass))
 
-    var freeIdentCount = 0
+    var wildcardPatternCount = 0
 
     fTree.walkTree { tree =>
       tree match {
-        case tree @ Ident(nme.Wildcard) =>
-          freeIdentCount += 1
-          assert(tree.tpe.isRef(defn.IntClass), clue(tree.tpe))
+        case tree @ WildcardPattern(tpe) =>
+          wildcardPatternCount += 1
+          assert(tpe.isRef(defn.IntClass), clue(tpe))
         case _ =>
           ()
       }
     }
 
-    assert(freeIdentCount == 2, clue(freeIdentCount))
+    assert(wildcardPatternCount == 2, clue(wildcardPatternCount))
   }
 
   testWithContext("return") {
@@ -288,7 +288,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     withReturnTree.walkTree { tree =>
       tree match {
-        case Return(expr, from) =>
+        case tree @ Return(expr, from) =>
           returnCount += 1
           assert(from == withReturnSym, clue(from))
           assert(tree.tpe.isNothing)
@@ -310,7 +310,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     fTree.walkTree { tree =>
       tree match {
-        case Assign(lhs, rhs) =>
+        case tree @ Assign(lhs, rhs) =>
           assignCount += 1
           assert(tree.tpe.isOfClass(defn.UnitClass), clue(tree.tpe))
         case _ =>


### PR DESCRIPTION
`TermTree`s are the only ones that have a generic `tpe`. Most term trees accept only `TermTree`s as arguments. For example, the `fun` and `args` or an `Apply` tree are all `TermTree`s.

Restricting `tpe` to `TermTree`s allows to get rid of many uses of `NoType`.

The pattern of `CaseDef` is limited to `PatternTree`s. Some "physical" TASTy tags are shared between similarly-looking term trees and pattern trees. The unpickler tells them apart. This way, when looking at patterns, the semantics are clearer.