### PR TITLE
Handle higher-kinded type param refs.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -199,6 +199,12 @@ private[tastyquery] object Subtyping:
                 else false
               case _ =>
                 false
+
+          case tycon1: TypeParamRef =>
+            tycon1 == tycon2 && isSubArgs(tp1.args, tp2.args, tparams)
+
+          case _ =>
+            false
         end match
 
       case _ =>
@@ -219,6 +225,10 @@ private[tastyquery] object Subtyping:
               // TODO? Handle bounded type lambdas (compareLower in TypeComparer)
               level4(tp1, tp2)
         end if
+
+      case tycon2: TypeParamRef =>
+        // TODO Compare with the lower bound of tycon2 (compareLower in TypeComparer)
+        isMatchingApply(tp1)
 
       case _ =>
         false

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -1436,6 +1436,11 @@ object Types {
       case _ =>
         low.isSubtype(tp) && tp.isSubtype(high)
     end contains
+
+    private[tastyquery] def mapBounds(f: Type => Type): TypeBounds = this match
+      case RealTypeBounds(low, high) => derivedTypeBounds(f(low), f(high))
+      case self @ TypeAlias(alias)   => self.derivedTypeAlias(f(alias))
+    end mapBounds
   }
 
   final case class RealTypeBounds(override val low: Type, override val high: Type) extends TypeBounds(low, high):

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -49,6 +49,28 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
   private object TermRefInternal:
     def unapply(tpe: TermRef): Some[(Prefix, AnyDesignator)] = Some((tpe.prefix, tpe.designatorInternal))
 
+  private object NothingAnyTypeBoundsTree:
+    def unapply(tree: TypeBoundsTree): Boolean = tree match
+      case TypeBoundsTree(
+            TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
+            TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
+          ) =>
+        true
+      case _ =>
+        false
+  end NothingAnyTypeBoundsTree
+
+  private object NothingAnyTypeBounds:
+    def unapply(bounds: RealTypeBounds): Boolean = bounds match
+      case RealTypeBounds(
+            TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing"))),
+            TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any")))
+          ) =>
+        true
+      case _ =>
+        false
+  end NothingAnyTypeBounds
+
   /** Extractors for `Type`s.
     *
     * "`ty`" stands for "type", but we make it very short not to clutter the
@@ -1140,17 +1162,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
 
     // abstract without user-specified bounds, therefore default bounds are generated
     val abstractTypeMember: StructureCheck = {
-      case TypeMember(
-            TypeName(SimpleName("AbstractType")),
-            BoundedTypeTree(
-              TypeBoundsTree(
-                TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-              ),
-              None
-            ),
-            _
-          ) =>
+      case TypeMember(TypeName(SimpleName("AbstractType")), BoundedTypeTree(NothingAnyTypeBoundsTree(), None), _) =>
     }
     assert(containsSubtree(abstractTypeMember)(clue(tree)))
 
@@ -1204,10 +1216,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                     List(
                       firstTypeParamTree @ TypeParam(
                         TypeName(SimpleName("T")),
-                        TypeBoundsTree(
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                        ),
+                        NothingAnyTypeBoundsTree(),
                         firstTypeParamSymbol
                       )
                     )
@@ -1222,10 +1231,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               _,
               (secondTypeParamTree @ TypeParam(
                 TypeName(SimpleName("T")),
-                RealTypeBounds(
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing"))),
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any")))
-                ),
+                NothingAnyTypeBounds(),
                 secondTypeParamSymbol
               )) :: _
             ),
@@ -1245,21 +1251,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val genericMethod: StructureCheck = {
       case DefDef(
             SimpleName("usesTypeParam"),
-            List(
-              Right(
-                List(
-                  TypeParam(
-                    TypeName(SimpleName("T")),
-                    TypeBoundsTree(
-                      TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                      TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                    ),
-                    _
-                  )
-                )
-              ),
-              Left(Nil)
-            ),
+            List(Right(List(TypeParam(TypeName(SimpleName("T")), NothingAnyTypeBoundsTree(), _))), Left(Nil)),
             AppliedTypeTree(TypeIdent(TypeName(SimpleName("Option"))), TypeIdent(TypeName(SimpleName("T"))) :: Nil),
             _,
             _
@@ -1274,18 +1266,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("genericExtension"),
             List(
               Left(List(ValDef(SimpleName("i"), TypeIdent(TypeName(SimpleName("Int"))), None, _))),
-              Right(
-                List(
-                  TypeParam(
-                    TypeName(SimpleName("T")),
-                    TypeBoundsTree(
-                      TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                      TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                    ),
-                    _
-                  )
-                )
-              ),
+              Right(List(TypeParam(TypeName(SimpleName("T")), NothingAnyTypeBoundsTree(), _))),
               Left(List(ValDef(SimpleName("genericArg"), TypeIdent(TypeName(SimpleName("T"))), None, _)))
             ),
             _,
@@ -1348,35 +1329,18 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             Template(
               DefDef(
                 SimpleName("<init>"),
-                List(
-                  Right(
-                    List(
-                      TypeParam(
-                        TypeName(SimpleName("T")),
-                        TypeBoundsTree(
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                        ),
-                        _
-                      )
-                    )
-                  ),
-                  Left(Nil)
-                ),
+                List(Right(List(TypeParam(TypeName(SimpleName("T")), NothingAnyTypeBoundsTree(), _))), Left(Nil)),
                 _,
                 _,
                 _
               ),
               _,
               _,
-              TypeParam(
-                TypeName(SimpleName("T")),
-                RealTypeBounds(
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing"))),
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any")))
-                ),
-                _
-              ) :: (innerDefTree @ ClassDef(TypeName(SimpleName("NestedGeneric")), _, innerSymbol)) :: _
+              TypeParam(TypeName(SimpleName("T")), NothingAnyTypeBounds(), _) :: (innerDefTree @ ClassDef(
+                TypeName(SimpleName("NestedGeneric")),
+                _,
+                innerSymbol
+              )) :: _
             ),
             outerSymbol
           ) if outerSymbol.tree.contains(outerDefTree) && innerSymbol.tree.contains(innerDefTree) =>
@@ -1389,35 +1353,14 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             Template(
               DefDef(
                 SimpleName("<init>"),
-                List(
-                  Right(
-                    List(
-                      TypeParam(
-                        TypeName(SimpleName("U")),
-                        TypeBoundsTree(
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                          TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                        ),
-                        _
-                      )
-                    )
-                  ),
-                  Left(Nil)
-                ),
+                List(Right(List(TypeParam(TypeName(SimpleName("U")), NothingAnyTypeBoundsTree(), _))), Left(Nil)),
                 _,
                 _,
                 _
               ),
               _,
               _,
-              TypeParam(
-                TypeName(SimpleName("U")),
-                RealTypeBounds(
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing"))),
-                  TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any")))
-                ),
-                _
-              ) :: _
+              TypeParam(TypeName(SimpleName("U")), NothingAnyTypeBounds(), _) :: _
             ),
             symbol
           ) if symbol.tree.contains(defTree) =>
@@ -1581,14 +1524,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             TypeName(SimpleName("TL")),
             TypeLambdaTree(
               // [X]
-              TypeParam(
-                TypeName(SimpleName("X")),
-                TypeBoundsTree(
-                  TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                  TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                ),
-                _
-              ) :: Nil,
+              TypeParam(TypeName(SimpleName("X")), NothingAnyTypeBoundsTree(), _) :: Nil,
               // List[X]
               AppliedTypeTree(TypeIdent(TypeName(SimpleName("List"))), TypeIdent(TypeName(SimpleName("X"))) :: Nil)
             ),
@@ -1750,16 +1686,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case TypeMember(
             TypeName(SimpleName("MT")),
             TypeLambdaTree(
-              List(
-                TypeParam(
-                  TypeName(SimpleName("X")),
-                  TypeBoundsTree(
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                  ),
-                  _
-                )
-              ),
+              List(TypeParam(TypeName(SimpleName("X")), NothingAnyTypeBoundsTree(), _)),
               MatchTypeTree(
                 // No bound on the match result
                 None,
@@ -1776,16 +1703,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case TypeMember(
             TypeName(SimpleName("MTWithBound")),
             TypeLambdaTree(
-              List(
-                TypeParam(
-                  TypeName(SimpleName("X")),
-                  TypeBoundsTree(
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                  ),
-                  _
-                )
-              ),
+              List(TypeParam(TypeName(SimpleName("X")), NothingAnyTypeBoundsTree(), _)),
               MatchTypeTree(
                 Some(TypeIdent(TypeName(SimpleName("Nothing")))),
                 TypeIdent(TypeName(SimpleName("X"))),
@@ -1801,16 +1719,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case TypeMember(
             TypeName(SimpleName("MTWithWildcard")),
             TypeLambdaTree(
-              List(
-                TypeParam(
-                  TypeName(SimpleName("X")),
-                  TypeBoundsTree(
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                  ),
-                  _
-                )
-              ),
+              List(TypeParam(TypeName(SimpleName("X")), NothingAnyTypeBoundsTree(), _)),
               MatchTypeTree(
                 // No bound on the match result
                 None,
@@ -1827,16 +1736,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       case TypeMember(
             TypeName(SimpleName("MTWithBind")),
             TypeLambdaTree(
-              List(
-                TypeParam(
-                  TypeName(SimpleName("X")),
-                  TypeBoundsTree(
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                    TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                  ),
-                  _
-                )
-              ),
+              List(TypeParam(TypeName(SimpleName("X")), NothingAnyTypeBoundsTree(), _)),
               MatchTypeTree(
                 // No bound on the match result
                 None,
@@ -1944,12 +1844,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             TypeWrapper(
               ty.AppliedType(
                 TypeRefInternal(_: PackageRef, TypeName(SimpleName("List"))),
-                ty.WildcardTypeBounds(
-                  RealTypeBounds(
-                    TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing"))),
-                    TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any")))
-                  )
-                ) :: Nil
+                ty.WildcardTypeBounds(NothingAnyTypeBounds()) :: Nil
               )
             ),
             None,
@@ -1964,12 +1859,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             SimpleName("anyList"),
             AppliedTypeTree(
               TypeIdent(TypeName(SimpleName("List"))),
-              WildcardTypeBoundsTree(
-                TypeBoundsTree(
-                  TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Nothing")))),
-                  TypeWrapper(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Any"))))
-                )
-              ) :: Nil
+              WildcardTypeBoundsTree(NothingAnyTypeBoundsTree()) :: Nil
             ),
             None,
             _

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -1547,6 +1547,44 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             && typeLambdaResultIsAny.isDefinedAt(tl.resultType) =>
     }
     assert(containsSubtree(typeLambda)(clue(tree)))
+
+    val fDef = findTree(tree) { case fDef @ DefDef(SimpleName("f"), _, _, _, _) =>
+      fDef
+    }
+    val fDefExpected: StructureCheck = {
+      case DefDef(
+            SimpleName("f"),
+            List(
+              Right(
+                List(
+                  TypeParam(
+                    TypeName(SimpleName("B")),
+                    TypeLambdaTree(
+                      List(TypeParam(_, NothingAnyTypeBoundsTree(), _)),
+                      BoundedTypeTree(NothingAnyTypeBoundsTree(), None)
+                    ),
+                    _
+                  ),
+                  TypeParam(TypeName(SimpleName("T")), NothingAnyTypeBoundsTree(), _)
+                )
+              ),
+              Left(
+                List(
+                  ValDef(
+                    SimpleName("x"),
+                    AppliedTypeTree(TypeIdent(TypeName(SimpleName("B"))), List(TypeIdent(TypeName(SimpleName("T"))))),
+                    None,
+                    _
+                  )
+                )
+              )
+            ),
+            AppliedTypeTree(TypeIdent(TypeName(SimpleName("B"))), List(TypeIdent(TypeName(SimpleName("T"))))),
+            None,
+            _
+          ) =>
+    }
+    assert(containsSubtree(fDefExpected)(clue(fDef)))
   }
 
   object TyParamRef:

--- a/test-sources/src/main/scala/simple_trees/HigherKinded.scala
+++ b/test-sources/src/main/scala/simple_trees/HigherKinded.scala
@@ -2,4 +2,6 @@ package simple_trees
 
 trait HigherKinded[A[_]] {
   def m[T](x: A[T]): A[T]
+
+  def f[B[_], T](x: B[T]): B[T]
 }

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -23,6 +23,8 @@ class TypesFromTASTy:
    */
   val toplevelOpaqueTypeAlias: crosspackagetasty.TopLevelOpaqueTypeAlias =
     crosspackagetasty.TopLevelOpaqueTypeAlias(5)
+
+  def higherKinded[F[_], T](x: F[T]): F[T] = x
 end TypesFromTASTy
 
 object TypesFromTASTy:


### PR DESCRIPTION
* When converting them from TASTy, and
* In subtyping.