### PR TITLE
Automatically fill in positions of trees based on their children.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -121,6 +121,11 @@ lazy val tastyQuery =
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#PolyType.fromParamsSymbols"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambda.fromParamsSymbols"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Types#TypeLambdaTypeCompanion.fromParamsSymbols"),
+
+          // New abstract methods in a completely sealed hierarchy, not an issue
+          ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tastyquery.Trees#*.canEqual"),
+          ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tastyquery.Trees#*.productArity"),
+          ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("tastyquery.Trees#*.productElement"),
         )
       },
     )

--- a/tasty-query/shared/src/main/scala/tastyquery/SourcePosition.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/SourcePosition.scala
@@ -3,8 +3,10 @@ package tastyquery
 import tastyquery.Spans.Span
 import tastyquery.Spans.NoSpan
 
-final class SourcePosition private[tastyquery] (val sourceFile: SourceFile, private val span: Span):
+final class SourcePosition private[tastyquery] (val sourceFile: SourceFile, private[tastyquery] val span: Span):
   override def toString(): String = s"$sourceFile:$span"
+
+  private[tastyquery] def isAuto: Boolean = !span.exists && sourceFile != SourceFile.NoSource
 
   /** True if this source position is unknown. */
   def isUnknown: Boolean = !span.exists
@@ -76,4 +78,7 @@ end SourcePosition
 
 object SourcePosition:
   val NoPosition: SourcePosition = new SourcePosition(SourceFile.NoSource, NoSpan)
+
+  private[tastyquery] def auto(source: SourceFile, span: Span): SourcePosition =
+    new SourcePosition(source, span)
 end SourcePosition


### PR DESCRIPTION
When pickling, dotc does not store the span of trees for which it is the same as the union of the spans of its children.

In order to recover those, we now have an internal "auto" mode of `SourcePosition`, which stores the `SourceFile` but with `NoSpan`. When building a `Tree`, if it is given an "auto" position, we compute the span based on its children. We mimick the formula used by dotc to do so, but only upward (dotc also does some weird mutating downward propagation, but AFAICT it will always store the spans of leaf trees, so we don't need that).