### PR TITLE
Add a method `TermOrTypeSymbol.matchingSymbol`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -310,6 +310,35 @@ object Symbols {
           && that.canMatchInheritedSymbols
           && this.overriddenSymbol(that.owner.asClass).contains(that)
       )
+
+    /** The symbol whose name and type matches the type of this symbol in the given class.
+      *
+      * If `inClass == this.owner`, `matchingSymbol` returns this symbol.
+      * Otherwise, private members and constructors are ignored.
+      *
+      * Unlike the override-related methods `overriddenSymbol` and
+      * `overridingSymbol`, this method can return non-empty results when
+      * `inClass` and `this.owner` are unrelated.
+      *
+      * `siteClass` must be a common subclass of `this.owner` and `inClass`.
+      *
+      * @param inClass
+      *   The class in which to look for a matching symbol
+      * @param siteClass
+      *   The base class from which member types are computed
+      * @throws java.lang.IllegalArgumentException
+      *   if `owner.isClass` is false, if `siteClass.isSubclass(owner.asClass)`
+      *   is false, or if `siteClass.isSubclass(inClass)` is false
+      */
+    final def matchingSymbol(inClass: ClassSymbol, siteClass: ClassSymbol)(using Context): Option[Symbol] =
+      require(owner.isClass, s"illegal matchingSymbol on local symbol $this")
+      require(siteClass.isSubclass(owner.asClass), s"site class $siteClass must be a subclass of owner $owner")
+      require(siteClass.isSubclass(inClass), s"site class $siteClass must be a subclass of target class $inClass")
+
+      if inClass == owner then Some(this)
+      else if !canMatchInheritedSymbols then None
+      else matchingDecl(inClass, siteClass)
+    end matchingSymbol
   end TermOrTypeSymbol
 
   final class TermSymbol private (val name: TermName, owner: Symbol) extends TermOrTypeSymbol(owner):

--- a/test-sources/src/main/scala/inheritance/Overrides.scala
+++ b/test-sources/src/main/scala/inheritance/Overrides.scala
@@ -41,7 +41,14 @@ object Overrides:
     def foo(x: A): A = x
     def foo(x: B): B = x
 
-  class ChildPoly[X <: Product] extends SuperPoly[X, Int]:
+  trait SecondSuperPoly[X <: Product]:
+    def foo(x: X): X
+    def foo(x: Int): Int
+
+  trait ThirdSuper:
+    def foo(x: String): String = x
+
+  class ChildPoly[X <: Product] extends SuperPoly[X, Int] with SecondSuperPoly[X] with ThirdSuper:
     override def foo(x: X): X = x
     override def foo(x: Int): Int = x
 end Overrides


### PR DESCRIPTION
It is a public, safer variant of `matchingDecl`. Unlike `overriddenSymbol` and `overridingSymbol`, it can find matching symbols in unrelated classes, but it requires a common subclass as argument.

Alternative to #235 that lets the user of the library implement `runtimeImplementingSymbol` and `nextSuperSymbol` in user-space.

/cc @shardulc