### PR TITLE
Fix #334: Make the signatureName of Nothing be `scala.Nothing`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -71,6 +71,7 @@ object Names {
     val scalaPackageName: SimpleName = termName("scala")
     val javaPackageName: SimpleName = termName("java")
     val langPackageName: SimpleName = termName("lang")
+    val runtimePackageName: SimpleName = termName("runtime")
 
     val EmptyTuple: SimpleName = termName("EmptyTuple")
 
@@ -130,6 +131,8 @@ object Names {
     val FromJavaObjectAliasMagic: TypeName = typeName("<FromJavaObject>")
 
     val scala2PackageObjectClass: TypeName = termName("package").withObjectSuffix.toTypeName
+
+    private[tastyquery] val runtimeNothing: TypeName = typeName("Nothing$")
 
     private[tastyquery] val internalRepeatedAnnot: TypeName = typeName("Repeated")
 
@@ -345,6 +348,7 @@ object Names {
     val emptyPackageName = FullyQualifiedName(nme.EmptyPackageName :: Nil)
     val scalaPackageName = FullyQualifiedName(nme.scalaPackageName :: Nil)
     val javaLangPackageName = FullyQualifiedName(nme.javaPackageName :: nme.langPackageName :: Nil)
+    val scalaRuntimePackageName = FullyQualifiedName(nme.scalaPackageName :: nme.runtimePackageName :: Nil)
 
     private[tastyquery] val scalaAnnotationInternalPackage =
       FullyQualifiedName(nme.scalaPackageName :: termName("annotation") :: termName("internal") :: Nil)

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -999,7 +999,10 @@ object Symbols {
     private[tastyquery] final def signatureName: FullyQualifiedName =
       def computeErasedName(owner: Symbol, name: TypeName): FullyQualifiedName = owner match
         case owner: PackageSymbol =>
-          owner.fullName.select(name)
+          val ownerFullName = owner.fullName
+          if name == tpnme.runtimeNothing && ownerFullName == FullyQualifiedName.scalaRuntimePackageName then
+            FullyQualifiedName(nme.scalaPackageName :: tpnme.Nothing :: Nil)
+          else ownerFullName.select(name)
 
         case owner: ClassSymbol =>
           owner.signatureName.mapLast(_.toTermName).select(name)

--- a/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
+++ b/test-sources/src/main/scala/simple_trees/OverloadedApply.scala
@@ -18,6 +18,8 @@ class OverloadedApply {
   def foo(a: Array[Foo.type]): Unit = ()
   def foo(a: => Num): Unit = ()
   def foo: String = "foo"
+  def foo(a: java.lang.String): Nothing = ???
+  def foo(a: CharSequence): Null = null
 
   @targetName("bar") def foo(a: Box[Int]): Unit = ()
 
@@ -28,5 +30,7 @@ class OverloadedApply {
   def callE = foo(Num())
   def callF = foo
   def callG = foo(Box(3))
+  def callH = foo("hello")
+  def callI = foo("hello": CharSequence)
 
 }


### PR DESCRIPTION
Although `Nothing` erases to the runtime class `scala.runtime.Nothing$`, it appears as `scala.Nothing` in signatures.