### PR TITLE
Implement selective transparency of opaque type aliases.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -508,7 +508,23 @@ object Symbols {
                 case None                           => default
             case NoPrefix =>
               throw InvalidProgramStructureException(s"invalid NoPrefix for class type parameter $this")
-        case _ =>
+
+        case sym: TypeMemberSymbol =>
+          sym.typeDef match
+            case TypeMemberDefinition.OpaqueTypeAlias(_, alias) =>
+              /* When selecting an opaque type alias on its owner's this type,
+               * it is transparent.
+               */
+              prefix match
+                case prefix: ThisType if prefix.cls == sym.owner =>
+                  // By definition, asSeenFrom would be a no-op in this case
+                  TypeAlias(alias)
+                case _ =>
+                  default
+            case _ =>
+              default
+
+        case sym: LocalTypeParamSymbol =>
           default
     end boundsAsSeenFrom
 

--- a/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
+++ b/test-sources/src/main/scala/subtyping/TypesFromTASTy.scala
@@ -70,12 +70,22 @@ class TypesFromTASTy:
     case OldStyleEnum.Parametric[Int] => Double
     case OldStyleEnum.Singleton2.type => String
     case OldStyleEnum.Parametric[t]   => t
+
+  opaque type InstanceOpaque <: AnyVal = Int
+
+  val instanceOpaqueVal: InstanceOpaque = 5
+
+  def makeInstanceOpaque(x: Int): InstanceOpaque = x
 end TypesFromTASTy
 
 object TypesFromTASTy:
   final class Inv[A]
 
   final class Consumer[-A]
+
+  opaque type Opaque <: AnyVal = Int
+
+  def makeOpaque(x: Int): Opaque = x
 
   opaque type InvariantOpaque[A] = A
 
@@ -92,4 +102,7 @@ object TypesFromTASTy:
     case object Singleton2 extends OldStyleEnum[Nothing]
     case class Parametric[+T](x: T) extends OldStyleEnum[T]
   end OldStyleEnum
+
+  val instance1: TypesFromTASTy = new TypesFromTASTy()
+  val instance2: TypesFromTASTy = new TypesFromTASTy()
 end TypesFromTASTy


### PR DESCRIPTION
When we compute the bounds an opaque type alias as seen from a this prefix of its enclosing class, we are allowed to see the alias.