### PR TITLE
Implement erasure for the remaining TypeProxy's.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -100,8 +100,12 @@ private[tastyquery] object Erasure:
           case None          => preErase(tpe.bound)
       case tpe: OrType =>
         erasedLub(preErase(tpe.first), preErase(tpe.second))
-      case tpe =>
+      case tpe: AndType =>
         throw UnsupportedOperationException(s"Cannot erase $tpe")
+      case tpe: TypeProxy =>
+        preErase(tpe.underlying)
+      case _: MethodicType | _: PackageRef | _: CustomTransientGroundType =>
+        throw IllegalArgumentException(s"Unexpected type in erasure: $tpe")
   end preErase
 
   private def finishErase(typeRef: ErasedTypeRef)(using Context): ErasedTypeRef =

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -305,6 +305,12 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
 
     val foo = RefinedTypeTree.findNonOverloadedDecl(name"foo")
     assertSigned(foo, "(simple_trees.RefinedTypeTree.A):scala.Int")
+
+    val innerRef = RefinedTypeTree.findNonOverloadedDecl(name"innerRef")
+    assertSigned(innerRef, "(simple_trees.RefinedTypeTree.C):scala.Int")
+
+    val innerRefVal = RefinedTypeTree.findNonOverloadedDecl(name"innerRefVal")
+    assertNotSigned(innerRefVal, "():simple_trees.RefinedTypeTree.C")
   }
 
   testWithContext("match types") {


### PR DESCRIPTION
In particular, for `RecType`s.

This makes the scala-debug-adapter CI pass again.