### PR TITLE
Correctly handle the `scala.|` and `scala.&` aliases in subtyping.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -108,7 +108,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     andTypeAlias.withFlags(EmptyFlagSet, None)
     andTypeAlias.withDefinition(
       TypeMemberDefinition.TypeAlias(
-        PolyType(andOrParamNames)(
+        TypeLambda(andOrParamNames)(
           pt => List(NothingAnyBounds, NothingAnyBounds),
           pt => AndType(pt.paramRefs(0), pt.paramRefs(1))
         )
@@ -119,7 +119,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     orTypeAlias.withFlags(EmptyFlagSet, None)
     orTypeAlias.withDefinition(
       TypeMemberDefinition.TypeAlias(
-        PolyType(andOrParamNames)(
+        TypeLambda(andOrParamNames)(
           pt => List(NothingAnyBounds, NothingAnyBounds),
           pt => OrType(pt.paramRefs(0), pt.paramRefs(1))
         )

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -145,6 +145,7 @@ private[tastyquery] object Subtyping:
 
     case tp2: OrType =>
       isSubtype(tp1, tp2.first) || isSubtype(tp1, tp2.second)
+        || level4(tp1, tp2)
 
     case _ =>
       level4(tp1, tp2)
@@ -262,8 +263,7 @@ private[tastyquery] object Subtyping:
   private def compareAppliedType1(tp1: AppliedType, tp2: Type)(using Context): Boolean =
     val tycon1 = tp1.tycon
     tycon1 match
-      case tycon1: TypeRef =>
-        // TODO?
+      case tycon1: TypeRef if tycon1.symbol.isClass =>
         false
       case tycon1: TypeProxy =>
         isSubtype(tp1.superType, tp2) // TODO superTypeNormalized for match types

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -490,6 +490,9 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       Types.AndType.make(defn.IntType, defn.StringType),
       Types.AndType.make(defn.IntType, defn.BooleanType)
     ).withRef[Int & String, Int & Boolean]
+
+    val SerializableClass = ctx.findTopLevelClass("java.io.Serializable")
+    assertEquiv(findTypesFromTASTyNamed("andType"), AndType(ProductClass.typeRef, SerializableClass.typeRef))
   }
 
   testWithContext("union-types") {
@@ -504,6 +507,8 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       Types.OrType.make(defn.IntType, defn.StringType),
       Types.OrType.make(defn.IntType, defn.BooleanType)
     ).withRef[Int | String, Int | Boolean]
+
+    assertEquiv(OrType(defn.IntType, defn.StringType), findTypesFromTASTyNamed("orType"))
   }
 
 end SubtypingSuite

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -4,4 +4,7 @@ class TypesFromTASTy:
   val listDefaultImport: List[Int] = Nil
   val listFullyQualified: scala.collection.immutable.List[Int] = Nil
   val listPackageAlias: scala.List[Int] = Nil
+
+  val orType: Int | String = 1
+  val andType: Product & Serializable = Nil
 end TypesFromTASTy


### PR DESCRIPTION
* They should be defined as `TypeLambda`s, not `PolyType`s.
* When there is a non-class tycon in an AppliedType on the left of a subtyping comparison, we need to try the `superType`, to handle the case where it is a `TypeRef` to a polymorphic type alias.