### PR TITLE
Make Nothing and AnyKind special types, instead of magic classes.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -104,6 +104,10 @@ private[tastyquery] object Erasure:
           case SourceLanguage.Scala3 => erasedGlb(preErase(tpe.first), preErase(tpe.second))
       case tpe: RecType =>
         preErase(tpe.parent)
+      case _: NothingType =>
+        defn.ErasedNothingClass.erasure
+      case _: AnyKindType =>
+        defn.ObjectClass.erasure
       case _: SingletonType | _: ByNameType | _: AnnotatedType | _: RefinedType =>
         throw AssertionError(s"Unexpected widened type $tpe")
       case _: MethodicType | _: TypeLambda | _: CustomTransientGroundType =>
@@ -152,16 +156,16 @@ private[tastyquery] object Erasure:
         else if defn.isPrimitiveValueClass(base1) || defn.isPrimitiveValueClass(base2) then erasedObject
         else ArrayTypeRef(ClassRef(erasedClassRefLub(base1, base2)), dims1)
       case (ClassRef(cls1), tp2: ArrayTypeRef) =>
-        if cls1 == defn.NothingClass || cls1 == defn.NullClass then tp2
+        if cls1 == defn.ErasedNothingClass || cls1 == defn.NullClass then tp2
         else erasedObject
       case (tp1: ArrayTypeRef, ClassRef(cls2)) =>
-        if cls2 == defn.NothingClass || cls2 == defn.NullClass then tp1
+        if cls2 == defn.ErasedNothingClass || cls2 == defn.NullClass then tp1
         else erasedObject
   end erasedLub
 
   private def erasedClassRefLub(cls1: ClassSymbol, cls2: ClassSymbol)(using Context): ClassSymbol =
-    if cls1 == defn.NothingClass then cls2
-    else if cls2 == defn.NothingClass then cls1
+    if cls1 == defn.ErasedNothingClass then cls2
+    else if cls2 == defn.ErasedNothingClass then cls1
     else if cls1 == defn.NullClass then
       if cls2.isSubclass(defn.ObjectClass) then cls2
       else defn.AnyClass

--- a/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
@@ -62,6 +62,10 @@ private[tastyquery] object Printers:
       case tpe: PackageRef =>
         print(tpe.fullyQualifiedName.toString())
 
+      case tpe: NothingType =>
+        print("Nothing")
+      case tpe: AnyKindType =>
+        print("AnyKind")
       case tpe @ (_: TermRef | _: TermParamRef | _: ThisType | _: SuperType | _: RecThis) =>
         printPrefix(tpe)
         print("type")

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1184,7 +1184,7 @@ object Symbols {
         // TODO Handle OrType
         None
 
-      case _: TypeLambda =>
+      case _: NothingType | _: AnyKindType | _: TypeLambda =>
         None
 
       case _: CustomTransientGroundType =>

--- a/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
@@ -26,6 +26,11 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowBasic(NoPrefix, "ε") // U+03F5 Greek Small Letter Epsilon")
     testShowBasic(ctx.findPackage("scala.collection").packageRef, "scala.collection")
 
+    testShowBasic(defn.AnyKindType, "AnyKind")
+    testShowBasic(defn.NothingType, "Nothing")
+    testShowBasic(defn.SyntacticAnyKindType, "scala.AnyKind")
+    testShowBasic(defn.SyntacticNothingType, "scala.Nothing")
+
     testShowBasic(ctx.findTopLevelClass("scala.Product").staticRef, "scala.Product")
     testShowBasic(ctx.findTopLevelModuleClass("scala.None").staticRef, "scala.None$")
     testShowBasic(ctx.findStaticTerm("scala.None").staticRef, "scala.None.type")

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -149,7 +149,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   }
 
   testWithContext("anykind") {
-    assertEquiv(defn.AnyKindType, defn.AnyKindClass.newTypeRef)
+    assertEquiv(defn.AnyKindType, defn.AnyKindType)
 
     assertStrictSubtype(defn.AnyType, defn.AnyKindType)
     assertStrictSubtype(defn.AnyRefType, defn.AnyKindType)
@@ -184,7 +184,7 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   }
 
   testWithContext("nothing") {
-    assertEquiv(defn.NothingType, defn.NothingClass.newTypeRef).withRef[Nothing, Nothing]
+    assertEquiv(defn.NothingType, defn.NothingType).withRef[Nothing, Nothing]
 
     assertStrictSubtype(defn.NothingType, defn.AnyType).withRef[Nothing, Any]
     assertStrictSubtype(defn.NothingType, defn.AnyRefType).withRef[Nothing, AnyRef]

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -47,7 +47,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
 
     def isAny(using Context): Boolean = tpe.isRef(defn.AnyClass)
 
-    def isNothing(using Context): Boolean = tpe.isRef(defn.NothingClass)
+    def isNothing(using Context): Boolean = tpe.isType(_.dealias.isInstanceOf[NothingType])
 
     def isIntersectionOf(tpes: (Type => Boolean)*)(using Context): Boolean =
       tpe match
@@ -883,7 +883,6 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     assert(clue(defn.ObjectClass.parentClasses) == List(defn.AnyClass, defn.MatchableClass))
     assert(clue(defn.AnyValClass.parentClasses) == List(defn.AnyClass, defn.MatchableClass))
     assert(clue(defn.NullClass.parentClasses) == List(defn.AnyClass, defn.MatchableClass))
-    assert(clue(defn.NothingClass.parentClasses) == List(defn.AnyClass))
   }
 
   testWithContext("parents-of-tuple-classes") {
@@ -2393,12 +2392,12 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     testApplyTypeApply(
       "testGetClassAny",
       nme.m_getClass,
-      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isRef(defn.NothingClass), _.isRef(defn.AnyClass))))
+      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isNothing, _.isRef(defn.AnyClass))))
     )
     testApplyTypeApply(
       "testGetClassProduct",
       nme.m_getClass,
-      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isRef(defn.NothingClass), _.isRef(ProductClass))))
+      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isNothing, _.isRef(ProductClass))))
     )
 
     /* `int.getClass()` should select the `Int.getClass(): Class[Int]` overload,
@@ -2411,7 +2410,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     testApplyTypeApply(
       "testGetClassInt",
       nme.m_getClass,
-      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isRef(defn.NothingClass), _.isRef(defn.IntClass))))
+      _.isApplied(_.isRef(ClassClass), List(_.isBounded(_.isNothing, _.isRef(defn.IntClass))))
     )
   }
 


### PR DESCRIPTION
`scala.AnyKind` and `scala.Nothing` are type aliases that point to the special types.

This design corresponds to the spec.