### PR TITLE
Remove a stray TODO comment in SignatureSuite.

### DIFF
--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -110,8 +110,6 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   testWithContext("array types") {
     val TypeRefIn = ctx.findTopLevelClass("simple_trees.TypeRefIn")
 
-    // TODO The erasure is not actually correct here, but at least we don't crash
-
     val withArray = TypeRefIn.findNonOverloadedDecl(name"withArray")
     assertSigned(withArray, "(1,java.lang.Object):scala.Unit")
 


### PR DESCRIPTION
It alleges that the test is not correct, but it was actually made correct in dea21ab080170f205050b02ca92d83ff2362546d.