### PR TITLE
Subtyping: eta-expand tp1 when tp2 is a TypeLambda.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -522,6 +522,10 @@ object Symbols {
     private[tastyquery] def paramVariance(using Context): Variance =
       Variance.fromFlags(flags)
 
+    private[tastyquery] def paramName: TypeName = name
+
+    private[tastyquery] def paramTypeBounds(using Context): TypeBounds = bounds
+
     final def typeRef(using Context): TypeRef = TypeRef(ThisType(owner.typeRef), this)
 
     /** The argument corresponding to this class type parameter as seen from prefix `pre`.

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -121,6 +121,12 @@ object Types {
   private[tastyquery] trait TypeParamInfo:
     /** The variance of the type parameter */
     private[tastyquery] def paramVariance(using Context): Variance
+
+    /** The name of the type parameter */
+    private[tastyquery] def paramName: TypeName
+
+    /** The bounds of the type parameter */
+    private[tastyquery] def paramTypeBounds(using Context): TypeBounds
   end TypeParamInfo
 
   sealed trait TypeMappable:
@@ -1299,6 +1305,12 @@ object Types {
   private[tastyquery] final class TypeLambdaParam(val typeLambda: TypeLambda, num: Int) extends TypeParamInfo:
     override def paramVariance(using Context): Variance =
       Variance.Invariant // TODO? Should we set structure variances?
+
+    private[tastyquery] def paramName: TypeName =
+      typeLambda.paramNames(num)
+
+    private[tastyquery] def paramTypeBounds(using Context): TypeBounds =
+      typeLambda.paramTypeBounds(num)
   end TypeLambdaParam
 
   final class TypeLambda(val paramNames: List[TypeName])(
@@ -1346,6 +1358,11 @@ object Types {
       using Context
     ): TypeLambda =
       apply(params.map(_.name))(_ => params.map(_.symbol.bounds), resultTypeExp)
+
+    private[tastyquery] def fromParamInfos(params: List[TypeParamInfo])(resultTypeExp: TypeLambda => Type)(
+      using Context
+    ): TypeLambda =
+      apply(params.map(_.paramName))(_ => params.map(_.paramTypeBounds), resultTypeExp)
   end TypeLambda
 
   final class TypeParamRef(val binders: TypeBinders, val paramNum: Int) extends TypeProxy with ValueType with ParamRef {

--- a/test-sources/src/main/scala/subtyping/paths/Paths.scala
+++ b/test-sources/src/main/scala/subtyping/paths/Paths.scala
@@ -53,4 +53,7 @@ class ConcreteSimplePathsChild extends SimplePaths:
   type ConcreteOnlyMember = Boolean
 
   override def abstractTerm: List[Int] = ???
+
+  class InnerClassMono extends A
+  class InnerClassPoly[T] extends C
 end ConcreteSimplePathsChild


### PR DESCRIPTION
This allows subtyping of refinements to work out for poly-kinded type refinements implemented by polymorphic classes.

Follow-up to https://github.com/scalacenter/tasty-query/pull/268#pullrequestreview-1356309953