### PR TITLE
Better computation of top-level v nested classfiles in Loaders.

### DIFF
--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -2178,4 +2178,26 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       case typeDef =>
         fail("unexpected typeDef", clues(typeDef))
   }
+
+  testWithContext("evil-class-names-1") {
+    val EvilClassClass = ctx.findTopLevelClass("simple_trees.evil_$_class")
+    assert(clue(EvilClassClass).name == typeName("evil_$_class"))
+
+    val EvilTraitClass = ctx.findTopLevelClass("simple_trees.evil_$_trait")
+    assert(clue(EvilTraitClass).name == typeName("evil_$_trait"))
+
+    val EvilClassInnerClass = EvilClassClass.findDecl(typeName("evil_$_inner"))
+    assert(clue(EvilClassInnerClass).name == typeName("evil_$_inner"))
+
+    val EvilTraitInnerClass = EvilTraitClass.findDecl(typeName("evil_$_inner"))
+    assert(clue(EvilTraitInnerClass).name == typeName("evil_$_inner"))
+  }
+
+  testWithContext("evil-class-names-2") {
+    val SubEvilClassClass = ctx.findStaticClass("simple_trees.EvilClassNames.SubEvilClass")
+    assert(clue(SubEvilClassClass.parentClasses.head).name == typeName("evil_$_class"))
+
+    val SubEvilTraitClass = ctx.findStaticClass("simple_trees.EvilClassNames.SubEvilTrait")
+    assert(clue(SubEvilTraitClass.parentClasses(1)).name == typeName("evil_$_trait"))
+  }
 }

--- a/test-sources/src/main/scala/simple_trees/EvilClassNames.scala
+++ b/test-sources/src/main/scala/simple_trees/EvilClassNames.scala
@@ -1,0 +1,13 @@
+package simple_trees
+
+class evil_$_class:
+  class evil_$_inner
+
+trait evil_$_trait:
+  class evil_$_inner
+
+object EvilClassNames:
+  class SubEvilClass extends evil_$_class
+
+  class SubEvilTrait extends evil_$_trait
+end EvilClassNames


### PR DESCRIPTION
The previous computation was not able to deal with top-level classes containing `$` signs. Now, we only consider a class to be nested (or companion) if some other class in the same directory is a *prefix* of it.

When only `.tasty` files are present, all classes are top-level.