### PR TITLE
Handle SHAREDterm's in `readPattern`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,6 +111,7 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
+          ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Trees#PatternTree.withSpan"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Types#Type.findMember"),
         )
       },

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -467,7 +467,9 @@ object Trees {
     override final def withSpan(span: Span): CaseDef = CaseDef(pattern, guard, body)(span)
   }
 
-  sealed abstract class PatternTree(span: Span) extends Tree(span)
+  sealed abstract class PatternTree(span: Span) extends Tree(span):
+    def withSpan(span: Span): PatternTree
+  end PatternTree
 
   /** Wildcard pattern `_`. */
   final case class WildcardPattern(tpe: Type)(span: Span) extends PatternTree(span):

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -790,6 +790,10 @@ private[tasties] class TreeUnpickler(
       val patType = readType
       val patterns = reader.until(end)(readPattern)
       Unapply(fun, args, patterns)(spn)
+    case SHAREDterm =>
+      val spn = span
+      reader.readByte()
+      forkAt(reader.readAddr()).readPattern.withSpan(spn)
     case _ =>
       val expr = readTerm
       ExprPattern(expr)(expr.span)

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -565,6 +565,28 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     assert(containsSubtree(tryMatch)(clue(tree)))
   }
 
+  testUnpickle("for-expressions", "simple_trees.ForExpressions") { tree =>
+    val test1Def = findTree(tree) { case test1Def @ DefDef(SimpleName("test1"), _, _, _, _) =>
+      test1Def
+    }
+
+    val forExpressionMatch1: StructureCheck = {
+      case CaseDef(
+            Unapply(
+              TypeApply(Select(Ident(SimpleName("Tuple2")), SignedName(SimpleName("unapply"), _, _)), _),
+              Nil,
+              List(
+                Bind(i, WildcardPattern(TypeRefInternal(_, TypeName(SimpleName("Int")))), _),
+                WildcardPattern(TypeRefInternal(_, TypeName(SimpleName("String"))))
+              )
+            ),
+            None,
+            Literal(Constant(true))
+          ) =>
+    }
+    assert(containsSubtree(forExpressionMatch1)(clue(test1Def)))
+  }
+
   testUnpickle("singletonType", "simple_trees.SingletonType") { tree =>
     val defDefWithSingleton: StructureCheck = {
       case DefDef(

--- a/test-sources/src/main/scala/simple_trees/ForExpressions.scala
+++ b/test-sources/src/main/scala/simple_trees/ForExpressions.scala
@@ -1,0 +1,10 @@
+package simple_trees
+
+class ForExpressions:
+  val listOfTups = List((1, "foo"))
+
+  def test1(): Unit =
+    for (i, _) <- listOfTups do
+      println(i)
+  end test1
+end ForExpressions


### PR DESCRIPTION
And with that, we solve the last issue caused by tasty-query in the langoustine project.
There will remain one issue to fix on tasty-mima's side.