### PR TITLE
Handle polymorphic type aliases in subtyping.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -189,8 +189,10 @@ private[tastyquery] object Subtyping:
             case cls2: ClassSymbol =>
               // TODO Handle generic tuple <: TupleN
               level3WithBaseType(tp1, tp2, cls2)
+            case sym2: TypeMemberSymbol if sym2.isTypeAlias =>
+              isSubtype(tp1, tp2.superType)
             case sym2: TypeSymbolWithBounds =>
-              // TODO Handle polymorphic type aliases (compareLower in TypeComparer)
+              // TODO? Handle bounded type lambdas (compareLower in TypeComparer)
               level4(tp1, tp2)
         end if
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -859,9 +859,12 @@ object Symbols {
             case tycon: TypeRef if tycon.symbol == this =>
               Some(tp)
             case tycon =>
-              // TODO Also handle TypeLambdas
               val typeParams = tycon.typeParams
-              recur(tycon).map(_.substClassTypeParams(typeParams.asInstanceOf[List[ClassTypeParamSymbol]], tp.args))
+              typeParams match
+                case (_: TypeLambdaParam) :: _ =>
+                  recur(tp.superType)
+                case _ =>
+                  recur(tycon).map(_.substClassTypeParams(typeParams.asInstanceOf[List[ClassTypeParamSymbol]], tp.args))
 
         case tp: TypeProxy =>
           recur(tp.superType)

--- a/tasty-query/shared/src/main/scala/tastyquery/Variances.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Variances.scala
@@ -10,6 +10,9 @@ private[tastyquery] object Variances:
     def fromFlags(flags: FlagSet): Variance =
       flags & VarianceFlags
 
+    val Invariant: Variance = fromFlags(EmptyFlagSet)
+  end Variance
+
   extension (variance: Variance)
     /** Is this covariant or bivariant? */
     def isCovariant: Boolean = variance.is(Covariant)

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -96,6 +96,9 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   def mutableSeqOf(tpe: Type)(using Context): Type =
     ctx.findTopLevelClass("scala.collection.mutable.Seq").typeRef.appliedTo(tpe)
 
+  def findTypesFromTASTyNamed(name: String)(using Context): Type =
+    ctx.findTopLevelClass("subtyping.TypesFromTASTy").findDecl(termName(name)).declaredType
+
   testWithContext("same-monomorphic-class") {
     assertEquiv(defn.IntType, defn.IntClass.typeRef).withRef[Int, scala.Int]
     assertEquiv(defn.IntType, defn.IntClass.newTypeRef)
@@ -206,6 +209,11 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       ScalaPackageObjectPrefix.select(tname"List").appliedTo(defn.IntType),
       defn.ArrayTypeOf(defn.IntType)
     ).withRef[List[Int], Array[Int]]
+
+    val listOfInt = listOf(defn.IntType)
+    assertEquiv(findTypesFromTASTyNamed("listFullyQualified"), listOfInt).withRef[IList[Int], IList[Int]]
+    assertEquiv(findTypesFromTASTyNamed("listDefaultImport"), listOfInt).withRef[List[Int], IList[Int]]
+    assertEquiv(findTypesFromTASTyNamed("listPackageAlias"), listOfInt).withRef[scala.List[Int], IList[Int]]
   }
 
   testWithContext("polymorphic-subclasses") {

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -1,0 +1,7 @@
+package subtyping
+
+class TypesFromTASTy:
+  val listDefaultImport: List[Int] = Nil
+  val listFullyQualified: scala.collection.immutable.List[Int] = Nil
+  val listPackageAlias: scala.List[Int] = Nil
+end TypesFromTASTy


### PR DESCRIPTION
This solves the issue of tasty-mima mentioned at
https://github.com/scalacenter/tasty-mima/blob/e88400d0981c079df60abacb3663ac8ac08c11db/test-lib-v1/src/main/scala/testlib/membertypechanges/MemberTypeChanges.scala#L3-L6