### PR TITLE
Fix erasure of array of union types.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -891,6 +891,13 @@ object Types {
 
     private[tastyquery] def apply(prefix: Prefix, external: Scala2ExternalSymRef): TypeRef =
       new TypeRef(prefix, external)
+
+    private[tastyquery] object OfClass:
+      def unapply(typeRef: TypeRef)(using Context): Option[ClassSymbol] =
+        val symbol = typeRef.symbol
+        if symbol.isClass then Some(symbol.asClass)
+        else None
+    end OfClass
   end TypeRef
 
   final class ThisType(val tref: TypeRef) extends PathType with SingletonType {

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -280,6 +280,9 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
       "classesOrType",
       "(scala.collection.generic.DefaultSerializable):scala.collection.immutable.Seq"
     )
+
+    val arrayOfUnion = UnionType.findNonOverloadedDecl(name"arrayOfUnion")
+    assertIsSignedName(arrayOfUnion.signedName, "arrayOfUnion", "(java.lang.Object[]):java.lang.Object[]")
   }
 
 end SignatureSuite

--- a/test-sources/src/main/scala/simple_trees/UnionType.scala
+++ b/test-sources/src/main/scala/simple_trees/UnionType.scala
@@ -4,4 +4,6 @@ class UnionType {
   def argWithOrType(x: Int | String) = x
 
   def classesOrType(x: List[Int] | Vector[String]): Seq[Int | String] = x
+
+  def arrayOfUnion(x: Array[AnyRef | Null]): Array[AnyRef | Null] = x
 }


### PR DESCRIPTION
In general, of array of `AppliedType(tycon, args)` where `tycon` is a type alias to a `TypeLambda`.