### PR TITLE
Read annotations from TASTy.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
@@ -1,0 +1,9 @@
+package tastyquery
+
+import tastyquery.Trees.*
+
+object Annotations:
+  final class Annotation(val tree: TermTree):
+    override def toString(): String = s"Annotation($tree)"
+  end Annotation
+end Annotations

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -4,6 +4,7 @@ import scala.annotation.tailrec
 
 import scala.collection.mutable
 
+import tastyquery.Annotations.*
 import tastyquery.Contexts.*
 import tastyquery.Exceptions.*
 import tastyquery.Flags.*
@@ -75,6 +76,7 @@ object Symbols {
     private var myFlags: FlagSet = Flags.EmptyFlagSet
     private var myTree: Option[DefiningTreeType] = None
     private var myPrivateWithin: Option[Symbol] = None
+    private var myAnnotations: List[Annotation] = Nil
 
     /** Checks that this `Symbol` has been completely initialized.
       *
@@ -110,6 +112,14 @@ object Symbols {
         myFlags = flags
         myPrivateWithin = privateWithin
         this
+
+    private[tastyquery] final def addAnnotations(annots: List[Annotation]): this.type =
+      myAnnotations = myAnnotations ::: annots
+      this
+
+    final def annotations: List[Annotation] =
+      // TODO Prevent reading before they are initialized
+      myAnnotations
 
     final def privateWithin: Option[Symbol] =
       if isFlagsInitialized then myPrivateWithin

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -158,6 +158,7 @@ private[reader] object ClassfileParser {
       .create(name.withObjectSuffix.toTypeName, classOwner)
       .withTypeParams(Nil)
       .withFlags(clsFlags | Flags.ModuleClassCreationFlags, clsPrivateWithin)
+      .setAnnotations(Nil)
       .withParentsDirect(defn.ObjectType :: Nil)
     allRegisteredSymbols += moduleClass
 
@@ -165,6 +166,7 @@ private[reader] object ClassfileParser {
       .create(name.toTermName, classOwner)
       .withDeclaredType(moduleClass.typeRef)
       .withFlags(clsFlags | Flags.ModuleValCreationFlags, clsPrivateWithin)
+      .setAnnotations(Nil)
     allRegisteredSymbols += module
 
     def readInnerClasses(innerClasses: Forked[DataStream]): InnerClasses =
@@ -177,6 +179,7 @@ private[reader] object ClassfileParser {
       val flags = baseFlags | access.toFlags
       val owner = if flags.is(Flags.Static) then moduleClass else cls
       val sym = TermSymbol.create(name, owner).withFlags(flags, privateWithin(access))
+      sym.setAnnotations(Nil) // TODO Read Java annotations on fields and methods
       allRegisteredSymbols += sym
       sym
 
@@ -214,7 +217,9 @@ private[reader] object ClassfileParser {
     end initParents
 
     cls.withFlags(clsFlags, clsPrivateWithin)
+    cls.setAnnotations(Nil) // TODO Read Java annotations on classes
     initParents()
+
     for (sym, sigOrDesc) <- loadMembers() do
       sigOrDesc match
         case SigOrDesc.Desc(desc) => sym.withDeclaredType(Descriptors.parseDescriptor(sym, desc))

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -261,7 +261,7 @@ private[classfiles] object JavaSignatures:
         val tparams = tparamNames.map { tname =>
           val paramSym = ClassTypeParamSymbol.create(tname, cls)
           allRegisteredSymbols += paramSym
-          paramSym.withFlags(ClassTypeParam, None)
+          paramSym.withFlags(ClassTypeParam, None).setAnnotations(Nil)
           paramSym
         }
         val lookup = tparamNames.lazyZip(tparams).toMap

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -275,6 +275,7 @@ private[pickles] class PickleReader {
         errorBadSignature("bad symbol tag: " + tag)
     }
     sym.withFlags(flags, privateWithin)
+    sym.setAnnotations(Nil) // TODO Read Scala 2 annotations
     sym
   }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -311,7 +311,7 @@ private[tasties] class TreeUnpickler(
           ()
     end while
 
-    sym.addAnnotations(annots)
+    sym.setAnnotations(annots)
   end readAnnotationsInModifiers
 
   private def readAnnotation()(using LocalContext): Annotation =
@@ -504,7 +504,7 @@ private[tasties] class TreeUnpickler(
         case bounds: TypeBoundsTree => bounds.toTypeBounds
         case bounds: TypeLambdaTree => defn.NothingAnyBounds
       paramSymbol.setBounds(typeBounds)
-      skipModifiers(end)
+      readAnnotationsInModifiers(paramSymbol, end)
       definingTree(paramSymbol, TypeParam(name, bounds, paramSymbol)(spn))
     }
     val acc = new ListBuffer[TypeParam]()
@@ -685,8 +685,8 @@ private[tasties] class TreeUnpickler(
       val name = readName
       val typ = readType
       val body = readPattern
-      skipModifiers(end)
       val symbol = localCtx.getSymbol[TermSymbol](start)
+      readAnnotationsInModifiers(symbol, end)
       symbol.withDeclaredType(typ)
       definingTree(symbol, Bind(name, body, symbol)(spn))
     case ALTERNATIVE =>
@@ -1203,8 +1203,8 @@ private[tasties] class TreeUnpickler(
         val typ = readTypeBounds
         NamedTypeBoundsTree(typeName, typ)(bodySpn)
       } else readTypeTree
-      skipModifiers(end)
       val sym = localCtx.getSymbol[LocalTypeParamSymbol](start)
+      readAnnotationsInModifiers(sym, end)
       sym.setBounds(bounds)
       definingTree(sym, TypeTreeBind(name, body, sym)(spn))
     // Type tree for a type member (abstract or bounded opaque)

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -16,6 +16,8 @@ import tastyquery.Symbols.*
 import tastyquery.Trees.*
 import tastyquery.Types.*
 
+import TestUtils.*
+
 class ReadTreeSuite extends RestrictedUnpicklingSuite {
   type StructureCheck = PartialFunction[Tree, Unit]
   type TypeStructureCheck = PartialFunction[Type, Unit]
@@ -1893,5 +1895,73 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
           ) =>
     }
     assert(containsSubtree(thisTypeCheck)(clue(tree)))
+  }
+
+  testUnpickle("annotations", "simple_trees.Annotations") { tree =>
+    object SimpleAnnotCtorNamed:
+      def unapply(t: Select): Option[String] = t match
+        case Select(New(TypeIdent(TypeName(SimpleName(name)))), _) => Some(name)
+        case _                                                     => None
+    end SimpleAnnotCtorNamed
+
+    val inlineAnnotCheck: StructureCheck = { case Apply(SimpleAnnotCtorNamed("inline"), Nil) =>
+    }
+
+    def deprecatedAnnotCheck(msg: String, since: String): StructureCheck = {
+      case Apply(SimpleAnnotCtorNamed("deprecated"), List(Literal(Constant(`msg`)), Literal(Constant(`since`)))) =>
+    }
+
+    def deprecatedAnnotNamedCheck(msg: String, since: String): StructureCheck = {
+      case Apply(
+            SimpleAnnotCtorNamed("deprecated"),
+            List(Literal(Constant(`msg`)), NamedArg(SimpleName("since"), Literal(Constant(`since`))))
+          ) =>
+    }
+
+    def implicitNotFoundAnnotCheck(msg: String): StructureCheck = {
+      case Apply(SimpleAnnotCtorNamed("implicitNotFound"), List(Literal(Constant(`msg`)))) =>
+    }
+
+    val constructorOnlyAnnotCheck: StructureCheck = { case Apply(SimpleAnnotCtorNamed("constructorOnly"), Nil) =>
+    }
+
+    val inlineMethodSym = findTree(tree) { case DefDef(SimpleName("inlineMethod"), _, _, _, sym) =>
+      sym
+    }
+    assert(clue(inlineMethodSym.annotations).sizeIs == 1)
+    assert(containsSubtree(inlineAnnotCheck)(clue(inlineMethodSym.annotations(0).tree)))
+
+    val inlineDeprecatedMethodSym = findTree(tree) { case DefDef(SimpleName("inlineDeprecatedMethod"), _, _, _, sym) =>
+      sym
+    }
+    assert(clue(inlineDeprecatedMethodSym.annotations).sizeIs == 2)
+    assert(containsSubtree(inlineAnnotCheck)(clue(inlineDeprecatedMethodSym.annotations(0).tree)))
+    assert(
+      containsSubtree(deprecatedAnnotNamedCheck("some reason", "1.0"))(
+        clue(inlineDeprecatedMethodSym.annotations(1).tree)
+      )
+    )
+
+    val deprecatedValSym = findTree(tree) { case ValDef(SimpleName("deprecatedVal"), _, _, sym) =>
+      sym
+    }
+    assert(clue(deprecatedValSym.annotations).sizeIs == 1)
+    assert(containsSubtree(deprecatedAnnotNamedCheck("reason", "forever"))(clue(deprecatedValSym.annotations(0).tree)))
+
+    val myTypeClassSym = findTree(tree) { case ClassDef(TypeName(SimpleName("MyTypeClass")), _, sym) =>
+      sym
+    }
+    assert(clue(myTypeClassSym.annotations).sizeIs == 1)
+    assert(
+      containsSubtree(implicitNotFoundAnnotCheck("Cannot find implicit for MyTypeClass[${T}]"))(
+        clue(myTypeClassSym.annotations(0).tree)
+      )
+    )
+
+    val intAliasSym = findTree(tree) { case TypeMember(TypeName(SimpleName("IntAlias")), _, sym) =>
+      sym
+    }
+    assert(clue(intAliasSym.annotations).sizeIs == 1)
+    assert(containsSubtree(deprecatedAnnotCheck("other reason", "forever"))(clue(intAliasSym.annotations(0).tree)))
   }
 }

--- a/test-sources/src/main/scala/simple_trees/Annotations.scala
+++ b/test-sources/src/main/scala/simple_trees/Annotations.scala
@@ -1,0 +1,21 @@
+package simple_trees
+
+import scala.annotation.implicitNotFound
+
+class Annotations:
+  @inline
+  def inlineMethod(): Unit = ()
+
+  @inline
+  @deprecated("some reason", since = "1.0")
+  def inlineDeprecatedMethod(): Unit = ()
+
+  @deprecated("reason", since = "forever")
+  val deprecatedVal: Int = 5
+
+  @implicitNotFound("Cannot find implicit for MyTypeClass[${T}]")
+  trait MyTypeClass[T]
+
+  @deprecated("other reason", "forever")
+  type IntAlias = Int
+end Annotations


### PR DESCRIPTION
This is the bare minimum to read the annotations.

There will be followups for
* Convenience accessors for annotation info (class symbol, constant arguments, etc.)
* Correct treatment of `targetName`