### PR TITLE
Skip the problematic getClass() definitions in Scala 2 prim classes.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -397,6 +397,8 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   def isTupleNClass(sym: ClassSymbol): Boolean =
     sym.owner == scalaPackage && TupleNClasses.contains(sym)
 
+  lazy val hasGenericTuples = scalaPackage.getDecl(tpnme.TupleCons).isDefined
+
   lazy val uninitializedMethod: Option[TermSymbol] =
     scalaCompiletimePackage.getDecl(moduleClassName("package$package")).flatMap { packageObjectClass =>
       packageObjectClass.asClass.getDecl(termName("uninitialized"))

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -294,7 +294,7 @@ private[tastyquery] object Subtyping:
         else
           tycon2.optSymbol match
             case Some(cls2: ClassSymbol) =>
-              (defn.isTupleNClass(cls2) && isSubtype(tp1, defn.GenericTupleTypeOf(tp2.args)))
+              (defn.hasGenericTuples && defn.isTupleNClass(cls2) && isSubtype(tp1, defn.GenericTupleTypeOf(tp2.args)))
                 || level3WithBaseType(tp1, tp2, cls2)
             case Some(sym2: TypeMemberSymbol) if sym2.isTypeAlias =>
               isSubtype(tp1, tp2.superType)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -259,7 +259,7 @@ private[pickles] class PickleReader {
           if cls.owner == defn.scalaPackage && tname == tpnme.AnyVal then
             // Patch the superclasses of AnyVal to contain Matchable
             scala2ParentTypes :+ defn.MatchableType
-          else if cls.owner == defn.scalaPackage && isTupleClassName(tname) then
+          else if cls.owner == defn.scalaPackage && isTupleClassName(tname) && defn.hasGenericTuples then
             // Patch the superclass of TupleN classes to inherit from *:
             defn.GenericTupleTypeOf(typeParams.map(_.typeRef)) :: scala2ParentTypes.tail
           else scala2ParentTypes

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -184,6 +184,9 @@ private[pickles] class PickleReader {
       case external =>
         errorBadSignature(s"expected local symbol reference but found $external")
 
+    if name1 == nme.m_getClass && owner.owner == defn.scalaPackage && HasProblematicGetClass.contains(owner.name) then
+      return NoExternalSymbolRef.instance
+
     /* In some situations, notably involving EXISTENTIALtpe, reading the
      * reference to the owner may re-try to read this very symbol. In that
      * case, the entries(storeInEntriesAt) will have been filled while reading
@@ -828,5 +831,17 @@ private[reader] object PickleReader {
       case _ =>
         false
   end isTupleClassName
+
+  private val HasProblematicGetClass: Set[Name] = Set(
+    tpnme.Unit,
+    tpnme.Boolean,
+    tpnme.Char,
+    tpnme.Byte,
+    tpnme.Short,
+    tpnme.Int,
+    tpnme.Long,
+    tpnme.Float,
+    tpnme.Double
+  )
 
 }

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -2693,4 +2693,21 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       case mt =>
         fail("unexpected type for 'apply'", clues(mt))
   }
+
+  testWithContext("no-scala-2-problematic-getClass") {
+    val primitiveClasses = List(
+      defn.UnitClass,
+      defn.BooleanClass,
+      defn.CharClass,
+      defn.ByteClass,
+      defn.ShortClass,
+      defn.IntClass,
+      defn.LongClass,
+      defn.FloatClass,
+      defn.DoubleClass
+    )
+
+    for primitiveClass <- primitiveClasses do
+      assert(clue(clue(primitiveClass).getAllOverloadedDecls(nme.m_getClass)).isEmpty)
+  }
 }


### PR DESCRIPTION
Review by @nicolasstucki

Resubmission of #310 