### PR TITLE
Do not wrap the result type of paramless methods in ExprType.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.None,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))
@@ -111,8 +111,6 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
-          ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Trees#PatternTree.withSpan"),
-          ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Types#Type.findMember"),
         )
       },
     )

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -80,7 +80,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   private def createSpecialMethod(
     owner: ClassSymbol,
     name: TermName,
-    tpe: MethodicType,
+    tpe: Type,
     flags: FlagSet = EmptyFlagSet
   ): TermSymbol =
     val sym = TermSymbol
@@ -154,7 +154,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   val Any_== = createSpecialMethod(AnyClass, nme.m_==, equalityMethodType, Final)
   val Any_!= = createSpecialMethod(AnyClass, nme.m_!=, equalityMethodType, Final)
-  val Any_## = createSpecialMethod(AnyClass, nme.m_##, ExprType(IntType), Final)
+  val Any_## = createSpecialMethod(AnyClass, nme.m_##, IntType, Final)
 
   val Any_equals = createSpecialMethod(AnyClass, nme.m_equals, equalityMethodType)
   val Any_hashCode = createSpecialMethod(AnyClass, nme.m_hashCode, MethodType(Nil, Nil, IntType))

--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -16,8 +16,8 @@ private[tastyquery] object Erasure:
 
   def erase(tpe: Type)(using Context): ErasedTypeRef =
     tpe match
-      case _: ExprType => ClassRef(defn.Function0Class)
-      case _           => finishErase(preErase(tpe))
+      case _: ByNameType => ClassRef(defn.Function0Class)
+      case _             => finishErase(preErase(tpe))
   end erase
 
   /** First pass of erasure, where some special types are preserved as is.

--- a/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
@@ -24,9 +24,7 @@ object Signatures:
   end Signature
 
   object Signature {
-    private[tastyquery] def fromMethodic(info: MethodicType, optCtorReturn: Option[ClassSymbol])(
-      using Context
-    ): Signature =
+    private[tastyquery] def fromMethodType(info: Type, optCtorReturn: Option[ClassSymbol])(using Context): Signature =
       def rec(info: Type, acc: List[ParamSig]): Signature =
         info match {
           case info: MethodType =>
@@ -39,9 +37,7 @@ object Signatures:
             Signature(acc, ErasedTypeRef.erase(retType).toSigFullName)
         }
 
-      info match
-        case info: ExprType => Signature(Nil, ErasedTypeRef.erase(info.resultType).toSigFullName)
-        case _              => rec(info, Nil)
-    end fromMethodic
+      rec(info, Nil)
+    end fromMethodType
   }
 end Signatures

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -161,10 +161,10 @@ private[tastyquery] object Subtyping:
       isSubtype(tp1, tp2.first) || isSubtype(tp1, tp2.second)
         || level4(tp1, tp2)
 
-    case tp2: ExprType =>
+    case tp2: ByNameType =>
       tp1 match
-        case tp1: ExprType => isSubtype(tp1.resultType, tp2.resultType)
-        case _             => level4(tp1, tp2)
+        case tp1: ByNameType => isSubtype(tp1.resultType, tp2.resultType)
+        case _               => level4(tp1, tp2)
 
     case _ =>
       level4(tp1, tp2)
@@ -177,7 +177,7 @@ private[tastyquery] object Subtyping:
   end level3WithBaseType
 
   private def nonExprBaseType(tp1: Type, cls2: ClassSymbol)(using Context): Option[Type] =
-    if tp1.isInstanceOf[ExprType] then None
+    if tp1.isInstanceOf[ByNameType] then None
     else tp1.baseType(cls2)
 
   private def compareAppliedType2(tp1: Type, tp2: AppliedType)(using Context): Boolean =

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -280,7 +280,7 @@ private[tastyquery] object Subtyping:
       def comparePaths: Boolean =
         tp2 match
           case tp2: TermRef =>
-            tp2.symbol.declaredTypeAsSeenFrom(tp2.prefix).widenExpr.dealias match
+            tp2.symbol.declaredTypeAsSeenFrom(tp2.prefix).dealias match
               case tp2Singleton: SingletonType =>
                 isSubtype(tp1, tp2Singleton)
               case _ =>
@@ -289,7 +289,7 @@ private[tastyquery] object Subtyping:
             false
 
       def proceedWithWidenedType: Boolean =
-        isSubtype(tp1.underlying.widenExpr, tp2)
+        isSubtype(tp1.underlying, tp2)
 
       comparePaths || proceedWithWidenedType
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -444,7 +444,7 @@ object Symbols {
       * A stable member is one that is known to be idempotent.
       */
     final def isStableMember(using Context): Boolean =
-      !isAnyOf(Method | Mutable) && !declaredType.isInstanceOf[ExprType]
+      !isAnyOf(Method | Mutable) && !declaredType.isInstanceOf[ByNameType]
   end TermSymbol
 
   object TermSymbol:

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -256,7 +256,7 @@ object Symbols {
             val targetType = self.declaredTypeAsSeenFrom(site)
             candidates.find { candidate =>
               // TODO Also check targetName here
-              candidate.declaredTypeAsSeenFrom(site).matchesLoosely(targetType)
+              candidate.declaredTypeAsSeenFrom(site).matches(targetType)
             }
     end matchingDecl
 
@@ -394,10 +394,9 @@ object Symbols {
       val local = mySignature
       if local != null then local
       else
-        val sig = declaredType match
-          case methodic: MethodicType =>
-            Some(Signature.fromMethodic(methodic, Option.when(isConstructor)(owner.asClass)))
-          case _ => None
+        val sig =
+          if is(Method) then Some(Signature.fromMethodType(declaredType, Option.when(isConstructor)(owner.asClass)))
+          else None
         mySignature = sig
         sig
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -642,7 +642,7 @@ object Trees {
   /** => T */
   final case class ByNameTypeTree(result: TypeTree)(span: Span) extends TypeTree(span) {
     override protected def calculateType(using Context): Type =
-      ExprType(result.toType)
+      ByNameType(result.toType)
 
     override final def withSpan(span: Span): ByNameTypeTree = ByNameTypeTree(result)(span)
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -60,8 +60,8 @@ private[tastyquery] object TypeMaps {
       tp.derivedOrType(tp1, tp2)
     protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Tree): Type =
       tp.derivedAnnotatedType(underlying, annot)
-    protected def derivedExprType(tp: ExprType, restpe: Type): Type =
-      tp.derivedExprType(restpe)
+    protected def derivedByNameType(tp: ByNameType, restpe: Type): Type =
+      tp.derivedByNameType(restpe)
     protected def derivedLambdaType(tp: LambdaType, formals: List[tp.PInfo], restpe: Type): Type =
       tp.derivedLambdaType(tp.paramNames, formals, restpe)
 
@@ -106,8 +106,8 @@ private[tastyquery] object TypeMaps {
         case tp: WildcardTypeBounds =>
           derivedWildcardTypeBounds(tp, this(tp.bounds))
 
-        case tp: ExprType =>
-          derivedExprType(tp, this(tp.resultType))
+        case tp: ByNameType =>
+          derivedByNameType(tp, this(tp.resultType))
 
         case tp: AnnotatedType =>
           derivedAnnotatedType(tp, this(tp.typ), tp.annotation) // tp.annotation.mapWith(this)

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -228,15 +228,6 @@ object Types {
         case tp: TermRef => tp.underlying.widenOverloads
         case tp          => tp
 
-    /** Widen from ExprType type to its result type.
-      *
-      * For all other types, return `this`.
-      */
-    final def widenExpr: Type = this match {
-      case tp: ExprType => tp.resultType
-      case _            => this
-    }
-
     /** Widen singleton types, ExprTypes, AnnotatedTypes and RefinedTypes. */
     final def widen(using Context): Type = this match
       case _: TypeRef | _: MethodType | _: PolyType => this // fast path for most frequent cases
@@ -327,7 +318,6 @@ object Types {
       this match {
         case tpe: NamedType    => tpe.symbol == sym
         case tpe: AppliedType  => tpe.underlying.isRef(sym)
-        case tpe: ExprType     => tpe.underlying.isRef(sym)
         case tpe: TermParamRef => tpe.underlying.isRef(sym)
         case tpe: TypeParamRef => tpe.bounds.high.isRef(sym)
         case _                 => false // todo: add ProxyType (need to fill in implementations of underlying)
@@ -407,15 +397,6 @@ object Types {
       */
     final def matches(that: Type)(using Context): Boolean =
       TypeOps.matchesType(this, that)
-
-    /** This is the same as `matches` except that it also matches `=> T` with `T` and vice versa. */
-    final def matchesLoosely(that: Type)(using Context): Boolean =
-      this.matches(that) || {
-        val thisResult = this.widenExpr
-        val thatResult = that.widenExpr
-        (this eq thisResult) != (that eq thatResult) && thisResult.matches(thatResult)
-      }
-    end matchesLoosely
 
     // Combinators
 
@@ -1012,8 +993,8 @@ object Types {
     override def toString(): String = s"AppliedType($tycon, $args)"
   }
 
-  /** A by-name parameter type of the form `=> T`, or the type of a method with no parameter list. */
-  final class ExprType(val resultType: Type) extends TypeProxy with MethodicType {
+  /** A by-name parameter type of the form `=> T`. */
+  final class ExprType(val resultType: Type) extends TypeProxy with TermType {
     override def underlying(using Context): Type = resultType
 
     private[tastyquery] final def derivedExprType(resultType: Type): ExprType =
@@ -1162,14 +1143,10 @@ object Types {
       *   - add @inlineParam to inline parameters
       */
     private[tastyquery] def fromSymbols(params: List[TermSymbol], resultType: Type)(using Context): MethodType = {
-      // def translateInline(tp: Type): Type = tp match {
-      //   case ExprType(resType) => ExprType(AnnotatedType(resType, Annotation(defn.InlineParamAnnot)))
-      //   case _ => AnnotatedType(tp, Annotation(defn.InlineParamAnnot))
-      // }
-      // def translateErased(tp: Type): Type = tp match {
-      //   case ExprType(resType) => ExprType(AnnotatedType(resType, Annotation(defn.ErasedParamAnnot)))
-      //   case _ => AnnotatedType(tp, Annotation(defn.ErasedParamAnnot))
-      // }
+      // def translateInline(tp: Type): Type =
+      //   AnnotatedType(tp, Annotation(defn.InlineParamAnnot))
+      // def translateErased(tp: Type): Type =
+      //   AnnotatedType(tp, Annotation(defn.ErasedParamAnnot))
       def paramInfo(param: TermSymbol) = {
         var paramType = param.declaredType //.annotatedToRepeated
         // if (param.is(Inline)) paramType = translateInline(paramType)

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -228,19 +228,19 @@ object Types {
         case tp: TermRef => tp.underlying.widenOverloads
         case tp          => tp
 
-    /** Widen singleton types, ExprTypes, AnnotatedTypes and RefinedTypes. */
+    /** Widen singleton types, ByNameTypes, AnnotatedTypes and RefinedTypes. */
     final def widen(using Context): Type = this match
       case _: TypeRef | _: MethodType | _: PolyType => this // fast path for most frequent cases
       case tp: TermRef => // fast path for next most frequent case
         if tp.isOverloaded then tp else tp.underlying.widen
       case tp: SingletonType => tp.underlying.widen
-      case tp: ExprType      => tp.resultType.widen
+      case tp: ByNameType    => tp.resultType.widen
       case tp: AnnotatedType => tp.typ.widen
       case tp: RefinedType   => tp.parent.widen
       case tp                => tp
 
     private[tastyquery] final def widenIfUnstable(using Context): Type = this match
-      case tp: ExprType                             => tp.resultType.widenIfUnstable
+      case tp: ByNameType                           => tp.resultType.widenIfUnstable
       case tp: TermRef if !tp.symbol.isStableMember => tp.underlying.widenIfUnstable
       case _                                        => this
 
@@ -994,13 +994,13 @@ object Types {
   }
 
   /** A by-name parameter type of the form `=> T`. */
-  final class ExprType(val resultType: Type) extends TypeProxy with TermType {
+  final class ByNameType(val resultType: Type) extends TypeProxy with TermType {
     override def underlying(using Context): Type = resultType
 
-    private[tastyquery] final def derivedExprType(resultType: Type): ExprType =
-      if (resultType eq this.resultType) this else ExprType(resultType)
+    private[tastyquery] final def derivedByNameType(resultType: Type): ByNameType =
+      if (resultType eq this.resultType) this else ByNameType(resultType)
 
-    override def toString(): String = s"ExprType($resultType)"
+    override def toString(): String = s"ByNameType($resultType)"
   }
 
   sealed trait LambdaType extends ParamRefBinders with TermType {

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -114,7 +114,7 @@ private[classfiles] object Descriptors:
 
     val parsedDescriptor =
       if isMethod then methodDescriptor
-      else ExprType(fieldDescriptor)
+      else fieldDescriptor
 
     if available > 0 then unconsumed
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -274,7 +274,7 @@ private[classfiles] object JavaSignatures:
         classRest(null)
 
     def fieldSignature: Type =
-      ExprType(referenceType(null))
+      referenceType(null)
 
     def cookFailure(tname: TypeName, reason: String): Nothing =
       val path = if !isClass then s"${member.owner.erasedName}#${member.name}" else member.erasedName

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -474,7 +474,7 @@ private[pickles] class PickleReader {
           case external: ExternalSymbolRef => external.toNamedType(pre)
           case _: NoExternalSymbolRef      => throw Scala2PickleFormatException("TYPEREFtpe references NoSymbol")
         val args = pkl.until(end, () => readTypeRef())
-        /*if (sym == defn.ByNameParamClass2x) ExprType(args.head)
+        /*if (sym == defn.ByNameParamClass2x) ByNameType(args.head)
         else if (ctx.settings.scalajs.value && args.length == 2 &&
             sym.owner == JSDefinitions.jsdefn.ScalaJSJSPackageClass && sym == JSDefinitions.jsdefn.PseudoUnionClass) {
           // Treat Scala.js pseudo-unions as real unions, this requires a

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -528,8 +528,8 @@ private[pickles] class PickleReader {
         //   - PT => register at index
         val restpe = readTypeRef()
         val typeParams = pkl.until(end, () => readLocalSymbolRef().asInstanceOf[TypeParamSymbol])
-        if typeParams.nonEmpty then TempPolyType(typeParams, restpe.widenExpr)
-        else ExprType(restpe)
+        if typeParams.nonEmpty then TempPolyType(typeParams, restpe)
+        else restpe
       case EXISTENTIALtpe =>
         val restpe = readTypeRef()
         // TODO Should these be LocalTypeParamSymbols?

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -1152,7 +1152,7 @@ private[tasties] class TreeUnpickler(
       OrType(readType, readType)
     case BYNAMEtype =>
       reader.readByte()
-      ExprType(readType)
+      ByNameType(readType)
     case POLYtype =>
       readLambdaType(_ => PolyType, name => name.toTypeName, _.readTypeBounds)
     case METHODtype =>

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -727,8 +727,7 @@ private[tasties] class TreeUnpickler(
         case Nil =>
           resultTpt.toType
 
-    if paramLists.isEmpty then ExprType(resultTpt.toType)
-    else rec(paramLists)
+    rec(paramLists)
   end makeDefDefType
 
   private def readTerms(end: Addr)(using LocalContext): List[TermTree] =

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -95,8 +95,8 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     object AnnotatedType:
       def unapply(tpe: Types.AnnotatedType): (Type, Tree) = (tpe.typ, tpe.annotation)
 
-    object ExprType:
-      def unapply(tpe: Types.ExprType): Some[Type] = Some(tpe.resultType)
+    object ByNameType:
+      def unapply(tpe: Types.ByNameType): Some[Type] = Some(tpe.resultType)
 
     object OrType:
       def unapply(tpe: Types.OrType): (Type, Type) = (tpe.first, tpe.second)
@@ -1459,7 +1459,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     val byName: StructureCheck = {
       case ValDef(
             SimpleName("byNameParam"),
-            TypeWrapper(ty.ExprType(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int"))))),
+            TypeWrapper(ty.ByNameType(TypeRefInternal(ScalaPackageRef(), TypeName(SimpleName("Int"))))),
             None,
             _
           ) =>

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -611,21 +611,21 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     val PStringType = PredefPrefix.select(tname"String")
 
     assertEquiv(
-      fun1Type(ExprType(defn.StringType), defn.StringType),
-      fun1Type(ExprType(defn.StringType), defn.StringType)
+      fun1Type(ByNameType(defn.StringType), defn.StringType),
+      fun1Type(ByNameType(defn.StringType), defn.StringType)
     ).withRef[(=> JString) => JString, (=> JString) => JString]
 
-    assertEquiv(fun1Type(ExprType(defn.StringType), defn.StringType), fun1Type(ExprType(PStringType), PStringType))
+    assertEquiv(fun1Type(ByNameType(defn.StringType), defn.StringType), fun1Type(ByNameType(PStringType), PStringType))
       .withRef[(=> JString) => JString, (=> PString) => PString]
 
     assertNeitherSubtype(
-      fun1Type(ExprType(defn.StringType), defn.StringType),
+      fun1Type(ByNameType(defn.StringType), defn.StringType),
       fun1Type(defn.StringType, defn.StringType)
     ).withRef[(=> JString) => JString, JString => JString]
 
     assertNeitherSubtype(
-      fun1Type(ExprType(defn.StringType), defn.StringType),
-      fun1Type(ExprType(defn.IntType), defn.StringType)
+      fun1Type(ByNameType(defn.StringType), defn.StringType),
+      fun1Type(ByNameType(defn.IntType), defn.StringType)
     ).withRef[(=> JString) => JString, (=> Int) => JString]
   }
 

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -43,8 +43,8 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     def isByName(arg: Type => Boolean)(using Context): Boolean =
       tpe match
-        case tpe: ExprType => arg(tpe.resultType)
-        case _             => false
+        case tpe: ByNameType => arg(tpe.resultType)
+        case _               => false
 
     def isArrayOf(arg: Type => Boolean)(using Context): Boolean =
       isApplied(_.isRef(defn.ArrayClass), Seq(arg))

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -41,6 +41,11 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
           app.args.corresponds(argRefs)((arg, argRef) => argRef(arg))
         case _ => false
 
+    def isByName(arg: Type => Boolean)(using Context): Boolean =
+      tpe match
+        case tpe: ExprType => arg(tpe.resultType)
+        case _             => false
+
     def isArrayOf(arg: Type => Boolean)(using Context): Boolean =
       isApplied(_.isRef(defn.ArrayClass), Seq(arg))
 
@@ -140,7 +145,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
   applyOverloadedTest("apply-overloaded-arrayObj")("callD", _.isRef(defn.ArrayClass))
   applyOverloadedTest("apply-overloaded-byName")(
     "callE",
-    _.isRef(ctx.findTopLevelClass("simple_trees.OverloadedApply").findDecl(tname"Num"))
+    _.isByName(_.isRef(ctx.findTopLevelClass("simple_trees.OverloadedApply").findDecl(tname"Num")))
   )
   applyOverloadedTest("apply-overloaded-gen-target-name")(
     "callG",
@@ -349,17 +354,14 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     // val start: Int
     val startSym = RangeClass.findDecl(name"start")
     assert(startSym.declaredType.isOfClass(defn.IntClass), clue(startSym.declaredType))
-    assert(startSym.declaredType.isInstanceOf[ExprType], clue(startSym.declaredType)) // should this be TypeRef?
 
     // val isEmpty: Boolean
     val isEmptySym = RangeClass.findDecl(name"isEmpty")
     assert(isEmptySym.declaredType.isOfClass(defn.BooleanClass), clue(isEmptySym.declaredType))
-    assert(isEmptySym.declaredType.isInstanceOf[ExprType], clue(isEmptySym.declaredType)) // should this be TypeRef?
 
     // def isInclusive: Boolean
     val isInclusiveSym = RangeClass.findDecl(name"isInclusive")
     assert(isInclusiveSym.declaredType.isOfClass(defn.BooleanClass), clue(isInclusiveSym.declaredType))
-    assert(isInclusiveSym.declaredType.isInstanceOf[ExprType], clue(isInclusiveSym.declaredType))
 
     // def by(step: Int): Range
     locally {


### PR DESCRIPTION
Reserve `ExprType` for by-name params only.

This is closer to the contents of TASTy and of pickles, and is also closer to a user understanding of the language.

We then rename `ExprType` to `ByNameType`.