### PR TITLE
Remove the `symbolic_--` package from the test-sources.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val testSources = crossProject(JSPlatform, JVMPlatform)
   .settings(commonSettings)
   .settings(
     publish / skip := true,
+    scalacOptions += "-Xfatal-warnings",
   )
 
 lazy val tastyQuery =

--- a/test-sources/src/main/scala/symbolic_--/lazyCons.scala
+++ b/test-sources/src/main/scala/symbolic_--/lazyCons.scala
@@ -1,3 +1,0 @@
-package symbolic_--
-
-class #::


### PR DESCRIPTION
That is officially deprecated in Scala 3 now, and we had no test left mentioning it.

We can now enable `-Xfatal-warnings` for Scala in `test-sources`.