### PR TITLE
Give access to the typeDef and bounds of type symbols without Context.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
@@ -255,8 +255,8 @@ private[tastyquery] object Printers:
         case tparam: ClassTypeParamSymbol => print(Variance.fromFlags(tparam.flags))
       print(tparam.name)
       tparam match
-        case tparam: TypeLambdaParam      => print(tparam.boundsDirect)
-        case tparam: ClassTypeParamSymbol => print(tparam.boundsDirect)
+        case tparam: TypeLambdaParam      => print(tparam.bounds)
+        case tparam: ClassTypeParamSymbol => print(tparam.bounds)
     end print
 
     def print(variance: Variance): Unit =

--- a/tasty-query/shared/src/main/scala/tastyquery/Scala2Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Scala2Erasure.scala
@@ -189,7 +189,7 @@ private[tastyquery] object Scala2Erasure:
         */
       def goUpperBound(psym: TypeSymbol | StructuralRef): Boolean =
         psym match
-          case sym: TypeSymbolWithBounds => go(pseudoSymbol(sym.upperBound))
+          case sym: TypeSymbolWithBounds => go(pseudoSymbol(sym.bounds.high))
           case sym: ClassSymbol          => false
           case tp: StructuralRef         => go(pseudoSymbol(tp.bounds.high))
       end goUpperBound

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -527,10 +527,6 @@ object Symbols {
         case sym: LocalTypeParamSymbol =>
           default
     end boundsAsSeenFrom
-
-    def lowerBound(using Context): Type
-
-    def upperBound(using Context): Type
   end TypeSymbolWithBounds
 
   sealed abstract class TypeParamSymbol protected (name: TypeName, owner: Symbol)
@@ -556,10 +552,6 @@ object Symbols {
       val local = myBounds
       if local == null then throw IllegalStateException(s"$this was not assigned type bounds")
       else local
-
-    final def lowerBound(using Context): Type = bounds.low
-
-    final def upperBound(using Context): Type = bounds.high
   end TypeParamSymbol
 
   final class ClassTypeParamSymbol private (name: TypeName, override val owner: ClassSymbol)
@@ -694,16 +686,6 @@ object Symbols {
       case TypeMemberDefinition.TypeAlias(alias)           => TypeAlias(alias)
       case TypeMemberDefinition.AbstractType(bounds)       => bounds
       case TypeMemberDefinition.OpaqueTypeAlias(bounds, _) => bounds
-
-    final def lowerBound(using Context): Type = typeDef match
-      case TypeMemberDefinition.TypeAlias(alias)           => alias
-      case TypeMemberDefinition.AbstractType(bounds)       => bounds.low
-      case TypeMemberDefinition.OpaqueTypeAlias(bounds, _) => bounds.low
-
-    final def upperBound(using Context): Type = typeDef match
-      case TypeMemberDefinition.TypeAlias(alias)           => alias
-      case TypeMemberDefinition.AbstractType(bounds)       => bounds.high
-      case TypeMemberDefinition.OpaqueTypeAlias(bounds, _) => bounds.high
   end TypeMemberSymbol
 
   object TypeMemberSymbol:

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -490,7 +490,7 @@ object Symbols {
   sealed abstract class TypeSymbolWithBounds protected (name: TypeName, owner: Symbol) extends TypeSymbol(name, owner):
     type DefiningTreeType <: TypeMember | TypeParam | TypeTreeBind
 
-    def bounds(using Context): TypeBounds
+    def bounds: TypeBounds
 
     private[tastyquery] final def boundsAsSeenFrom(prefix: Prefix)(using Context): TypeBounds =
       def default: TypeBounds =
@@ -545,10 +545,7 @@ object Symbols {
       myBounds = bounds
       this
 
-    final def bounds(using Context): TypeBounds =
-      boundsDirect
-
-    private[tastyquery] final def boundsDirect: TypeBounds =
+    final def bounds: TypeBounds =
       val local = myBounds
       if local == null then throw IllegalStateException(s"$this was not assigned type bounds")
       else local
@@ -671,18 +668,18 @@ object Symbols {
       myDefinition = definition
       this
 
-    final def typeDef(using Context): TypeMemberDefinition =
+    final def typeDef: TypeMemberDefinition =
       val local = myDefinition
       if local == null then throw IllegalStateException("$this was not assigned a definition")
       else local
 
-    final def aliasedType(using Context): Type =
+    final def aliasedType: Type =
       typeDef.asInstanceOf[TypeMemberDefinition.TypeAlias].alias
 
     private[tastyquery] def aliasedTypeAsSeenFrom(pre: Prefix)(using Context): Type =
       aliasedType.asSeenFrom(pre, owner)
 
-    final def bounds(using Context): TypeBounds = typeDef match
+    final def bounds: TypeBounds = typeDef match
       case TypeMemberDefinition.TypeAlias(alias)           => TypeAlias(alias)
       case TypeMemberDefinition.AbstractType(bounds)       => bounds
       case TypeMemberDefinition.OpaqueTypeAlias(bounds, _) => bounds

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -255,7 +255,7 @@ object Types {
     def name: TypeName
 
     /** The bounds of the type parameter. */
-    def bounds(using Context): TypeBounds
+    def bounds: TypeBounds
   end TypeConstructorParam
 
   sealed abstract class TypeMappable:
@@ -1731,10 +1731,7 @@ object Types {
     def name: TypeName =
       typeLambda.paramNames(num)
 
-    def bounds(using Context): TypeBounds =
-      boundsDirect
-
-    private[tastyquery] def boundsDirect: TypeBounds =
+    def bounds: TypeBounds =
       typeLambda.paramTypeBounds(num)
   end TypeLambdaParam
 

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -851,8 +851,8 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(clue(GenericJavaClass.typeParams).sizeIs == 1)
     val tparam = GenericJavaClass.typeParams.head
 
-    assert(clue(tparam.lowerBound).isNothing)
-    assert(clue(tparam.upperBound).isFromJavaObject)
+    assert(clue(tparam.bounds.low).isNothing)
+    assert(clue(tparam.bounds.high).isFromJavaObject)
   }
 
   testWithContext("inferred-from-java-object") {


### PR DESCRIPTION
They are always available syntactically. They were the only thing for which `Printers` needed some private access.