### PR TITLE
Support reading all sorts of refinement types.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.None,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -589,7 +589,13 @@ object Trees {
     override final def withSpan(span: Span): SingletonTypeTree = SingletonTypeTree(ref)(span)
   }
 
-  final case class RefinedTypeTree(underlying: TypeTree, refinements: List[Tree], refinedCls: ClassSymbol)(span: Span)
+  type RefinementMemberDef = TypeMember | ValOrDefDef
+
+  final case class RefinedTypeTree(
+    underlying: TypeTree,
+    refinements: List[RefinementMemberDef],
+    refinedCls: ClassSymbol
+  )(span: Span)
       extends TypeTree(span) {
 
     override protected def calculateType(using Context): Type =

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -46,8 +46,10 @@ private[tastyquery] object TypeMaps {
 
     protected def derivedSelect(tp: NamedType, pre: Type): Type =
       tp.derivedSelect(pre)
-    protected def derivedRefinedType(tp: RefinedType, parent: Type, info: TypeBounds): Type =
-      tp.derivedRefinedType(parent, tp.refinedName, info)
+    protected def derivedTypeRefinement(tp: TypeRefinement, parent: Type, refinedBounds: TypeBounds): Type =
+      tp.derivedTypeRefinement(parent, tp.refinedName, refinedBounds)
+    protected def derivedTermRefinement(tp: TermRefinement, parent: Type, refinedType: Type): Type =
+      tp.derivedTermRefinement(parent, tp.refinedName, refinedType)
     protected def derivedWildcardTypeBounds(tp: WildcardTypeBounds, bounds: TypeBounds): Type =
       tp.derivedWildcardTypeBounds(bounds)
     protected def derivedAppliedType(tp: AppliedType, tycon: Type, args: List[Type]): Type =
@@ -113,8 +115,11 @@ private[tastyquery] object TypeMaps {
         case _: ThisType =>
           tp
 
-        case tp: RefinedType =>
-          derivedRefinedType(tp, this(tp.parent), this(tp.refinedInfo))
+        case tp: TypeRefinement =>
+          derivedTypeRefinement(tp, this(tp.parent), this(tp.refinedBounds))
+
+        case tp: TermRefinement =>
+          derivedTermRefinement(tp, this(tp.parent), this(tp.refinedType))
 
         case tp: AndType =>
           derivedAndType(tp, this(tp.first), this(tp.second))

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -1114,7 +1114,13 @@ private[tasties] class TreeUnpickler(
       val end = reader.readEnd()
       val parent = readTypeTree
       val statements = readStats(end)(using localCtx.withOwner(cls))
-      RefinedTypeTree(parent, statements, cls)(spn)
+      val refinements = statements.map {
+        case memberDef: RefinementMemberDef =>
+          memberDef
+        case otherDef =>
+          throw TastyFormatException(s"Unexpected member $otherDef in refinement type")
+      }
+      RefinedTypeTree(parent, refinements, cls)(spn)
     case APPLIEDtpt =>
       val spn = span
       reader.readByte()

--- a/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
@@ -122,7 +122,17 @@ class PositionSuite extends RestrictedUnpicklingSuite {
   /** Functions */
 
   testUnpickleWithCode("def-def", "simple_trees.Function") { (tree, code) =>
-    assertEquals(collectCode[DefDef](tree, code), List("(x: Int) => x + 1", "() => ()"))
+    assertEquals(
+      collectCode[DefDef](tree, code),
+      List(
+        "(x: Int) => x + 1",
+        "() => ()",
+        "T] => T => T", // TODO Improve this
+        "T] => (x: T) => x", // TODO Improve this
+        "(x: Any) => x.type",
+        "x => x"
+      )
+    )
   }
 
   testUnpickleWithCode("def-def-nested", "simple_trees.NestedMethod") { (tree, code) =>
@@ -271,7 +281,7 @@ class PositionSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickleWithCode("refined-type", "simple_trees.RefinedType") { (tree, code) =>
-    assertEquals(collectCode[RefinedTypeTree](tree, code), Nil)
+    assertEquals(collectCode[RefinedTypeTree](tree, code), List("{ def foo(using Int): Int }"))
   }
 
   testUnpickleWithCode("by-name-type", "simple_trees.ByNameParameter") { (tree, code) =>

--- a/test-sources/src/main/scala/simple_trees/Function.scala
+++ b/test-sources/src/main/scala/simple_trees/Function.scala
@@ -4,4 +4,8 @@ class Function {
   val functionLambda = (x: Int) => x + 1
 
   val samLambda: Runnable = () => ()
+
+  val polyID: [T] => T => T = [T] => (x: T) => x
+
+  val dependentID: (x: Any) => x.type = x => x
 }

--- a/test-sources/src/main/scala/simple_trees/RefinedType.scala
+++ b/test-sources/src/main/scala/simple_trees/RefinedType.scala
@@ -13,4 +13,7 @@ class RefinedType {
     new Trait {
       def f: Int = 0
     }
+
+  // Intentionally without explicit type
+  def givenRefinement = ??? : { def foo(using Int): Int }
 }


### PR DESCRIPTION
Including their members which can contain RECthis, METHODtype, and POLYtype.

Fix #6, fix #16, fix #20, fix #21.

This is not enough for #213 yet, since they are not handled correctly in member selection nor subtyping yet.