### PR TITLE
Include the isStable flag in `TermMemberResult`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -365,7 +365,7 @@ private[tastyquery] object Subtyping:
             tp2.refinedBounds.contains(tp1.select(cls))
           case ResolveMemberResult.TypeMember(symbols, bounds) =>
             tp2.refinedBounds.contains(bounds)
-          case ResolveMemberResult.TermMember(symbols, tpe) =>
+          case ResolveMemberResult.TermMember(symbols, tpe, isStable) =>
             throw AssertionError(s"found term member for $tp2 in $tp1")
 
       case tp2: TermRefinement =>
@@ -373,8 +373,8 @@ private[tastyquery] object Subtyping:
           tp1.resolveMember(tp2.refinedName, tp1) match
             case ResolveMemberResult.NotFound =>
               false
-            case ResolveMemberResult.TermMember(_, tpe) =>
-              tpe.isSubTypeOrMethodic(tp2.refinedType)
+            case ResolveMemberResult.TermMember(_, tpe, isStable) =>
+              tpe.isSubTypeOrMethodic(tp2.refinedType) && (isStable || !tp2.isStable)
             case _: ResolveMemberResult.ClassMember | _: ResolveMemberResult.TypeMember =>
               throw AssertionError(s"found type member for $tp2 in $tp1")
         else

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1215,7 +1215,7 @@ object Symbols {
     private[tastyquery] def resolveMember(name: Name, pre: NonEmptyPrefix)(using Context): ResolveMemberResult =
       findMember(pre, name) match
         case Some(sym: TermSymbol) =>
-          ResolveMemberResult.TermMember(sym :: Nil, sym.declaredTypeAsSeenFrom(pre))
+          ResolveMemberResult.TermMember(sym :: Nil, sym.declaredTypeAsSeenFrom(pre), sym.isStableMember)
         case Some(sym: ClassSymbol) =>
           ResolveMemberResult.ClassMember(sym)
         case Some(sym: TypeSymbolWithBounds) =>
@@ -1240,7 +1240,7 @@ object Symbols {
                 && name.sig.paramsCorrespond(decl.signature)
             if matches then
               val tpe = decl.declaredTypeAsSeenFrom(pre)
-              if typePredicate(tpe) then return ResolveMemberResult.TermMember(decl :: Nil, tpe)
+              if typePredicate(tpe) then return ResolveMemberResult.TermMember(decl :: Nil, tpe, decl.isStableMember)
             end if
             overloadsRest = overloadsRest.tail
           end while

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -252,7 +252,7 @@ private[tastyquery] object TypeMaps {
               // If H#T = ? >: S <: U, then for any x in L..H, S <: x.T <: U,
               // hence we can replace with S..U under all variances
               Some(expandBounds(bounds))
-        case ResolveMemberResult.TermMember(symbols, tpe) =>
+        case ResolveMemberResult.TermMember(symbols, tpe, isStable) =>
           tpe.dealias match
             case tpe: SingletonType =>
               // if H#x: y.type, then for any x in L..H, x.type =:= y.type,

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMatching.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMatching.scala
@@ -327,8 +327,8 @@ private[tastyquery] object TypeMatching:
       .from(1)
       .map { index =>
         tycon.resolveMember(termName("_" + index), tycon) match
-          case ResolveMemberResult.TermMember(_, declaredType: Type) => Some(declaredType)
-          case _                                                     => None
+          case ResolveMemberResult.TermMember(_, declaredType: Type, _) => Some(declaredType)
+          case _                                                        => None
       }
       .takeWhile(_.isDefined)
       .map(_.get)


### PR DESCRIPTION
So that selecting from a `val` term refinement indeed gives a stable `TermRef`.

This also brings term member resolution closer to the spec.