### PR TITLE
Fixes for applying tasty-mima across Scala 2 and Scala 3

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -277,7 +277,7 @@ object Names {
       extends NumberedName(underlying, num) {
     override def tag: Int = NameTags.DEFAULTGETTER
 
-    override def toString: String = s"$underlying$$default$num"
+    override def toString: String = s"$underlying$$default$$${num + 1}"
 
     override def toDebugString: String = s"${underlying.toDebugString}[default $num]"
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -124,6 +124,7 @@ object Names {
     private[tastyquery] val internalRepeatedAnnot: TypeName = typeName("Repeated")
 
     private[tastyquery] val scala2LocalChild: TypeName = typeName("<local child>")
+    private[tastyquery] val scala2ByName: TypeName = typeName("<byname>")
   }
 
   /** Create a type name from a string */

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -122,6 +122,8 @@ object Names {
     val scala2PackageObjectClass: TypeName = termName("package").withObjectSuffix.toTypeName
 
     private[tastyquery] val internalRepeatedAnnot: TypeName = typeName("Repeated")
+
+    private[tastyquery] val scala2LocalChild: TypeName = typeName("<local child>")
   }
 
   /** Create a type name from a string */

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -465,6 +465,9 @@ object Symbols {
   object TermSymbol:
     private[tastyquery] def create(name: TermName, owner: Symbol): TermSymbol =
       owner.addDeclIfDeclaringSym(TermSymbol(name, owner))
+
+    private[tastyquery] def createNotDeclaration(name: TermName, owner: Symbol): TermSymbol =
+      TermSymbol(name, owner)
   end TermSymbol
 
   sealed abstract class TypeSymbol protected (val name: TypeName, owner: Symbol) extends TermOrTypeSymbol(owner):

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -519,7 +519,16 @@ private[pickles] class PickleReader {
         else if (args.nonEmpty) tycon.safeAppliedTo(EtaExpandIfHK(sym.typeParams, args.map(translateTempPoly)))
         else if (sym.typeParams.nonEmpty) tycon.EtaExpand(sym.typeParams)
         else tycon*/
+        def isByNameParamClass(tpe: Type): Boolean = tpe match
+          case tpe: TypeRef if tpe.name == tpnme.scala2ByName =>
+            tpe.prefix match
+              case prefix: PackageRef => prefix.symbol == defn.scalaPackage
+              case _                  => false
+          case _ =>
+            false
+        end isByNameParamClass
         if args.isEmpty then tycon
+        else if isByNameParamClass(tycon) then ByNameType(args.head)
         else AppliedType(tycon, args)
       case TYPEBOUNDStpe =>
         val lo = readTypeRef()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -16,25 +16,18 @@ private[reader] object Unpickler {
         if (reader.missingSymbolEntry(i)) {
           pkl.unsafeFork(offset) {
             reader.readMaybeExternalSymbolAt(i)
-            //   sym.infoOrCompleter match {
-            //     case info: ClassUnpickler => info.init()
-            //     case _                    =>
-            //   }
           }
         }
       }
+
       // read children last, fix for SI-3951
       index.loopWithIndices { (offset, i) =>
         if (reader.missingEntry(i)) {
-          // if (isSymbolAnnotationEntry(i)) {
-          //   data.unsafeFork(reader.index(i)) {
-          //     readSymbolAnnotation()
-          //   }
-          // } else if (isChildrenEntry(i)) {
-          //   data.unsafeFork(index(i)) {
-          //     readChildren()
-          //   }
-          // }
+          if (reader.isChildrenEntry(i)) {
+            pkl.unsafeFork(offset) {
+              reader.readChildren()
+            }
+          }
         }
       }
 

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -937,6 +937,18 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(mt.resultType.isRef(defn.BooleanClass), clue(mt.resultType))
   }
 
+  testWithContext("unmangle-scala-2-names") {
+    // `$extension` methods pickled by Scala 2 are not visible from a Scala 3 point of view
+    val ArrayOpsModClass = ctx.findTopLevelModuleClass("scala.collection.ArrayOps")
+    assert(clue(ArrayOpsModClass.getAllOverloadedDecls(termName("partition$extension"))).isEmpty)
+    for decl <- ArrayOpsModClass.declarations do assert(!clue(decl.name).toString().endsWith("$extension"))
+
+    // Consistency check: Scala 3 does not emit `$extension` methods either
+    val ValueClassModClass = ctx.findTopLevelModuleClass("simple_trees.ValueClass")
+    assert(clue(ValueClassModClass.getAllOverloadedDecls(termName("myLength$extension"))).isEmpty)
+    for decl <- ValueClassModClass.declarations do assert(!clue(decl.name).toString().endsWith("$extension"))
+  }
+
   testWithContext("select-field-from-tasty-in-other-package:dependency-from-class-file") {
     val BoxedConstantsClass = ctx.findTopLevelClass("crosspackagetasty.BoxedConstants")
     val ConstantsClass = ctx.findTopLevelClass("simple_trees.Constants")

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -1076,6 +1076,16 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     assert(SealedClass.isAllOf(Sealed, butNotAnyOf = Enum))
     assert(clue(SealedClass.sealedChildren) == List(ClassCaseClass, ObjectCaseTerm))
+
+    val EquivClass = ctx.findTopLevelClass("scala.=:=")
+    assert(clue(EquivClass.sealedChildren) == List(EquivClass))
+
+    assert(clue(EquivClass.getDecl(tpnme.scala2LocalChild)).isEmpty)
+
+    val ListClass = ctx.findTopLevelClass("scala.collection.immutable.List")
+    val ConsClass = ctx.findTopLevelClass("scala.collection.immutable.::")
+    val NilModule = ctx.findStaticTerm("scala.collection.immutable.Nil")
+    assert(clue(ListClass.sealedChildren).toSet == Set(ConsClass, NilModule))
   }
 
   testWithContext("enum-children") {

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -949,6 +949,24 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     for decl <- ValueClassModClass.declarations do assert(!clue(decl.name).toString().endsWith("$extension"))
   }
 
+  testWithContext("scala-2-by-name-params") {
+    val OptionClass = ctx.findTopLevelClass("scala.Option")
+
+    val getOrElseSym = OptionClass.findNonOverloadedDecl(termName("getOrElse"))
+
+    getOrElseSym.declaredType match
+      case pt: PolyType =>
+        assert(clue(pt.paramNames).sizeIs == 1)
+        pt.resultType match
+          case mt: MethodType =>
+            assert(clue(mt.paramNames).sizeIs == 1)
+            assert(clue(mt.paramTypes.head).isByName(_ eq pt.paramRefs.head))
+          case _ =>
+            throw AssertionError(s"unexpected type $pt")
+      case tpe =>
+        throw AssertionError(s"unexpected type $tpe")
+  }
+
   testWithContext("select-field-from-tasty-in-other-package:dependency-from-class-file") {
     val BoxedConstantsClass = ctx.findTopLevelClass("crosspackagetasty.BoxedConstants")
     val ConstantsClass = ctx.findTopLevelClass("simple_trees.Constants")

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -967,6 +967,23 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         throw AssertionError(s"unexpected type $tpe")
   }
 
+  testWithContext("scala-2-default-params") {
+    val DefaultParamsClass = ctx.findTopLevelClass("simple_trees.DefaultParams")
+    assert(clue(DefaultParamsClass.getNonOverloadedDecl(DefaultGetterName(termName("foo"), 0))).isEmpty)
+    DefaultParamsClass.findNonOverloadedDecl(DefaultGetterName(termName("foo"), 1))
+    DefaultParamsClass.findNonOverloadedDecl(DefaultGetterName(termName("foo"), 2))
+    assert(clue(DefaultParamsClass.getNonOverloadedDecl(DefaultGetterName(termName("foo"), 3))).isEmpty)
+
+    val IteratorClass = ctx.findTopLevelClass("scala.collection.Iterator")
+    assert(clue(IteratorClass.getNonOverloadedDecl(DefaultGetterName(termName("indexWhere"), 0))).isEmpty)
+    IteratorClass.findNonOverloadedDecl(DefaultGetterName(termName("indexWhere"), 1))
+    assert(clue(IteratorClass.getNonOverloadedDecl(DefaultGetterName(termName("indexWhere"), 2))).isEmpty)
+
+    val ArrayDequeModClass = ctx.findTopLevelModuleClass("scala.collection.mutable.ArrayDeque")
+    ArrayDequeModClass.findNonOverloadedDecl(DefaultGetterName(nme.Constructor, 0))
+    assert(clue(ArrayDequeModClass.getNonOverloadedDecl(DefaultGetterName(nme.Constructor, 1))).isEmpty)
+  }
+
   testWithContext("select-field-from-tasty-in-other-package:dependency-from-class-file") {
     val BoxedConstantsClass = ctx.findTopLevelClass("crosspackagetasty.BoxedConstants")
     val ConstantsClass = ctx.findTopLevelClass("simple_trees.Constants")

--- a/test-sources/src/main/scala/simple_trees/DefaultParams.scala
+++ b/test-sources/src/main/scala/simple_trees/DefaultParams.scala
@@ -1,0 +1,5 @@
+package simple_trees
+
+class DefaultParams:
+  def foo(x: Int, y: Int = 1, z: String = "hello"): String = s"$x $y $z"
+end DefaultParams

--- a/test-sources/src/main/scala/simple_trees/ValueClass.scala
+++ b/test-sources/src/main/scala/simple_trees/ValueClass.scala
@@ -1,0 +1,5 @@
+package simple_trees
+
+final class ValueClass(val it: List[_]) extends AnyVal {
+  def myLength: Int = it.size
+}


### PR DESCRIPTION
@nicolasstucki Do you want to review this one? There's not everything yet, notably the `InternalError`s, but it's already something.