### PR TITLE
Correctly fill in typeDef for opaque type aliases without bounds.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -931,6 +931,15 @@ object Types {
       case sym: TypeSymbolWithBounds =>
         sym.upperBound
 
+    override def translucentSuperType(using Context): Type = symbol match
+      case sym: TypeMemberSymbol =>
+        sym.typeDef match
+          case TypeMemberDefinition.OpaqueTypeAlias(_, alias) => alias
+          case _                                              => underlying
+      case _ =>
+        underlying
+    end translucentSuperType
+
     private[tastyquery] override def findMember(name: Name, pre: Type)(using Context): Option[Symbol] =
       symbol match
         case sym: ClassSymbol =>

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -419,9 +419,12 @@ private[tasties] class TreeUnpickler(
                   case None        => TypeMemberDefinition.AbstractType(bt.bounds)
                   case Some(alias) => TypeMemberDefinition.OpaqueTypeAlias(bt.bounds, alias)
               case alias =>
-                TypeMemberDefinition.TypeAlias(alias)
+                if symbol.is(Opaque) then TypeMemberDefinition.OpaqueTypeAlias(defn.NothingAnyBounds, alias)
+                else TypeMemberDefinition.TypeAlias(alias)
           case bounds: TypeBounds =>
             TypeMemberDefinition.AbstractType(bounds)
+        if symbol.is(Opaque) != typeDef.isInstanceOf[TypeMemberDefinition.OpaqueTypeAlias] then
+          throw TastyFormatException(s"typeDef inconsistent with Opaque flag for $symbol at $posErrorMsg")
         symbol.withDefinition(typeDef)
         definingTree(symbol, TypeMember(name, typeBounds, symbol)(spn))
       }

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -2018,4 +2018,28 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       assert(clue(body.tpe).isApplied(_.isRef(PairClass), List(_.isRef(fooTArg), _.isRef(defn.IntClass))))
     end for
   }
+
+  testWithContext("opaque-type-aliases") {
+    val TypeMemberClass = ctx.findTopLevelClass("simple_trees.TypeMember")
+
+    val opaqueNoBounds = TypeMemberClass.findDecl(typeName("Opaque")).asInstanceOf[TypeMemberSymbol]
+    assert(opaqueNoBounds.isOpaqueTypeAlias)
+    opaqueNoBounds.typeDef match
+      case TypeMemberDefinition.OpaqueTypeAlias(bounds, alias) =>
+        assert(clue(bounds.low).isNothing)
+        assert(clue(bounds.high).isAny)
+        assert(clue(alias).isRef(defn.IntClass))
+      case typeDef =>
+        fail("unexpected typeDef", clues(typeDef))
+
+    val opaqueWithBounds = TypeMemberClass.findDecl(typeName("OpaqueWithBounds")).asInstanceOf[TypeMemberSymbol]
+    assert(opaqueWithBounds.isOpaqueTypeAlias)
+    opaqueWithBounds.typeDef match
+      case TypeMemberDefinition.OpaqueTypeAlias(bounds, alias) =>
+        assert(clue(bounds.low).isRef(defn.NullClass))
+        assert(clue(bounds.high).isRef(ctx.findTopLevelClass("scala.Product")))
+        assert(clue(alias).isRef(defn.NullClass))
+      case typeDef =>
+        fail("unexpected typeDef", clues(typeDef))
+  }
 }


### PR DESCRIPTION
It was incorrectly initialized as a `TypeAlias` instead of an `OpaqueTypeAlias`.