### PR TITLE
Make ClassSymbol.thisType and Type.typeParams public.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,14 @@ lazy val tastyQuery =
           // private[reader], so this is fine
           ProblemFilters.exclude[Problem]("tastyquery.reader.tasties.TastyUnpickler#*"),
 
+          // private[tastyquery], so this is fine
+          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Types$TypeParamInfo"),
+
+          /* We removed TypeParamInfo from the parents of ClassTypeParam.
+           * Since TypeParamInfo was `private[tastyquery]`, there is little chance it leaked.
+           */
+          ProblemFilters.exclude[MissingTypesProblem]("tastyquery.Symbols$ClassTypeParamSymbol"),
+
           // new abstract method in fully sealed trait, so this is fine
           ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Types#TermLambdaType.paramTypes"),
         )

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -295,11 +295,11 @@ private[tastyquery] object Subtyping:
         false
   end compareAppliedType2
 
-  private def isSubArgs(tp1: Type, args1: List[Type], args2: List[Type], tparams: List[TypeParamInfo])(
+  private def isSubArgs(tp1: Type, args1: List[Type], args2: List[Type], tparams: List[TypeConstructorParam])(
     using Context
   ): Boolean =
-    def isSubArg(arg1: Type, arg2: Type, tparam: TypeParamInfo): Boolean =
-      val variance = tparam.paramVariance
+    def isSubArg(arg1: Type, arg2: Type, tparam: TypeConstructorParam): Boolean =
+      val variance = tparam.variance
 
       arg2 match
         case arg2: WildcardTypeBounds =>
@@ -334,7 +334,7 @@ private[tastyquery] object Subtyping:
     }
   end isSubArgs
 
-  private def etaExpand(tp: Type, tparams: List[TypeParamInfo])(using Context): TypeLambda =
+  private def etaExpand(tp: Type, tparams: List[TypeConstructorParam])(using Context): TypeLambda =
     TypeLambda.fromParamInfos(tparams)(tl => tp.appliedTo(tl.paramRefs))
 
   private def hasMatchingRefinedMember(tp1: Type, tp2: RefinedType)(using Context): Boolean =

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1221,7 +1221,7 @@ object Symbols {
     private var myThisType: ThisType | Null = null
 
     /** The `ThisType` for this class, as visible from inside this class. */
-    private[tastyquery] final def thisType(using Context): ThisType =
+    final def thisType(using Context): ThisType =
       val local = myThisType
       if local != null then local
       else

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -542,15 +542,11 @@ object Symbols {
 
   final class ClassTypeParamSymbol private (name: TypeName, override val owner: ClassSymbol)
       extends TypeParamSymbol(name, owner)
-      with TypeParamInfo:
+      with TypeConstructorParam:
     type DefiningTreeType = TypeParam
 
-    private[tastyquery] def paramVariance(using Context): Variance =
+    def variance(using Context): Variance =
       Variance.fromFlags(flags)
-
-    private[tastyquery] def paramName: TypeName = name
-
-    private[tastyquery] def paramTypeBounds(using Context): TypeBounds = bounds
 
     final def typeRef(using Context): TypeRef = TypeRef(ThisType(owner.typeRef), this)
 
@@ -588,7 +584,7 @@ object Symbols {
             case (tp1, None) =>
               tp1
             case (Some(tp1), Some(tp2)) =>
-              val variance = this.paramVariance.sign
+              val variance = this.variance.sign
               val result: Type =
                 if tp1.isInstanceOf[WildcardTypeBounds] || tp2.isInstanceOf[WildcardTypeBounds] || variance == 0 then
                   // Compute based on bounds, instead of returning the original reference

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -175,11 +175,11 @@ private[tastyquery] object TypeMaps {
     override protected def derivedSelect(tp: NamedType, pre: Type): Type =
       tp.normalizedDerivedSelect(pre)
 
-    protected def mapArgs(args: List[Type], tparams: List[TypeParamInfo]): List[Type] = args match
+    protected def mapArgs(args: List[Type], tparams: List[TypeConstructorParam]): List[Type] = args match
       case arg :: otherArgs if tparams.nonEmpty =>
         val arg1 = arg match
           case arg: WildcardTypeBounds => this(arg)
-          case arg                     => atVariance(variance * tparams.head.paramVariance.sign)(this(arg))
+          case arg                     => atVariance(variance * tparams.head.variance.sign)(this(arg))
         val otherArgs1 = mapArgs(otherArgs, tparams.tail)
         if ((arg1 eq arg) && (otherArgs1 eq otherArgs)) args
         else arg1 :: otherArgs1
@@ -386,9 +386,9 @@ private[tastyquery] object TypeMaps {
             // Fail for non-variant argument ranges (see use-site else branch below).
             // If successful, the L-arguments are in loBut, the H-arguments in hiBuf.
             // @return  operation succeeded for all arguments.
-            def distributeArgs(args: List[Type], tparams: List[TypeParamInfo]): Boolean = args match {
+            def distributeArgs(args: List[Type], tparams: List[TypeConstructorParam]): Boolean = args match {
               case Range(lo, hi) :: args1 =>
-                val v = tparams.head.paramVariance.sign
+                val v = tparams.head.variance.sign
                 if (v == 0) false
                 else {
                   if (v > 0) { loBuf += lo; hiBuf += hi }


### PR DESCRIPTION
They make sense at the spec level, and are needed by the tasty checker.