### PR TITLE
Handle `ExprType`s in subtyping.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -146,15 +146,24 @@ private[tastyquery] object Subtyping:
     case tp2: OrType =>
       isSubtype(tp1, tp2.first) || isSubtype(tp1, tp2.second)
 
+    case tp2: ExprType =>
+      tp1 match
+        case tp1: ExprType => isSubtype(tp1.resultType, tp2.resultType)
+        case _             => level4(tp1, tp2)
+
     case _ =>
       level4(tp1, tp2)
   end level3
 
   private def level3WithBaseType(tp1: Type, tp2: Type, cls2: ClassSymbol)(using Context): Boolean =
-    tp1.baseType(cls2) match
+    nonExprBaseType(tp1, cls2) match
       case Some(base) if base ne tp1 => isSubtype(base, tp2)
       case _                         => level4(tp1, tp2)
   end level3WithBaseType
+
+  private def nonExprBaseType(tp1: Type, cls2: ClassSymbol)(using Context): Option[Type] =
+    if tp1.isInstanceOf[ExprType] then None
+    else tp1.baseType(cls2)
 
   private def compareAppliedType2(tp1: Type, tp2: AppliedType)(using Context): Boolean =
     val tycon2 = tp2.tycon

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -506,4 +506,30 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     ).withRef[Int | String, Int | Boolean]
   }
 
+  testWithContext("by-name-params") {
+    val Function1Class = ctx.findTopLevelClass("scala.Function1")
+    def fun1Type(argType: Type, resultType: Type): Type =
+      AppliedType(Function1Class.typeRef, argType :: resultType :: Nil)
+
+    val PStringType = PredefPrefix.select(tname"String")
+
+    assertEquiv(
+      fun1Type(ExprType(defn.StringType), defn.StringType),
+      fun1Type(ExprType(defn.StringType), defn.StringType)
+    ).withRef[(=> JString) => JString, (=> JString) => JString]
+
+    assertEquiv(fun1Type(ExprType(defn.StringType), defn.StringType), fun1Type(ExprType(PStringType), PStringType))
+      .withRef[(=> JString) => JString, (=> PString) => PString]
+
+    assertNeitherSubtype(
+      fun1Type(ExprType(defn.StringType), defn.StringType),
+      fun1Type(defn.StringType, defn.StringType)
+    ).withRef[(=> JString) => JString, JString => JString]
+
+    assertNeitherSubtype(
+      fun1Type(ExprType(defn.StringType), defn.StringType),
+      fun1Type(ExprType(defn.IntType), defn.StringType)
+    ).withRef[(=> JString) => JString, (=> Int) => JString]
+  }
+
 end SubtypingSuite


### PR DESCRIPTION
They represent by-name params to function types.