### PR TITLE
Look in *all* package objects for the PackageRef.findMember fallback.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -181,6 +181,9 @@ object Names {
 
     def append(s: String): SimpleName =
       termName(s"$name$s")
+
+    private[tastyquery] def isPackageObjectName: Boolean =
+      name == "package" || name.endsWith(str.topLevelSuffix)
   }
 
   abstract class DerivedName(val underlying: TermName) extends TermName {

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -829,10 +829,10 @@ object Types {
          * whose prefix is a PackageRef but the name references something in a
          * *package object*. That goes contrary to TASTy's purpose of being a
          * fully-resolved thing. We have to work around it here.
+         * This is very annoying because we have to load a bunch of things that
+         * may not be necessary.
          */
-        symbol.getDecl(tpnme.scala2PackageObjectClass) match
-          case Some(pkgObjectClass) => pkgObjectClass.asClass.getDecl(name)
-          case None                 => None
+        symbol.allPackageObjectDecls().iterator.flatMap(_.getDecl(name)).nextOption()
       }
 
     override def toString(): String = s"PackageRef($fullyQualifiedName)"

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
@@ -147,6 +147,19 @@ private[tastyquery] object Loaders {
       do completeRoot(Loader.Root(pkg, rootName), entry)
     end loadAllRoots
 
+    /** Loads all the roots of the given `pkg` that could be package objects. */
+    private[tastyquery] def loadAllPackageObjectRoots(pkg: PackageSymbol)(using Context): Unit =
+      roots.get(pkg) match
+        case Some(entries) =>
+          val candidateNames = entries.keysIterator.filter(_.isPackageObjectName).toList.sorted // sort for determinism
+          for
+            rootName <- candidateNames
+            entry <- entries.remove(rootName)
+          do completeRoot(Loader.Root(pkg, rootName), entry)
+        case None =>
+          ()
+    end loadAllPackageObjectRoots
+
     /** Loads the root of the given `pkg` that would define `name`, if there is one such root.
       *
       * When this method returns `true`, it is not guaranteed that the

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -345,6 +345,23 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     assertStrictSubtype(invariantOpaqueRef.appliedTo(defn.IntType), defn.AnyType)
   }
 
+  testWithContext("crosspackage-toplevel-opaque-type-alias") {
+    import crosspackagetasty.TopLevelOpaqueTypeAlias
+
+    val TopLevelOpaqueTypeAliasSym =
+      ctx
+        .findStaticType("crosspackagetasty.TopLevelOpaqueTypeAlias$package.TopLevelOpaqueTypeAlias")
+        .asInstanceOf[TypeMemberSymbol]
+
+    assertEquiv(TopLevelOpaqueTypeAliasSym.staticRef, TopLevelOpaqueTypeAliasSym.staticRef)
+      .withRef[TopLevelOpaqueTypeAlias, TopLevelOpaqueTypeAlias]
+
+    assertNeitherSubtype(TopLevelOpaqueTypeAliasSym.staticRef, defn.IntType)
+      .withRef[TopLevelOpaqueTypeAlias, Int]
+
+    assertEquiv(findTypesFromTASTyNamed("toplevelOpaqueTypeAlias"), TopLevelOpaqueTypeAliasSym.staticRef)
+  }
+
   testWithContext("this-type") {
     // No withRef's in this test because we cannot write code that refers to the `this` of an external class
 

--- a/test-sources/src/main/scala/crosspackagetasty/TopLevelOpaqueTypeAlias.scala
+++ b/test-sources/src/main/scala/crosspackagetasty/TopLevelOpaqueTypeAlias.scala
@@ -1,0 +1,7 @@
+package crosspackagetasty
+
+opaque type TopLevelOpaqueTypeAlias <: AnyVal = Int
+
+object TopLevelOpaqueTypeAlias:
+  def apply(x: Int): TopLevelOpaqueTypeAlias = x
+end TopLevelOpaqueTypeAlias

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -15,6 +15,14 @@ class TypesFromTASTy:
   val iarrayOfInt: IArray[Int] = IArray(1)
 
   val invariantOpaqueOfInt: InvariantOpaque[Int] = makeInvariantOpaque(5)
+
+  /* This explicit selection generates a
+   * Select(PackageRef(crosspackagetasty), TopLevelOpaqueTypeAlias)
+   * in TASTy, without any mention of the enclosing package object.
+   * So we have to find it by iterating on all the possible package objects.
+   */
+  val toplevelOpaqueTypeAlias: crosspackagetasty.TopLevelOpaqueTypeAlias =
+    crosspackagetasty.TopLevelOpaqueTypeAlias(5)
 end TypesFromTASTy
 
 object TypesFromTASTy:


### PR DESCRIPTION
Unfortunately, #179 also happens for Scala 3 package objects created for top-level definitions. So in fact we have to load all possible package objects in the fallback of `PackageRef.findMember`.