### PR TITLE
Handle polymorphic opaque type aliases.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -464,6 +464,10 @@ object Symbols {
     final def isOpaqueTypeAlias(using Context): Boolean = this match
       case sym: TypeMemberSymbol => sym.typeDef.isInstanceOf[TypeMemberDefinition.OpaqueTypeAlias]
       case _                     => false
+
+    final def staticRef(using Context): TypeRef =
+      require(isStatic, s"Cannot construct a staticRef for non-static symbol $this")
+      TypeRef(owner.staticOwnerPrefix, this)
   end TypeSymbol
 
   sealed abstract class TypeSymbolWithBounds protected (name: TypeName, owner: Symbol) extends TypeSymbol(name, owner):

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -340,7 +340,7 @@ object Types {
       case tp: TermRef if !tp.symbol.isStableMember => tp.underlying.widenIfUnstable
       case _                                        => this
 
-    final def dealias(using Context): Type = dealias1(keepOpaques = false)
+    final def dealias(using Context): Type = dealias1(keepOpaques = true)
 
     private def dealias1(keepOpaques: Boolean)(using Context): Type = this match {
       case tp: TypeRef =>

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -1,6 +1,8 @@
 package subtyping
 
 class TypesFromTASTy:
+  import TypesFromTASTy.*
+
   val listDefaultImport: List[Int] = Nil
   val listFullyQualified: scala.collection.immutable.List[Int] = Nil
   val listPackageAlias: scala.List[Int] = Nil
@@ -9,4 +11,14 @@ class TypesFromTASTy:
   val andType: Product & Serializable = Nil
 
   type TToTType[T] = T => T
+
+  val iarrayOfInt: IArray[Int] = IArray(1)
+
+  val invariantOpaqueOfInt: InvariantOpaque[Int] = makeInvariantOpaque(5)
+end TypesFromTASTy
+
+object TypesFromTASTy:
+  opaque type InvariantOpaque[A] = A
+
+  def makeInvariantOpaque[A](x: A): InvariantOpaque[A] = x
 end TypesFromTASTy


### PR DESCRIPTION
In TASTy, their info is stored as a TypeLambda over "opaque TypeBounds" (BoundedType's in our implementation). However, that does not fit our model for `TypeMemberDefinition`.

We now distribute `TypeLambda`s over `BoundedType`s so that we can correctly handle polymorphic opaque type aliases.

We do not handle variance yet.

This commit includes a fix to `dealias` not to follow opaque type aliases. From a public point of view, it does not make sense to do so.