### PR TITLE
Make the `Classpath` and `Classpath.Entry` constructors public.

### DIFF
--- a/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
+++ b/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
@@ -55,8 +55,8 @@ object ClasspathLoaders:
         }
       }
 
-    def compressPackages(allFiles: Seq[FileContent]): Iterable[PackageData] =
-      allFiles
+    def makeEntry(allFiles: Seq[FileContent]): Classpath.Entry =
+      val packageDatas = allFiles
         .groupMap[String, ClassData | TastyData](_.packagePath) { fileContent =>
           val isClassFile = fileContent.name.endsWith(".class")
           val binaryName =
@@ -73,10 +73,10 @@ object ClasspathLoaders:
           }
           PackageData(packageName, IArray.from(classes.sortBy(_.binaryName)), IArray.from(tastys.sortBy(_.binaryName)))
         }
+      Classpath.Entry(IArray.from(packageDatas))
+    end makeEntry
 
-    for allEntries <- allEntriesFuture yield
-      val compressedEntries = allEntries.map(compressPackages andThen IArray.from)
-      Classpath.from(compressedEntries)
+    for allEntries <- allEntriesFuture yield Classpath(IArray.from(allEntries).map(makeEntry))
   end read
 
   private def fromDirectory(dir: String, relPath: String)(implicit ec: ExecutionContext): Future[Seq[FileContent]] =

--- a/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
+++ b/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
@@ -82,7 +82,7 @@ object ClasspathLoaders {
       IArray.from(pkgs).sorted
     end compressPackageData
 
-    def packagesOfEntry(entry: ClasspathEntry) =
+    def toEntry(entry: ClasspathEntry): Classpath.Entry =
       val map = entry.walkFiles(kinds.toSeq*) { (kind, fileWithExt, path, bytes) =>
         val (s"$file.${kind.`ext`}") = fileWithExt: @unchecked
         val bin = binaryName(file)
@@ -94,11 +94,12 @@ object ClasspathLoaders {
             packageName -> TastyData(simpleName, path, bytes)
         }
       }
-      compressPackageData(map.get(FileKind.Class).getOrElse(Nil) ++ map.get(FileKind.Tasty).getOrElse(Nil))
-    end packagesOfEntry
+      val packageDatas =
+        compressPackageData(map.get(FileKind.Class).getOrElse(Nil) ++ map.get(FileKind.Tasty).getOrElse(Nil))
+      Classpath.Entry(packageDatas)
+    end toEntry
 
-    val cp = classpathToEntries(classpath).map(packagesOfEntry)
-    Classpath.from(cp)
+    Classpath(classpathToEntries(classpath).map(toEntry))
   end read
 
   private def loadBytes(fileStream: InputStream): IArray[Byte] = {

--- a/tasty-query/shared/src/main/scala/tastyquery/Classpaths.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Classpaths.scala
@@ -26,7 +26,7 @@ object Classpaths:
     * [[Contexts.Context]]. The latter gives semantic access to all the
     * definitions on the classpath.
     */
-  final class Classpath private (val entries: IArray[Classpath.Entry]):
+  final class Classpath(val entries: IArray[Classpath.Entry]):
 
     /** Returns the concatenation of this classpath with `other`.
       * This is useful for structural sharing of [[Classpath.Entry Classpath Entries]]. e.g. in the following example
@@ -70,23 +70,25 @@ object Classpaths:
   /** Factory object for [[Classpath]] instances. */
   object Classpath {
 
-    /** A [[Classpath.Entry]] encapsulates the package data for a single classpath entry
-      * (i.e. a given directory or jar file).
-      * Can only be created by [[Classpath.from]]. You can lookup all symbols
-      * originating from this entry
+    /** An entry (directory or jar file) of a [[Classpath]].
+      *
+      * You can lookup all symbols originating from a particular [[Classpath.Entry]]
       * with [[Contexts.Context.findSymbolsByClasspathEntry ctx.findSymbolsByClasspathEntry]].
-      * e.g.:
+      *
+      * For example:
+      *
       * ```scala
       * val classpath = ClasspathLoaders.read(myLibraryPath :: stdLibPaths)
       * given Context = Contexts.init(classpath)
       * val myLibSyms = ctx.findSymbolsByClasspathEntry(classpath.entries.head)
       * ```
       */
-    final class Entry private[Classpath] (val packages: IArray[PackageData])
+    final class Entry(val packages: IArray[PackageData])
 
     /** Creates a [[Classpath]] from a sequence of classpath entries. Each entry corresponds to a single directory
       * or jar file, and represents the various `.class` and `.tasty` files found within it.
       */
+    @deprecated("use Classpath(IArray.from(entries).map(Classpath.Entry(_)) instead", since = "0.5.2")
     def from(entries: Seq[IArray[PackageData]]): Classpath =
       Classpath(IArray.from(entries).map(Entry(_)))
   }


### PR DESCRIPTION
This is fine, since they are immutable data-only containers. It allows to create these in a more hierarchical way in the loaders.

We deprecate the `Classpath.from` method, as it does not add any value anymore.