### PR TITLE
Fix reading of source file information.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -117,6 +117,7 @@ lazy val tastyQuery =
 
           // private[tastyquery], not an issue
           ProblemFilters.exclude[IncompatibleMethTypeProblem]("tastyquery.Symbols#ClassSymbol.createRefinedClassSymbol"),
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Symbols#ClassSymbol.createRefinedClassSymbol"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#PolyType.fromParamsSymbols"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambda.fromParamsSymbols"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambdaTypeCompanion.fromParamsSymbols"),

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1635,15 +1635,6 @@ object Symbols {
     private[tastyquery] def createNotDeclaration(name: TypeName, owner: Symbol): ClassSymbol =
       ClassSymbol(name, owner)
 
-    private[tastyquery] def createRefinedClassSymbol(
-      owner: Symbol,
-      objectType: TypeRef,
-      flags: FlagSet,
-      pos: SourcePosition
-    ): ClassSymbol =
-      // TODO Store the `pos`
-      createRefinedClassSymbol(owner, objectType, flags)
-
     private[tastyquery] def createRefinedClassSymbol(owner: Symbol, objectType: TypeRef, flags: FlagSet): ClassSymbol =
       val cls = ClassSymbol(tpnme.RefinedClassMagic, owner) // by-pass `owner.addDeclIfDeclaringSym`
       cls


### PR DESCRIPTION
I had completely misunderstood the format of source file information. Previously, I thought they applied to a range of position information in the positions section of the TASTy file. In fact, they apply to sub-*trees* rooted in any given tree.

I locally verified that it fixes the following test when adding the compiler to the test classpath:
```scala
  testWithContext("enum position") {
    val BindingPrecClass = ctx.findStaticClass("dotty.tools.dotc.typer.Typer.BindingPrec")

    def desc(pos: SourcePosition): String =
      "${pos.sourceFile.name}:${pos.startLine}:${pos.startColumn}-${pos.pointLine}:${pos.pointColumn}-${pos.endLine}:${pos.ndColumn}"

    val cd = BindingPrecClass.tree.get
    println(cd.pos)
    println(desc(cd.pos))
    println(cd.rhs.pos)
    println(desc(cd.rhs.pos))
  }
```
However, it seems difficult to reproduce without complicate source files depending on other complicated source files through inlining, so I could not reproduce it as a unit test.