### PR TITLE
Fix the definition of `RepeatedParamClass`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -256,7 +256,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     val cls = ClassSymbol.create(name, scalaPackage)
 
     val tparam = ClassTypeParamSymbol.create(typeName("T"), cls)
-    tparam.withFlags(ClassTypeParam, None)
+    tparam.withFlags(ClassTypeParam | paramFlags, None)
     tparam.setBounds(NothingAnyBounds)
     tparam.setAnnotations(Nil)
     tparam.checkCompleted()
@@ -264,7 +264,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     cls.withTypeParams(tparam :: Nil)
     cls.withFlags(EmptyFlagSet | Artifact, None)
 
-    val parents = parentConstrs(TypeRef(NoPrefix, tparam))
+    val parents = parentConstrs(TypeRef(cls.thisType, tparam))
     cls.withParentsDirect(parents)
     cls
   end createSpecialPolyClass

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -322,6 +322,18 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       .withRef[IList[JString], Seq[Int]]
   }
 
+  testWithContext("repeated-type") {
+    assertEquiv(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.IntType))
+    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.IntType))
+
+    assertNeitherSubtype(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.StringType))
+    assertNeitherSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.StringType))
+
+    // Covariance
+    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.AnyValType))
+    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.AnyValType))
+  }
+
   testWithContext("polymorphic-opaque-type-alias") {
     val IArraySym = ctx.findStaticType("scala.IArray$package.IArray").asInstanceOf[TypeMemberSymbol]
 


### PR DESCRIPTION
- Its type param must be covariant.
- The TypeRef to the type param must have a `ThisType` prefix in the parent constructors.