### PR TITLE
Clean up TASTy-MiMa-related stuff from the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,150 +80,11 @@ The product is a multi-dimensional graph involving symbols, trees and types.
 
 tasty-query's job is to read TASTy files for you, and present the information it contains (explicitly or implicitly) in as convenient way as possible.
 
-### Compatibility
+## Use cases
 
-In general, we can talk about the compatibility between two "environments" A and B.
-Assuming B comes *after* A (for some definition of "after" such as version-based), then we can define *backward* and *forward* compatibility:
+### TASTy-MiMa
 
-* *Backward* compatibility: if something "works" with environment A, it also works with environment B.
-* *Forward* compatibility: if something works with environment B, it also works with environment A.
-
-By default, and otherwise specified, we refer to *backward* compatibility.
-
-In the Scala 2 ecosystem, there were two kinds of compatibility: *source* and *binary* compatibility.
-
-* Source compatibility: if a program source successfully compiles with environment A, then it also successfully compiles, with the same meaning, with environment B.
-* Binary compatibility: if a program's classfiles successfully link with environment A, then they also successfully link, with the same meaning, with environment B.
-
-On the JVM, linking errors materialize as various forms of `LinkageError` at run-time.
-In Scala.js and Scala Native, they materialize as error messages at link time, i.e., at the time of producing a `.js` file or an executable.
-
-Scala 3 adds a third kind of compatibility:
-
-* TASTy compatibility: if a program's TASTy files successfully retypecheck with environment A, then they also successfully retypecheck, with the same meaning, with environment B.
-
-As we will see later, "retypechecking" errors typically materialize during macro or `inline def` expansion.
-
-Because of [reasons](https://www.youtube.com/watch?v=2wkEX6MCxJs), it is not practical nor useful to guarantee source compatibility.
-The Scala 2 ecosystem is therefore organized around *binary* compatibility.
-The Scala 3 ecosystem, however, has to be organized around *both* binary and TASTy compatibility.
-
-### MiMa and the consequences of binary incompatibility
-
-[MiMa](https://github.com/lightbend/mima) is a tool to automatically catch binary incompatibilities between two versions of a library.
-MiMa has been instrumental in building a reliable ecosystem for Scala, which avoids [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell).
-
-Oftentimes, as humans not necessarily privy to all the compilation strategies of the Scala compiler, we think that a change will be compatible, although it is not.
-A typical example is the addition of a `private var` in a `trait`, e.g., going from
-
-```scala
-trait A {
-  var x: Int = 1
-  def foo(): Int = x
-}
-```
-
-to
-
-```scala
-trait A {
-  var x: Int = 1
-  private var y: Int = 2
-  def foo(): Int = x + y
-}
-```
-
-When mixing `A` into a class `C`, the compiler needs to create a field for `y` in `C`.
-If `C` was compiled against the former version of `A`, but is linked against the latter, linking breaks.
-
-MiMa detects that this change is invalid, and reports it so that it can be fixed before shipping erroneous versions of a library.
-
-### Consequences of TASTy incompatibility
-
-Similarly to binaries, changes in a Scala program can be TASTy incompatible even though we think they are compatible.
-For example, adding a `super` call within the body of a trait method, or switching between a `Seq` and a vararg parameter.
-
-Breaking TASTy compatibility in the API of a library `L` can cause issues when retypechecking the library with another library `M` that depends on it, when used from a project `P` that depends on both.
-In particular, problems can arise if `M` has `inline def`s that call into the API of `L`.
-
-Here is a concrete example.
-
-```scala
-// L.scala
-object L {
-  def list(xs: Seq[Int]): List[Int] = xs.toList
-}
-```
-
-```scala
-// M.scala
-object M {
-  inline def foo(): String =
-    L.list(Seq(1, 2, 3)).sum.toString
-}
-```
-
-```scala
-// Test.Scala
-object Test {
-  def main(args: Array[String]): Unit = {
-    println(M.foo())
-  }
-}
-```
-
-We first compile everything, and we even verify that it runs:
-
-```
-$ cs launch scalac:3.1.2 -- -d bin/ L.scala M.scala Test.scala
-$ cs launch scala:3.1.2 -- -cp bin/ Test
-6
-```
-
-Then, we change `xs: Seq[Int]` into `xs: Int*` in `L.scala`:
-
-```scala
-// L.scala
-object L {
-  def list(xs: Int*): List[Int] = xs.toList
-}
-```
-
-and recompile only `L`:
-
-```
-$ cs launch scalac:3.1.2 -- -d bin L.scala
-```
-
-This change is not detected by MiMa, as it is binary compatible.
-
-Finally we try to recompile only `Test`:
-
-```
-$ cs launch scalac:3.1.2 -- -cp bin/ -d bin/ Test.scala
--- [E007] Type Mismatch Error: Test.scala:3:17 ---------------------------------
-3 |    println(M.foo())
-  |            ^^^^^^^
-  |            Found:    Seq[Int]
-  |            Required: Int
-  | This location contains code that was inlined from M.scala:3
-
-longer explanation available when compiling with `-explain`
-1 error found
-```
-
-This happens even though, from the point of view of `Test`, the change of `L` is both source and binary compatible, because it is not TASTy-compatible.
-When inlining the body of `M.foo()` inside `main`, it gets *retypechecked* (but not re-*elaborated*) in the context of `main`.
-Retypechecking fails because it is not valid to pass a `Seq[Int]` to a method that expects `Int*` varargs.
-
-For a non-`inline` method, this wouldn't cause any issue, since there would be no reason for the compiler to retypecheck its body.
-
-To guard against this kind of situation, we will need an equivalent of MiMa that checks TASTy-compatibility.
-This is what TASTy-MiMa will be.
-
-### TASTy-MiMa as use case of tasty-query
-
-To implement TASTy-MiMa, we need a way to load TASTy files and extract semantic information out of them.
+In order to perform its job, [TASTy-MiMa](https://github.com/scalacenter/tasty-mima) needs to load TASTy files and extract semantic information out of them.
 This is precisely what tasty-query is built for.
 
 Like MiMa, TASTy-MiMa faces a particular challenge that the compiler itself is not built to handle: the ability to load symbols and types from different classpaths and somehow relate them.
@@ -235,6 +96,7 @@ TASTy-MiMa needs the following "features" from tasty-query:
 * Iterate through all the symbols defined in a library (a set of TASTy files within a classpath)
 * Semantically compare types for equivalence and subtyping
 * Identify which methods in super classes and super traits a given method implements or overrides
+* List the direct children of sealed traits and classes
 
 ### Other use cases
 


### PR DESCRIPTION
The deleted sections have been moved to the readme of TASTy-MiMa itself.