### PR TITLE
Add methods that follow the semantics of dynamic method calls.

### DIFF
--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1083,6 +1083,55 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(classWithParams)(clue(tree)))
   }
 
+  testUnpickle("super-accessors", "simple_trees.SuperDoubleDiamond$") { tree =>
+    val ABTemplate = findTree(tree) { case ClassDef(TypeName(SimpleName("AB")), template, _) =>
+      template
+    }
+    val ABCheck: StructureCheck = {
+      case Template(
+            _,
+            _,
+            _,
+            List(
+              DefDef(
+                PrefixedName(
+                  NameTags.SUPERACCESSOR,
+                  ExpandedName(
+                    NameTags.EXPANDED,
+                    ExpandedName(NameTags.EXPANDPREFIX, _, SimpleName("AB")),
+                    SimpleName("foo")
+                  )
+                ),
+                _,
+                _,
+                None,
+                _
+              ),
+              DefDef(
+                SimpleName("foo"),
+                _,
+                _,
+                Some(
+                  Select(
+                    This(TypeIdent(TypeName(SimpleName("AB")))),
+                    PrefixedName(
+                      NameTags.SUPERACCESSOR,
+                      ExpandedName(
+                        NameTags.EXPANDED,
+                        ExpandedName(NameTags.EXPANDPREFIX, _, SimpleName("AB")),
+                        SimpleName("foo")
+                      )
+                    )
+                  )
+                ),
+                _
+              )
+            )
+          ) =>
+    }
+    assert(containsSubtree(ABCheck)(clue(ABTemplate)))
+  }
+
   testUnpickle("super-types", "simple_trees.SuperTypes$") { tree =>
     val treeBar = findTree(tree) { case cd @ ClassDef(TypeName(SimpleName("Bar")), _, _) =>
       cd

--- a/test-sources/src/main/scala/simple_trees/SuperDoubleDiamond.scala
+++ b/test-sources/src/main/scala/simple_trees/SuperDoubleDiamond.scala
@@ -1,0 +1,30 @@
+package simple_trees
+
+object SuperDoubleDiamond:
+  // Lin = A, AnyRef
+  trait A:
+    def foo = 2
+
+  // Lin = B, AnyRef
+  trait B:
+    def foo = 3
+
+  // Lin = AA, A, AnyRef
+  trait AA extends A:
+    def foo: Int
+
+  // Lin = BB, B, AnyRef
+  trait BB extends B:
+    override def foo = super.foo
+
+  // Lin = AB, B, A, AnyRef
+  trait AB extends A, B:
+    override def foo = super.foo
+
+  // Lin = AAABBB, BB, AB, B, AA, A, AnyRef
+  class AAABBB extends AA, AB, BB:
+    override def foo = super.foo
+
+  // Lin = AABBAB, AB, BB, B, AA, A, AnyRef
+  class AABBAB extends AA, BB, AB
+end SuperDoubleDiamond


### PR DESCRIPTION
* `runtimeImplementingSymbol` for regular method calls.
* `nextSuperSymbol` for unqualified `super` method calls.

Qualified `super[T]` method calls are statically resolved, so they do not need any special method.

/cc @shardulc