### PR TITLE
The Great Types Refactoring: Adapt our Types hierarchy to the spec.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.None,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -45,13 +45,13 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   val ObjectType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("Object"))
 
   val ArrayTypeUnapplied: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Array"))
-  def ArrayTypeOf(tpe: Type): AppliedType = AppliedType(ArrayTypeUnapplied, List(tpe))
+  def ArrayTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(ArrayTypeUnapplied, List(tpe))
 
   val SeqTypeUnapplied: TypeRef = TypeRef(scalaCollectionImmutablePackage.packageRef, typeName("Seq"))
-  def SeqTypeOf(tpe: Type): AppliedType = AppliedType(SeqTypeUnapplied, List(tpe))
+  def SeqTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(SeqTypeUnapplied, List(tpe))
 
   val RepeatedTypeUnapplied: TypeRef = TypeRef(scalaPackage.packageRef, tpnme.RepeatedParamClassMagic)
-  def RepeatedTypeOf(tpe: Type): AppliedType = AppliedType(RepeatedTypeUnapplied, List(tpe))
+  def RepeatedTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(RepeatedTypeUnapplied, List(tpe))
 
   val IntType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Int"))
   val LongType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Long"))
@@ -66,7 +66,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   val StringType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("String"))
 
   val UnappliedClassType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("Class"))
-  def ClassTypeOf(tpe: Type): AppliedType = AppliedType(UnappliedClassType, List(tpe))
+  def ClassTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(UnappliedClassType, List(tpe))
 
   val ThrowableType: TypeRef = TypeRef(javaLangPackage.packageRef, typeName("Throwable"))
 
@@ -78,9 +78,10 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   val NonEmptyTupleType: TypeRef = TypeRef(scalaPackage.packageRef, tpnme.NonEmptyTuple)
 
   val TupleConsTypeUnapplied: TypeRef = TypeRef(scalaPackage.packageRef, tpnme.TupleCons)
-  def TupleConsTypeOf(head: Type, tail: Type): AppliedType = AppliedType(TupleConsTypeUnapplied, List(head, tail))
+  def TupleConsTypeOf(head: TypeOrWildcard, tail: TypeOrWildcard): AppliedType =
+    AppliedType(TupleConsTypeUnapplied, List(head, tail))
 
-  def GenericTupleTypeOf(elementTypes: List[Type]): Type =
+  def GenericTupleTypeOf(elementTypes: List[TypeOrWildcard]): Type =
     elementTypes.foldRight[Type](EmptyTupleType)(TupleConsTypeOf(_, _))
 
   // Magic symbols that are not found on the classpath, but rather created by hand
@@ -98,7 +99,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   private def createSpecialMethod(
     owner: ClassSymbol,
     name: TermName,
-    tpe: Type,
+    tpe: TypeOrMethodic,
     flags: FlagSet = EmptyFlagSet
   ): TermSymbol =
     val sym = TermSymbol

--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -41,7 +41,7 @@ private[tastyquery] object Erasure:
         case typeRef =>
           typeRef.arrayOf()
 
-    def arrayOf(tpe: Type): ErasedTypeRef = tpe match
+    def arrayOf(tpe: TypeOrWildcard): ErasedTypeRef = tpe match
       case tpe: AppliedType =>
         tpe.tycon match
           case TypeRef.OfClass(cls) =>
@@ -63,9 +63,8 @@ private[tastyquery] object Erasure:
           case _ =>
             arrayOfBounds(tpe.bounds)
       case tpe: TypeParamRef       => arrayOfBounds(tpe.bounds)
+      case tpe: Type               => preErase(tpe).arrayOf()
       case tpe: WildcardTypeBounds => arrayOfBounds(tpe.bounds)
-      case _ =>
-        preErase(tpe).arrayOf()
     end arrayOf
 
     tpe.widen match
@@ -92,8 +91,6 @@ private[tastyquery] object Erasure:
             preErase(tpe.underlying)
       case tpe: TypeParamRef =>
         preErase(tpe.bounds.high)
-      case tpe: WildcardTypeBounds =>
-        preErase(tpe.bounds.high)
       case tpe: MatchType =>
         tpe.reduced match
           case Some(reduced) => preErase(reduced)
@@ -109,7 +106,7 @@ private[tastyquery] object Erasure:
         preErase(tpe.parent)
       case _: SingletonType | _: ByNameType | _: AnnotatedType | _: RefinedType =>
         throw AssertionError(s"Unexpected widened type $tpe")
-      case _: MethodicType | _: TypeLambda | _: PackageRef | _: CustomTransientGroundType =>
+      case _: MethodicType | _: TypeLambda | _: CustomTransientGroundType =>
         throw IllegalArgumentException(s"Unexpected type in erasure: $tpe")
   end preErase
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Scala2Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Scala2Erasure.scala
@@ -119,7 +119,7 @@ private[tastyquery] object Scala2Erasure:
       )
   end pseudoSymbol
 
-  private def widenDealias(tp: Type)(using Context): Type =
+  private def widenDealias(tp: TypeOrMethodic)(using Context): TypeOrMethodic =
     val tp1 = tp.widen.dealias
     if tp1 eq tp then tp
     else widenDealias(tp1)
@@ -249,7 +249,7 @@ private[tastyquery] object Scala2Erasure:
   private def intersectionDominator(parents: List[Type])(using Context): Type =
     val psyms = parents.map(pseudoSymbol)
     if psyms.contains(defn.ArrayClass) then
-      defn.ArrayTypeOf(intersectionDominator(parents.collect { case ArrayTypeOfExtractor(arg) => arg }))
+      defn.ArrayTypeOf(intersectionDominator(parents.collect { case ArrayTypeOfExtractor(arg) => arg.highIfWildcard }))
     else
       def isUnshadowed(psym: PseudoSymbol): Boolean =
         !(psyms.exists(qsym => !psym.sameSymbol(qsym) && qsym.isNonBottomSubClass(psym)))
@@ -262,7 +262,7 @@ private[tastyquery] object Scala2Erasure:
   end intersectionDominator
 
   private object ArrayTypeOfExtractor:
-    def unapply(tp: Type)(using Context): Option[Type] = tp match
+    def unapply(tp: Type)(using Context): Option[TypeOrWildcard] = tp match
       case tp: AppliedType if tp.tycon.classSymbol.contains(defn.ArrayClass) =>
         Some(tp.args.head)
       case _ =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
@@ -27,17 +27,19 @@ object Signatures:
   end Signature
 
   object Signature {
-    private[tastyquery] def fromType(info: Type, language: SourceLanguage, optCtorReturn: Option[ClassSymbol])(
-      using Context
-    ): Signature =
-      def rec(info: Type, acc: List[ParamSig]): Signature =
+    private[tastyquery] def fromType(
+      info: TypeOrMethodic,
+      language: SourceLanguage,
+      optCtorReturn: Option[ClassSymbol]
+    )(using Context): Signature =
+      def rec(info: TypeOrMethodic, acc: List[ParamSig]): Signature =
         info match {
           case info: MethodType =>
             val erased = info.paramTypes.map(tpe => ParamSig.Term(ErasedTypeRef.erase(tpe, language).toSigFullName))
             rec(info.resultType, acc ::: erased)
           case info: PolyType =>
             rec(info.resultType, acc ::: ParamSig.TypeLen(info.paramTypeBounds.length) :: Nil)
-          case tpe =>
+          case tpe: Type =>
             val retType = optCtorReturn.map(_.typeRef).getOrElse(tpe)
             Signature(acc, ErasedTypeRef.erase(retType, language).toSigFullName)
         }

--- a/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Substituters.scala
@@ -10,13 +10,13 @@ private[tastyquery] object Substituters:
   def substBinders(tp: TypeMappable, from: Binders, to: Binders): tp.ThisTypeMappableType =
     new SubstBindingMap(from, to).apply(tp)
 
-  def substParams(tp: TypeMappable, from: Binders, to: List[Type])(using Context): tp.ThisTypeMappableType =
+  def substParams(tp: TypeMappable, from: Binders, to: List[TypeOrWildcard])(using Context): tp.ThisTypeMappableType =
     new SubstParamsMap(from, to).apply(tp)
 
   def substRecThis(tp: TypeMappable, from: RecType, to: Type)(using Context): tp.ThisTypeMappableType =
     new SubstRecThisMap(from, to).apply(tp)
 
-  def substClassTypeParams(tp: TypeMappable, from: List[ClassTypeParamSymbol], to: List[Type])(
+  def substClassTypeParams(tp: TypeMappable, from: List[ClassTypeParamSymbol], to: List[TypeOrWildcard])(
     using Context
   ): tp.ThisTypeMappableType =
     new SubstClassTypeParamsMap(from, to).apply(tp)
@@ -37,62 +37,62 @@ private[tastyquery] object Substituters:
     new SubstRefinementThisMap(from, to).apply(tp)
 
   final class SubstBindingMap(from: Binders, to: Binders) extends TypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: BoundType =>
           if tp.binders eq from then tp.copyBoundType(to.asInstanceOf[tp.BindersType]) else tp
         case tp: NamedType =>
           tp.prefix match
-            case NoPrefix     => tp
-            case prefix: Type => tp.derivedSelect(apply(prefix))
+            case NoPrefix | _: PackageRef => tp
+            case prefix: Type             => tp.derivedSelect(apply(prefix))
         case _: ThisType =>
           tp
         case tp: AppliedType =>
-          tp.map(apply(_))
+          tp.map(apply(_), apply(_))
         case _ =>
           mapOver(tp)
-    end apply
+    end transform
   end SubstBindingMap
 
-  private final class SubstParamsMap(from: Binders, to: List[Type])(using Context) extends NormalizingTypeMap:
-    def apply(tp: Type): Type =
+  private final class SubstParamsMap(from: Binders, to: List[TypeOrWildcard])(using Context) extends NormalizingTypeMap:
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: ParamRef =>
           if tp.binders eq from then to(tp.paramNum) else tp
         case tp: NamedType =>
           tp.prefix match
-            case NoPrefix     => tp
-            case prefix: Type => tp.normalizedDerivedSelect(apply(prefix))
+            case NoPrefix | _: PackageRef => tp
+            case prefix: Type             => tp.normalizedDerivedSelect(apply(prefix))
         case _: ThisType =>
           tp
         case tp: AppliedType =>
-          tp.map(apply(_))
+          tp.map(apply(_), apply(_))
         case _ =>
           mapOver(tp)
-    end apply
+    end transform
   end SubstParamsMap
 
   private final class SubstRecThisMap(from: RecType, to: Type)(using Context) extends NormalizingTypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: RecThis =>
           if tp.binders eq from then to else tp
         case tp: NamedType =>
           tp.prefix match
-            case NoPrefix     => tp
-            case prefix: Type => tp.normalizedDerivedSelect(apply(prefix))
+            case NoPrefix | _: PackageRef => tp
+            case prefix: Type             => tp.normalizedDerivedSelect(apply(prefix))
         case _: ThisType =>
           tp
         case tp: AppliedType =>
-          tp.map(apply(_))
+          tp.map(apply(_), apply(_))
         case _ =>
           mapOver(tp)
-    end apply
+    end transform
   end SubstRecThisMap
 
-  private final class SubstClassTypeParamsMap(from: List[ClassTypeParamSymbol], to: List[Type])(using Context)
+  private final class SubstClassTypeParamsMap(from: List[ClassTypeParamSymbol], to: List[TypeOrWildcard])(using Context)
       extends NormalizingTypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: NamedType =>
           tp.prefix match
@@ -106,17 +106,17 @@ private[tastyquery] object Substituters:
               tp
             case prefix: Type =>
               tp.normalizedDerivedSelect(apply(prefix))
-            case NoPrefix =>
+            case NoPrefix | _: PackageRef =>
               tp
         case _: ThisType | _: BoundType =>
           tp
         case _ =>
           mapOver(tp)
-    end apply
+    end transform
   end SubstClassTypeParamsMap
 
   private final class SubstLocalParamsMap(from: List[Symbol], to: List[Type]) extends TypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: NamedType =>
           tp.prefix match
@@ -128,21 +128,24 @@ private[tastyquery] object Substituters:
                 fs = fs.tail
                 ts = ts.tail
               tp
+            case prefix: PackageRef =>
+              tp
             case prefix: Type =>
               tp.derivedSelect(this(prefix))
         case _: ThisType | _: BoundType =>
           tp
         case _ =>
           mapOver(tp)
+    end transform
   end SubstLocalParamsMap
 
   private final class SubstLocalThisClassTypeParamsMap(from: List[ClassTypeParamSymbol], to: List[Type])
       extends TypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: NamedType =>
           tp.prefix match
-            case NoPrefix =>
+            case NoPrefix | _: PackageRef =>
               tp
             case prefix: ThisType if tp.isSomeClassTypeParamRef =>
               /* In theory, we should check that `prefix.cls` is indeed the
@@ -166,10 +169,11 @@ private[tastyquery] object Substituters:
           tp
         case _ =>
           mapOver(tp)
+    end transform
   end SubstLocalThisClassTypeParamsMap
 
   private final class SubstRefinementThisMap(from: ClassSymbol, to: RecThis) extends TypeMap:
-    def apply(tp: Type): Type =
+    protected def transform(tp: TypeMappable): TypeMappable =
       tp match
         case tp: ThisType =>
           if tp.tref.isLocalRef(from) then to else tp
@@ -177,6 +181,7 @@ private[tastyquery] object Substituters:
           tp
         case _ =>
           mapOver(tp)
+    end transform
   end SubstRefinementThisMap
 
 end Substituters

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/Descriptors.scala
@@ -29,7 +29,7 @@ private[classfiles] object Descriptors:
     resolver.resolve(binaryName)
 
   @throws[ClassfileFormatException]
-  def parseDescriptor(member: Symbol, desc: String)(using Context, InnerClasses, Resolver): Type =
+  def parseDescriptor(member: Symbol, desc: String)(using Context, InnerClasses, Resolver): TypeOrMethodic =
     // TODO: once we support inner classes, decide if we merge with parseSignature
     var offset = 0
     var end = desc.length
@@ -91,7 +91,7 @@ private[classfiles] object Descriptors:
       if consume('V') then defn.UnitType
       else fieldDescriptor
 
-    def methodDescriptor: Type =
+    def methodDescriptor: MethodType =
       if consume('(') then // must have '(', ')', and return type
         def paramDescriptors(acc: List[Type]): List[Type] =
           if consume(')') then acc.reverse

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -23,7 +23,7 @@ private[classfiles] object JavaSignatures:
     using Context,
     InnerClasses,
     Resolver
-  ): Type =
+  ): TypeOrMethodic =
     var offset = 0
     var end = signature.length
     val isClass = member.isClass
@@ -171,7 +171,7 @@ private[classfiles] object JavaSignatures:
       else None
     end classTypeSignature
 
-    def typeArgument(env: JavaSignature): Type =
+    def typeArgument(env: JavaSignature): TypeOrWildcard =
       if available >= 1 then
         (peek: @switch) match
           case '*' =>
@@ -190,7 +190,7 @@ private[classfiles] object JavaSignatures:
             referenceType(env)
       else abort
 
-    def typeArgumentsRest(env: JavaSignature): List[Type] =
+    def typeArgumentsRest(env: JavaSignature): List[TypeOrWildcard] =
       readUntil('>', typeArgument(env))
 
     def typeParameter(env: JavaSignature): TypeBounds =
@@ -240,8 +240,8 @@ private[classfiles] object JavaSignatures:
     def termParamsRest(env: JavaSignature): List[Type] =
       readUntil(')', javaTypeSignature(env))
 
-    def methodSignature: Type =
-      def methodRest(env: JavaSignature): Type =
+    def methodSignature: MethodicType =
+      def methodRest(env: JavaSignature): MethodType =
         if consume('(') then // must have '(', ')', and return type
           val params = termParamsRest(env)
           val ret = result(env)

--- a/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
@@ -95,7 +95,7 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     )
     testShowBasic(
       TermRefinement(ProductType, isStable = false, termName("foo"), MethodType(Nil, Nil, defn.IntType)),
-      "(scala.Product { def foo: ()scala.Int })"
+      "(scala.Product { def foo()scala.Int })"
     )
 
     testShowBasic(defn.ArrayTypeOf(WildcardTypeBounds(defn.NothingAnyBounds)), "scala.Array[?]")

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -99,7 +99,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       def unapply(tpe: Types.PackageRef): Some[FullyQualifiedName] = Some(tpe.fullyQualifiedName)
 
     object AppliedType:
-      def unapply(tpe: Types.AppliedType): (Type, List[Type]) = (tpe.tycon, tpe.args)
+      def unapply(tpe: Types.AppliedType): (Type, List[TypeOrWildcard]) = (tpe.tycon, tpe.args)
 
     object ThisType:
       def unapply(tpe: Types.ThisType): Some[TypeRef] = Some(tpe.tref)
@@ -130,7 +130,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
         (tpe.parent, tpe.refinedName, tpe.refinedBounds)
 
     object TermRefinement:
-      def unapply(tpe: Types.TermRefinement): (Type, Name, Type) =
+      def unapply(tpe: Types.TermRefinement): (Type, Name, TypeOrMethodic) =
         (tpe.parent, tpe.refinedName, tpe.refinedType)
 
     object WildcardTypeBounds:
@@ -143,11 +143,11 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
       def unapply(tpe: Types.MatchTypeCase): (List[Type], Type, Type) = (tpe.paramRefs, tpe.pattern, tpe.result)
 
     object PolyType:
-      def unapply(tpe: Types.PolyType): (List[(TypeName, TypeBounds)], Type) =
+      def unapply(tpe: Types.PolyType): (List[(TypeName, TypeBounds)], TypeOrMethodic) =
         (tpe.paramNames.zip(tpe.paramTypeBounds), tpe.resultType)
 
     object MethodType:
-      def unapply(tpe: Types.MethodType): (List[(TermName, Type)], Type) =
+      def unapply(tpe: Types.MethodType): (List[(TermName, Type)], TypeOrMethodic) =
         (tpe.paramNames.zip(tpe.paramTypes), tpe.resultType)
 
     object TypeLambda:


### PR DESCRIPTION
A `Type` is now what the spec calls a type. It does not include `WildcardTypeBounds`, `MethodicType` nor `PackageRef` anymore. For that, the super traits `TypeOrMethodic`, `TypeOrWildcard`, or `NonEmptyPrefix` must be used instead.

`TypeOrWildcard`s can only be used as type arguments of `AppliedType`s. `TypeOrMethodic`s are used as the underlying type of term members.

Arbitrary terms have `TermType`s. These are real `Type`s, `MethodicType`s or `PackageRef`s.