### PR TITLE
Remove TermRef.symbol and use optSymbol instead.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
@@ -136,7 +136,7 @@ object Annotations:
     @tailrec
     def loop(tree: TermTree): TermSymbol = tree match
       case Apply(fun, _)              => loop(fun)
-      case tree @ Select(New(tpt), _) => tree.tpe.asInstanceOf[TermRef].symbol
+      case tree @ Select(New(tpt), _) => tree.tpe.asInstanceOf[TermRef].optSymbol.get
       case TypeApply(fun, _)          => loop(fun)
       case Block(_, expr)             => loop(expr)
       case _                          => invalid()

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -166,7 +166,7 @@ private[tastyquery] object Subtyping:
     case tp1: ThisType =>
       val cls1 = tp1.cls
       tp2 match {
-        case tp2: TermRef if cls1.is(Module) && isTypeRefOf(tp2.symbol.declaredType, cls1) =>
+        case tp2: TermRef if cls1.is(Module) && isTypeRefOf(tp2.underlying, cls1) =>
           (cls1.isStatic || isSubprefix(cls1.typeRef.prefix, tp2.prefix))
             || level3(tp1, tp2)
         case _ =>
@@ -441,7 +441,7 @@ private[tastyquery] object Subtyping:
       def comparePaths: Boolean =
         tp2 match
           case tp2: TermRef =>
-            tp2.symbol.declaredTypeAsSeenFrom(tp2.prefix).dealias match
+            tp2.underlying.dealias match
               case tp2Singleton: SingletonType =>
                 isSubtype(tp1, tp2Singleton)
               case _ =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -126,13 +126,14 @@ private[tastyquery] object Subtyping:
        * relationship if they are defined in different classes of the same hierarchy.
        */
 
-      def sameTermSignature: Boolean =
-        // TODO? dotc does this but in my (sjrd) opinion, this should be !sym1.needsSignature && !sym2.needsSignature
-        // If we get here, both are terms, and terms always have symbols
-        val sym1Term = sym1.get.asTerm
-        val sym2Term = sym2.get.asTerm
-        if sym1Term.needsSignature then sym2Term.needsSignature && tp1.asTermRef.signature == tp2.asTermRef.signature
-        else !sym2Term.needsSignature
+      def areBothNonMethodic: Boolean =
+        /* dotc fully compares signatures instead of doing this, which in theory
+         * allows methodic term refs to be subtypes. We validated in
+         *   https://github.com/lampepfl/dotty/pull/18045
+         * that it breaks nothing to restrict subtyping to non-methodic term refs.
+         */
+        def isTermRefMethodic(tp: NamedType) = tp.asTermRef.underlyingOrMethodic.isInstanceOf[MethodicType]
+        tp1.isType || (!isTermRefMethodic(tp1) && !isTermRefMethodic(tp2))
 
       def areBothClasses: Boolean =
         tp1.isType && tp1.asTypeRef.isClass && tp2.asTypeRef.isClass
@@ -140,7 +141,7 @@ private[tastyquery] object Subtyping:
       val trueBecauseOverriddenMembers =
         tp1.name == tp2.name
           && isSubprefix(tp1.prefix, tp2.prefix)
-          && (tp1.isType || sameTermSignature)
+          && areBothNonMethodic
           && !areBothClasses // classes can shadow each other without being subtypes
 
       trueBecauseOverriddenMembers || level2(tp1, tp2)

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1350,8 +1350,8 @@ object Symbols {
           tpe.args match
             case TypeRef.OfClass(childCls) :: Nil =>
               childCls
-            case (childRef: TermRef) :: Nil if childRef.symbol.isAnyOf(Module | Enum) =>
-              childRef.symbol
+            case (childRef: TermRef) :: Nil if childRef.optSymbol.exists(_.isAnyOf(Module | Enum)) =>
+              childRef.optSymbol.get
             case _ =>
               throw InvalidProgramStructureException(s"Unexpected type $tpe for $annot")
         case tpe =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -265,8 +265,12 @@ object Trees {
     protected final def calculateType(using Context): TermType = tpe
 
     def symbol(using Context): TermSymbol | PackageSymbol = tpe match
-      case termRef: TermRef       => termRef.symbol
+      case termRef: TermRef =>
+        termRef.optSymbol.getOrElse {
+          throw InvalidProgramStructureException(s"$this with type $tpe does not have a symbol")
+        }
       case packageRef: PackageRef => packageRef.symbol
+    end symbol
 
     override final def withSpan(span: Span): Ident = Ident(name)(tpe)(span)
   end Ident
@@ -289,9 +293,13 @@ object Trees {
         case None           => NamedType.possibleSelFromPackage(prefix, name)
 
     def symbol(using Context): TermSymbol | PackageSymbol = tpe match
-      case termRef: TermRef       => termRef.symbol
+      case termRef: TermRef =>
+        termRef.optSymbol.getOrElse {
+          throw InvalidProgramStructureException(s"$this with type $tpe does not have a symbol")
+        }
       case packageRef: PackageRef => packageRef.symbol
       case tpe                    => throw AssertionError(s"unexpected type $tpe in Select node")
+    end symbol
 
     override def withSpan(span: Span): Select = Select(qualifier, name)(selectOwner)(span)
   end Select

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -895,7 +895,6 @@ object Types {
     private var mySymbol: TermSymbol | Null = null
     private var myUnderlying: TypeOrMethodic | Null = null
     private var myIsStable: Boolean = false // only meaningful once mySymbol is non-null
-    private var mySignature: Signature | Null = null
 
     private def this(prefix: NonEmptyPrefix, resolved: ResolveMemberResult.TermMember) =
       this(prefix, resolved.symbols.head)
@@ -955,15 +954,6 @@ object Types {
 
     override def underlying(using ctx: Context): Type =
       underlyingOrMethodic.requireType
-
-    private[tastyquery] final def signature(using Context): Signature =
-      val local = mySignature
-      if local != null then local
-      else
-        val computed = symbol.signature
-        mySignature = computed
-        computed
-    end signature
 
     final override def isStable(using Context): Boolean =
       ensureResolved()

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -474,7 +474,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     // No 'withRef' because this codebase uses explicit nulls; we would need an Any-typed or (T | Null)-typed reference
     assertStrictSubtype(defn.NullType, x)
     assertStrictSubtype(defn.NullType, xAlias)
-    assertStrictSubtype(defn.NullType, xAlias.symbol.declaredType.requireType)
+    assertStrictSubtype(defn.NullType, xAlias.optSymbol.get.declaredType.requireType)
 
     assertEquiv(x.select(tname"AbstractType"), x.select(tname"AbstractType"))
       .withRef[refx.AbstractType, refx.AbstractType]
@@ -1460,7 +1460,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       (body.tpe: @unchecked) match
         case tpe: TermRef =>
           assert(tpe.prefix == NoPrefix)
-          assertEquiv(tpe.symbol.declaredType.requireType, defn.IntType)
+          assertEquiv(tpe.optSymbol.get.declaredType.requireType, defn.IntType)
 
       val methodType = makeMethodSym.declaredType.asInstanceOf[MethodType]
       assertStrictSubtype(body.tpe.requireType, methodType.resultType.requireType)
@@ -1488,7 +1488,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
       (body.tpe: @unchecked) match
         case tpe: TermRef =>
           assert(tpe.prefix == NoPrefix)
-          assertEquiv(tpe.symbol.declaredType.requireType, defn.IntType)
+          assertEquiv(tpe.optSymbol.get.declaredType.requireType, defn.IntType)
 
       val methodType = makeMethodSym.declaredType.asInstanceOf[MethodType]
       assertStrictSubtype(body.tpe.requireType, methodType.resultType.requireType)


### PR DESCRIPTION
In fact, it is possible to select a term that does not have a symbol, as a type. It is not allowed as the type of an `Ident` or `Select`, however.