### PR TITLE
Introduce a more restrictive `ReaderContext` inside `reader.*`.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,23 +112,14 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
-          // private, so this is fine
-          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.reader.tasties.TreeUnpickler#Caches.refinedTypeTreeCache"),
-          ProblemFilters.exclude[MissingClassProblem]("tastyquery.reader.tasties.TreeUnpickler$LocalContext"),
+          // Everything in tastyquery.reader is private[tastyquery] at most
+          ProblemFilters.exclude[Problem]("tastyquery.reader.*"),
 
-          // private[reader], so this is fine
-          ProblemFilters.exclude[Problem]("tastyquery.reader.tasties.TastyUnpickler#*"),
-
-          // private[tastyquery], so this is fine
-          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Types$TypeParamInfo"),
-
-          /* We removed TypeParamInfo from the parents of ClassTypeParam.
-           * Since TypeParamInfo was `private[tastyquery]`, there is little chance it leaked.
-           */
-          ProblemFilters.exclude[MissingTypesProblem]("tastyquery.Symbols$ClassTypeParamSymbol"),
-
-          // new abstract method in fully sealed trait, so this is fine
-          ProblemFilters.exclude[ReversedMissingMethodProblem]("tastyquery.Types#TermLambdaType.paramTypes"),
+          // private[tastyquery], not an issue
+          ProblemFilters.exclude[IncompatibleMethTypeProblem]("tastyquery.Symbols#ClassSymbol.createRefinedClassSymbol"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#PolyType.fromParamsSymbols"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambda.fromParamsSymbols"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambdaTypeCompanion.fromParamsSymbols"),
         )
       },
     )

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -411,7 +411,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   def isTupleNClass(sym: ClassSymbol): Boolean =
     sym.owner == scalaPackage && TupleNClasses.contains(sym)
 
-  lazy val hasGenericTuples = scalaPackage.getDecl(tpnme.TupleCons).isDefined
+  lazy val hasGenericTuples = ctx.classloader.hasGenericTuples
 
   lazy val uninitializedMethod: Option[TermSymbol] =
     scalaCompiletimePackage.getDecl(moduleClassName("package$package")).flatMap { packageObjectClass =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -693,10 +693,10 @@ object Types {
       None // TODO
 
     /** Is this type exactly Nothing (no vars, aliases, refinements etc allowed)? */
-    private[tastyquery] final def isExactlyNothing(using Context): Boolean = this match
+    private[tastyquery] final def isExactlyNothing: Boolean = this match
       case tp: TypeRef if tp.name == tpnme.Nothing =>
         tp.prefix.match
-          case prefix: PackageRef => prefix.symbol == defn.scalaPackage
+          case prefix: PackageRef => prefix.symbol.isScalaPackage
           case _                  => false
       case _ =>
         false
@@ -893,6 +893,10 @@ object Types {
 
     private[tastyquery] final def isLocalRef(sym: Symbol): Boolean =
       prefix == NoPrefix && (designator eq sym)
+
+    private[tastyquery] final def localSymbol: ThisSymbolType =
+      require(prefix == NoPrefix, prefix)
+      designator.asInstanceOf[ThisSymbolType]
 
     private[tastyquery] final def isSomeClassTypeParamRef: Boolean =
       designator.isInstanceOf[ClassTypeParamSymbol]
@@ -1585,9 +1589,7 @@ object Types {
   sealed abstract class TypeLambdaTypeCompanion[RT <: TypeOrMethodic, LT <: TypeLambdaType]
       extends LambdaTypeCompanion[TypeName, TypeBounds, RT, LT] {
     @targetName("fromParamsSymbols")
-    private[tastyquery] final def fromParams(params: List[LocalTypeParamSymbol], resultType: RT)(
-      using Context
-    ): LT | RT =
+    private[tastyquery] final def fromParams(params: List[LocalTypeParamSymbol], resultType: RT): LT | RT =
       if params.isEmpty then resultType
       else
         val paramNames = params.map(_.name)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -1,0 +1,77 @@
+package tastyquery.reader
+
+import tastyquery.Contexts.*
+import tastyquery.Names.*
+import tastyquery.SourceFile
+import tastyquery.Symbols.*
+import tastyquery.Types.*
+
+/** A restricted Context that is safe to use from the readers.
+  *
+  * It does not give access to anything that might require reading other files.
+  */
+private[reader] final class ReaderContext(underlying: Context):
+  def RootPackage: PackageSymbol = underlying.defn.RootPackage
+  def EmptyPackage: PackageSymbol = underlying.defn.EmptyPackage
+  def javaLangPackage: PackageSymbol = underlying.defn.javaLangPackage
+  def scalaPackage: PackageSymbol = underlying.defn.scalaPackage
+
+  def NothingType: NothingType = underlying.defn.NothingType
+  def AnyType: TypeRef = underlying.defn.AnyType
+  def MatchableType: TypeRef = underlying.defn.MatchableType
+  def ObjectType: TypeRef = underlying.defn.ObjectType
+  def FromJavaObjectType: TypeRef = underlying.defn.FromJavaObjectType
+
+  def IntType: TypeRef = underlying.defn.IntType
+  def LongType: TypeRef = underlying.defn.LongType
+  def FloatType: TypeRef = underlying.defn.FloatType
+  def DoubleType: TypeRef = underlying.defn.DoubleType
+  def BooleanType: TypeRef = underlying.defn.BooleanType
+  def ByteType: TypeRef = underlying.defn.ByteType
+  def ShortType: TypeRef = underlying.defn.ShortType
+  def CharType: TypeRef = underlying.defn.CharType
+  def UnitType: TypeRef = underlying.defn.UnitType
+
+  def ArrayTypeOf(tpe: TypeOrWildcard): AppliedType = underlying.defn.ArrayTypeOf(tpe)
+  def RepeatedTypeOf(tpe: TypeOrWildcard): AppliedType = underlying.defn.RepeatedTypeOf(tpe)
+
+  def GenericTupleTypeOf(elementTypes: List[TypeOrWildcard]): Type = underlying.defn.GenericTupleTypeOf(elementTypes)
+
+  def NothingAnyBounds: RealTypeBounds = underlying.defn.NothingAnyBounds
+
+  def uninitializedMethodTermRef: TermRef = underlying.defn.uninitializedMethodTermRef
+
+  def findPackageFromRootOrCreate(fullyQualifiedName: FullyQualifiedName): PackageSymbol =
+    underlying.findPackageFromRootOrCreate(fullyQualifiedName)
+
+  /** Reads a package reference, with a fallback on faked term references.
+    *
+    * In a full, correct classpath, `createPackageSelection()` will always
+    * return a `PackageRef`. However, in an incomplete or incorrect classpath,
+    * this method may return a `TermRef` if the target package does not exist.
+    *
+    * An alternative would be to create missing packages on the fly, but that
+    * would not be consistent with `Trees.Select.tpe` and
+    * `Trees.TermRefTypeTree.toType`.
+    */
+  def createPackageSelection(path: List[TermName]): TermReferenceType =
+    path.foldLeft[TermReferenceType](RootPackage.packageRef) { (prefix, name) =>
+      NamedType.possibleSelFromPackage(prefix, name)
+    }
+  end createPackageSelection
+
+  def getSourceFile(path: String): SourceFile =
+    underlying.getSourceFile(path)
+
+  def hasGenericTuples: Boolean = underlying.classloader.hasGenericTuples
+
+  def createObjectMagicMethods(cls: ClassSymbol): Unit =
+    underlying.defn.createObjectMagicMethods(cls)
+
+  def createStringMagicMethods(cls: ClassSymbol): Unit =
+    underlying.defn.createStringMagicMethods(cls)
+end ReaderContext
+
+private[reader] object ReaderContext:
+  def rctx(using context: ReaderContext): context.type = context
+end ReaderContext

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
@@ -189,20 +189,16 @@ private[classfiles] final class ClassfileReader private () {
     reader
   }
 
-  def readFields(op: (SimpleName, SigOrDesc, AccessFlags) => Unit)(using DataStream, ConstantPool)(
-    using Context
-  ): Unit =
+  def readFields(op: (SimpleName, SigOrDesc, AccessFlags) => Unit)(using DataStream, ConstantPool): Unit =
     readMembers(isMethod = false, op)
 
-  def readMethods(op: (SimpleName, SigOrDesc, AccessFlags) => Unit)(using DataStream, ConstantPool)(
-    using Context
-  ): Unit =
+  def readMethods(op: (SimpleName, SigOrDesc, AccessFlags) => Unit)(using DataStream, ConstantPool): Unit =
     readMembers(isMethod = true, op)
 
   private def readMembers(
     isMethod: Boolean,
     op: (SimpleName, SigOrDesc, AccessFlags) => Unit
-  )(using DataStream, ConstantPool)(using Context): Unit = {
+  )(using DataStream, ConstantPool): Unit = {
     val count = data.readU2()
     loop(count) {
       val accessFlags = readAccessFlags()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -2,13 +2,14 @@ package tastyquery.reader.pickles
 
 import PickleReader.{PklStream, index, pkl}
 
-import tastyquery.Contexts.Context
 import tastyquery.Exceptions.*
 import tastyquery.Flags.*
 import tastyquery.SourceLanguage
 
+import tastyquery.reader.ReaderContext
+
 private[reader] object Unpickler {
-  def loadInfo(sigBytes: IArray[Byte])(using Context): Unit = {
+  def loadInfo(sigBytes: IArray[Byte])(using ReaderContext): Unit = {
 
     def run(reader: PickleReader, structure: reader.Structure)(using PklStream): Unit = {
       import structure.given

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/PositionUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/PositionUnpickler.scala
@@ -15,8 +15,11 @@ import tastyquery.SourceFile
 import tastyquery.SourcePosition
 import tastyquery.Spans.*
 
+import tastyquery.reader.ReaderContext
+import tastyquery.reader.ReaderContext.rctx
+
 /** Unpickler for tree positions */
-private[reader] class PositionUnpickler(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable)(using Context) {
+private[reader] class PositionUnpickler(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable)(using ReaderContext) {
   import reader.*
 
   private val mySourcePositions = mutable.HashMap.empty[Addr, SourcePosition]
@@ -67,7 +70,7 @@ private[reader] class PositionUnpickler(reader: TastyReader, nameAtRef: TastyUnp
           header = readInt()
           if header == SOURCE then
             val path = nameAtRef.simple(readNameRef()).toString()
-            curSource = ctx.getSourceFile(path)
+            curSource = rctx.getSourceFile(path)
             if noSourceSeenYet then
               curSource.setLineSizes(myLineSizes)
               noSourceSeenYet = false

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
@@ -11,21 +11,21 @@ import tastyquery.Exceptions.*
 import tastyquery.Names.*
 import tastyquery.Signatures.*
 
-import tastyquery.reader.UTF8Utils
+import tastyquery.reader.{ReaderContext, UTF8Utils}
 
 private[reader] object TastyUnpickler {
 
   abstract class SectionUnpickler[R](val name: String) {
-    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using Context): R
+    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): R
   }
 
   class TreeSectionUnpickler(posUnpickler: Option[PositionUnpickler]) extends SectionUnpickler[TreeUnpickler]("ASTs") {
-    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using Context): TreeUnpickler =
+    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): TreeUnpickler =
       new TreeUnpickler(filename, reader, nameAtRef, posUnpickler)
   }
 
   class PositionSectionUnpickler extends SectionUnpickler[PositionUnpickler]("Positions") {
-    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using Context): PositionUnpickler =
+    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): PositionUnpickler =
       new PositionUnpickler(reader, nameAtRef)
   }
 
@@ -146,7 +146,7 @@ private[reader] class TastyUnpickler(reader: TastyReader) {
     }
   }
 
-  def unpickle[R](filename: String, sec: SectionUnpickler[R])(using Context): Option[R] =
+  def unpickle[R](filename: String, sec: SectionUnpickler[R])(using ReaderContext): Option[R] =
     for (reader <- sectionReader.get(sec.name)) yield sec.unpickle(filename, reader, nameAtRef)
 
   def bytes: Array[Byte] = reader.bytes


### PR DESCRIPTION
It statically makes sure that we never access anything that requires reading another file.

This change surfaced a couple places where there could potentially be external reading, and which are now a bit more complicated to fit the static restriction. The most prominent example is `TreeUnpickler.readWithin`, which also suggested that we decouple reading the `privateWithin` from the flags (to only do it after `createSymbols()` is over).