### PR TITLE
Consolidate Trees for type bounds and type definitions.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -1440,20 +1440,6 @@ object Types {
     override def toString(): String = s"TypeAlias($alias)"
   }
 
-  final class BoundedType(val bounds: TypeBounds, val alias: Option[Type]) extends Type {
-    private[tastyquery] def findMember(name: Name, pre: Type)(using Context): Option[Symbol] =
-      bounds.high.findMember(name, pre)
-
-    override def toString(): String = s"BoundedType($bounds, $alias)"
-  }
-
-  final class NamedTypeBounds(val name: TypeName, val bounds: TypeBounds) extends Type {
-    private[tastyquery] def findMember(name: Name, pre: Type)(using Context): Option[Symbol] =
-      bounds.high.findMember(name, pre)
-
-    override def toString(): String = s"NamedTypeBounds($name, $bounds)"
-  }
-
   final class WildcardTypeBounds(val bounds: TypeBounds) extends TypeProxy {
     override def underlying(using Context): Type = bounds.high
 

--- a/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
@@ -327,7 +327,7 @@ class PositionSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickleWithCode("bounded-type".ignore, "simple_trees.TypeMember") { (tree, code) =>
-    assertEquals(collectCode[BoundedTypeTree](tree, code), List(""))
+    assertEquals(collectCode[TypeDefinitionTree](tree, code), List(""))
   }
 
   testUnpickleWithCode("named-type-bounds".ignore, "simple_trees.MatchType") { (tree, code) =>
@@ -335,7 +335,7 @@ class PositionSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickleWithCode("type-lambda", "simple_trees.TypeLambda") { (tree, code) =>
-    assertEquals(collectCode[TypeLambdaTree](tree, code), List("[X] =>> List[X]"))
+    assertEquals(collectCode[PolyTypeDefinitionTree](tree, code), List("[X] =>> List[X]"))
   }
 
   /** Inlined */


### PR DESCRIPTION
We create a new category of trees, `TypeDefinitionTree`, for the rhs of type definitions: type members, type parameters and type captures. They isolate the weird, context-dependent meaning of TYPEBOUNDS, TYPEBOUNDStpt (sometimes wrapped in LAMBDAtpt) from the hierarchy of `Type`s and the corresponding `TypeTree`s.

The `TypeDefinitionTree`s are read from TASTy using a few isolated functions, and they are transformed depending on their context into `TypeBounds`, `WildcardTypeBounds`, `TypeMemberDefinition`s, etc.

These changes allow to completely remove `BoundedType` and `NamedTypeBounds` from the hierarchy of `Type`s, so that we are certain they do not leak to the semantic areas of the API.