### PR TITLE
Make signature, targetName and signedName more user-friendly.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
@@ -24,7 +24,7 @@ object Signatures:
   end Signature
 
   object Signature {
-    private[tastyquery] def fromMethodType(info: Type, optCtorReturn: Option[ClassSymbol])(using Context): Signature =
+    private[tastyquery] def fromType(info: Type, optCtorReturn: Option[ClassSymbol])(using Context): Signature =
       def rec(info: Type, acc: List[ParamSig]): Signature =
         info match {
           case info: MethodType =>
@@ -38,6 +38,6 @@ object Signatures:
         }
 
       rec(info, Nil)
-    end fromMethodType
+    end fromType
   }
 end Signatures

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -83,11 +83,20 @@ private[tastyquery] object Subtyping:
       /* When the symbols are not the same, we could still have a subtyping
        * relationship if they are defined in different classes of the same hierarchy.
        */
+
+      def sameTermSignature: Boolean =
+        // TODO? dotc does this but in my (sjrd) opinion, this should be !sym1.needsSignature && !sym2.needsSignature
+        val sym1Term = sym1.asTerm
+        val sym2Term = sym2.asTerm
+        if sym1Term.needsSignature then sym2Term.needsSignature && tp1.asTerm.signature == tp2.asTerm.signature
+        else !sym2Term.needsSignature
+
       val trueBecauseOverriddenMembers =
         sym1.name == sym2.name
           && isSubprefix(tp1.prefix, tp2.prefix)
-          && tp1.optSignature == tp2.optSignature
+          && (sym1.isType || sameTermSignature)
           && !(sym1.isClass && sym2.isClass) // classes can shadow each other without being subtypes
+
       trueBecauseOverriddenMembers || level2(tp1, tp2)
   end level1NamedNamed
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -526,7 +526,6 @@ object Types {
 
     private var myName: ThisName | Null = null
     private var mySymbol: ThisSymbolType | Null = null
-    private var myOptSignature: Option[Signature] | Null = null
 
     private[tastyquery] final def isLocalRef(sym: Symbol): Boolean =
       prefix == NoPrefix && designator == sym
@@ -641,17 +640,6 @@ object Types {
       }
     end argForParam
 
-    private[tastyquery] final def optSignature(using Context): Option[Signature] =
-      val local = myOptSignature
-      if local != null then local
-      else
-        val computed = this match
-          case termRef: TermRef => termRef.symbol.signature
-          case _: TypeRef       => None
-        myOptSignature = computed
-        computed
-    end optSignature
-
     /** A selection of the same kind, but with potentially a different prefix.
       * The following normalization is performed for type selections T#A:
       *
@@ -735,6 +723,9 @@ object Types {
     type ThisNamedType = TermRef
     protected type ThisDesignatorType = TermSymbol | TermName | LookupIn | Scala2ExternalSymRef
 
+    // Cache fields
+    private var mySignature: Signature | Null = null
+
     protected def designator: ThisDesignatorType = myDesignator
 
     protected def storeComputedSymbol(sym: ThisSymbolType): Unit =
@@ -761,6 +752,15 @@ object Types {
       val termSymbol = symbol
       termSymbol.declaredType.asSeenFrom(prefix, termSymbol.owner)
     }
+
+    private[tastyquery] final def signature(using Context): Signature =
+      val local = mySignature
+      if local != null then local
+      else
+        val computed = symbol.signature
+        mySignature = computed
+        computed
+    end signature
 
     final def isOverloaded(using Context): Boolean =
       myDesignator match


### PR DESCRIPTION
We make `signature` and `targetName` public. All terms now have a `signature` (it is non-optional). For fields, it is the signature of the JVM/IR getter method, which is also the descriptor of the underlying JVM field.

In contrast, `signedName` does not return a `SignedName` for parameterless methods anymore. It returns a `SignedName` if and only if a `SignedName` is required to find the symbol through `getDecl`. To access the JVM signature of a parameterless method, `signature` can be used.

---

~~Based on #257.~~