### PR TITLE
Handle (non-refining) `AnnotatedType`s in subtyping.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -64,6 +64,9 @@ private[tastyquery] object Subtyping:
         case _ =>
           level2(tp1, tp2)
 
+    case tp2: AnnotatedType =>
+      isSubtype(tp1, tp2.typ)
+
     case _ =>
       level2(tp1, tp2)
   end level1

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -10,6 +10,7 @@ import scala.util.NotGiven
 
 import scala.Predef.String as PString
 
+import tastyquery.Annotations.*
 import tastyquery.Contexts.*
 import tastyquery.Flags.*
 import tastyquery.Names.*
@@ -610,6 +611,24 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
 
     assertEquiv(tToTTypeLambda, makeTToTTypeLambda()).withRef[TToTType, TToTType]
     assertEquiv(tToTTypeLambda, fromTasty)
+  }
+
+  testWithContext("annotated-types") {
+    import scala.annotation.unchecked.uncheckedVariance as uV
+
+    // TODO Differentiate *refining* annotations
+
+    val uncheckedVarianceClass = ctx.findTopLevelClass("scala.annotation.unchecked.uncheckedVariance")
+    val annot = Annotation(uncheckedVarianceClass).tree
+
+    assertEquiv(AnnotatedType(defn.IntType, annot), AnnotatedType(defn.IntType, annot)).withRef[Int @uV, Int @uV]
+    assertEquiv(defn.IntType, AnnotatedType(defn.IntType, annot)).withRef[Int, Int @uV]
+    assertEquiv(AnnotatedType(defn.IntType, annot), defn.IntType).withRef[Int @uV, Int]
+
+    assertStrictSubtype(AnnotatedType(defn.IntType, annot), AnnotatedType(defn.AnyValType, annot))
+      .withRef[Int @uV, AnyVal @uV]
+    assertStrictSubtype(defn.IntType, AnnotatedType(defn.AnyValType, annot)).withRef[Int, AnyVal @uV]
+    assertStrictSubtype(AnnotatedType(defn.IntType, annot), defn.AnyValType).withRef[Int @uV, AnyVal]
   }
 
 end SubtypingSuite


### PR DESCRIPTION
They were already handled on the lhs, but not on the rhs.

Refining annotations are supposed to prevent this, but currently we treat them as the non-refining ones.