### PR TITLE
Be even more tolerant when typing polymorphic `Apply(New, ...)`.

### DIFF
--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -1136,6 +1136,62 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     end for
   }
 
+  testWithContext("poly constructor params normalization") {
+    val prefix = "inheritance.CtorParamsNormalization"
+
+    val PolySuperClassNoNormClass = ctx.findStaticClass(s"$prefix.PolySuperClassNoNorm")
+    val PolySuperTraitNoNormClass = ctx.findStaticClass(s"$prefix.PolySuperTraitNoNorm")
+
+    for cls <- List(PolySuperClassNoNormClass, PolySuperTraitNoNormClass) do
+      val ctor = cls.findNonOverloadedDecl(nme.Constructor)
+      ctor.declaredType match
+        case pt1: PolyType =>
+          assert(clue(pt1).paramNames.sizeIs == 1, cls)
+          pt1.resultType match
+            case mt1: MethodType =>
+              assert(clue(mt1).paramNames.isEmpty, cls)
+              mt1.resultType match
+                case mt2: MethodType =>
+                  assert(clue(mt2).paramNames.sizeIs == 1, cls)
+                case mt2 =>
+                  fail("expected MethodType", clues(cls, pt1))
+            case mt1 =>
+              fail("expected MethodType", clues(cls, pt1))
+        case pt1 =>
+          fail("expected PolyType", clues(cls, pt1))
+    end for
+
+    val PolySuperClassWithNormClass = ctx.findStaticClass(s"$prefix.PolySuperClassWithNorm")
+    val PolySuperTraitWithNormClass = ctx.findStaticClass(s"$prefix.PolySuperTraitWithNorm")
+
+    for cls <- List(PolySuperClassWithNormClass, PolySuperTraitWithNormClass) do
+      val ctor = cls.findNonOverloadedDecl(nme.Constructor)
+      ctor.declaredType match
+        case pt1: PolyType =>
+          assert(clue(pt1).paramNames.sizeIs == 1, cls)
+          pt1.resultType match
+            case mt1: MethodType =>
+              assert(clue(mt1).paramNames.sizeIs == 1, cls)
+              mt1.resultType match
+                case mt2: MethodType =>
+                  assert(clue(mt2).paramNames.isEmpty, cls)
+                case mt2 =>
+                  fail("expected MethodType", clues(cls, mt1))
+            case mt1 =>
+              fail("expected MethodType", clues(cls, mt1))
+        case pt1 =>
+          fail("expected PolyType", clues(cls, pt1))
+    end for
+
+    for n <- 1 to 4 do
+      val PolySubNClass = ctx.findStaticClass(s"$prefix.PolySub$n")
+      val expectedParentClass = if n % 2 == 1 then PolySuperClassNoNormClass else PolySuperClassWithNormClass
+      val expectedParentTrait = if n <= 2 then PolySuperTraitNoNormClass else PolySuperTraitWithNormClass
+      val expectedParents = List(expectedParentClass, expectedParentTrait)
+      assert(clue(clue(PolySubNClass).parentClasses) == clue(expectedParents))
+    end for
+  }
+
   testWithContext("overrides-mono-no-overloads") {
     val SuperMonoClass = ctx.findStaticClass("inheritance.Overrides.SuperMono")
     val SuperMonoTraitClass = ctx.findStaticClass("inheritance.Overrides.SuperMonoTrait")

--- a/test-sources/src/main/scala/inheritance/CtorParamsNormalization.scala
+++ b/test-sources/src/main/scala/inheritance/CtorParamsNormalization.scala
@@ -15,4 +15,17 @@ object CtorParamsNormalization:
   class Sub2 extends SuperClassWithNorm with SuperTraitNoNorm
   class Sub3 extends SuperClassNoNorm with SuperTraitWithNorm
   class Sub4 extends SuperClassWithNorm with SuperTraitWithNorm
+
+  class PolySuperClassNoNorm[T]()(using x: T)
+
+  trait PolySuperTraitNoNorm[T]()(using x: T)
+
+  class PolySuperClassWithNorm[T](using x: T)
+
+  trait PolySuperTraitWithNorm[T](using x: T)
+
+  class PolySub1 extends PolySuperClassNoNorm[Int] with PolySuperTraitNoNorm[Int]
+  class PolySub2 extends PolySuperClassWithNorm[Int] with PolySuperTraitNoNorm[Int]
+  class PolySub3 extends PolySuperClassNoNorm[Int] with PolySuperTraitWithNorm[Int]
+  class PolySub4 extends PolySuperClassWithNorm[Int] with PolySuperTraitWithNorm[Int]
 end CtorParamsNormalization


### PR DESCRIPTION
I was not able to reproduce the issue in a standalone test, but apparently it is possible to have *both* a `New` with an `AppliedType` (hence, monomorphic) wrapped in a `TypeApply`. This would attempt to reapply type parameters to an already monomorphic type, which crashed.

We are now a bit more tolerant, and apply type parameter lists to the type of the `New` as long as we have a polymorphic type. We stop applying further type parameter lists when the type is fully monomorphic.

---

The first commit contains more tests that were an attempt at reproducing the above issue. They don't, but the tests are valuable anyway.