### PR TITLE
Fix #336: Fix all the member-not-founds in the dotty codebase.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -273,6 +273,28 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   lazy val String_+ : TermSymbol = StringClass.findNonOverloadedDecl(nme.m_+)
 
+  /** Creates the members that are patched from stdLibPatches on Predef.
+    *
+    * dotc does that generically, but it does not really work for us, as we
+    * cannot read other files while loading one file.
+    */
+  private[tastyquery] def createPredefMagicMethods(cls: ClassSymbol): Unit =
+    val nnMethodType = PolyType(List(typeName("T")))(
+      _ => List(NothingAnyBounds),
+      pt => MethodType(List(termName("x")))(_ => List(pt.paramRefs(0)), mt => AndType(mt.paramRefs(0), pt.paramRefs(0)))
+    )
+    createSpecialMethod(cls, termName("nn"), nnMethodType, Inline | Final | Extension)
+
+    val anyRefOrNull = OrType(AnyRefType, NullType)
+    val eqNeMethodType = MethodType(
+      List(termName("x")),
+      List(anyRefOrNull),
+      MethodType(List(termName("y")), List(anyRefOrNull), BooleanType)
+    )
+    createSpecialMethod(cls, termName("eq"), eqNeMethodType, Inline | Final | Extension)
+    createSpecialMethod(cls, termName("ne"), eqNeMethodType, Inline | Final | Extension)
+  end createPredefMagicMethods
+
   private def createSpecialPolyClass(
     name: TypeName,
     paramFlags: FlagSet,

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -416,6 +416,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   lazy val ProductClass = scalaPackage.requiredClass("Product")
 
   lazy val ErasedNothingClass = scalaRuntimePackage.requiredClass("Nothing$")
+  lazy val ErasedBoxedUnitClass = scalaRuntimePackage.requiredClass("BoxedUnit")
 
   private[tastyquery] lazy val targetNameAnnotClass = scalaAnnotationPackage.optionalClass("targetName")
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -273,6 +273,10 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   lazy val String_+ : TermSymbol = StringClass.findNonOverloadedDecl(nme.m_+)
 
+  private[tastyquery] def createEnumMagicMethods(cls: ClassSymbol): Unit =
+    createSpecialMethod(cls, nme.Constructor, PolyType(List(typeName("E")), List(NothingAnyBounds), UnitType))
+  end createEnumMagicMethods
+
   /** Creates the members that are patched from stdLibPatches on Predef.
     *
     * dotc does that generically, but it does not really work for us, as we

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -121,6 +121,7 @@ object Names {
     val Tuple: TypeName = typeName("Tuple")
     val NonEmptyTuple: TypeName = typeName("NonEmptyTuple")
     val TupleCons: TypeName = typeName("*:")
+    val Enum: TypeName = typeName("Enum")
 
     @deprecated("you probably meant the term name `nme.EmptyTuple` instead", since = "0.8.3")
     val EmptyTuple: TypeName = typeName("EmptyTuple")

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -138,6 +138,8 @@ object Names {
 
     private[tastyquery] val scala2LocalChild: TypeName = typeName("<local child>")
     private[tastyquery] val scala2ByName: TypeName = typeName("<byname>")
+
+    private[tastyquery] val PredefModule: TypeName = moduleClassName("Predef")
   }
 
   /** Create a type name from a string */

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -133,6 +133,7 @@ object Names {
     val scala2PackageObjectClass: TypeName = termName("package").withObjectSuffix.toTypeName
 
     private[tastyquery] val runtimeNothing: TypeName = typeName("Nothing$")
+    private[tastyquery] val runtimeBoxedUnit: TypeName = typeName("BoxedUnit")
 
     private[tastyquery] val internalRepeatedAnnot: TypeName = typeName("Repeated")
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
@@ -40,7 +40,7 @@ object Signatures:
           case info: PolyType =>
             rec(info.resultType, acc ::: ParamSig.TypeLen(info.paramTypeBounds.length) :: Nil)
           case tpe: Type =>
-            val retType = optCtorReturn.map(_.localRef).getOrElse(tpe)
+            val retType = optCtorReturn.map(_.appliedRefInsideThis).getOrElse(tpe)
             Signature(acc, ErasedTypeRef.erase(retType, language).toSigFullName)
         }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Signatures.scala
@@ -41,7 +41,8 @@ object Signatures:
             rec(info.resultType, acc ::: ParamSig.TypeLen(info.paramTypeBounds.length) :: Nil)
           case tpe: Type =>
             val retType = optCtorReturn.map(_.appliedRefInsideThis).getOrElse(tpe)
-            Signature(acc, ErasedTypeRef.erase(retType, language).toSigFullName)
+            val erasedRetType = ErasedTypeRef.erase(retType, language, keepUnit = true)
+            Signature(acc, erasedRetType.toSigFullName)
         }
 
       rec(info, Nil)

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -190,14 +190,14 @@ private[tastyquery] object Subtyping:
 
   private def level3(tp1: Type, tp2: Type)(using Context): Boolean = tp2 match
     case TypeRef.OfClass(cls2) =>
-      if cls2.typeParams.isEmpty then
+      val tparams2 = cls2.typeParams
+      if tparams2.isEmpty then
         if tp1.isLambdaSub then false // should be tp1.hasHigherKind, but the scalalib does not like that
         else if cls2 == defn.AnyClass then true
         else if cls2 == defn.SingletonClass && isSingleton(tp1) then true
         else level3WithBaseType(tp1, tp2, cls2)
-      else
-        // TODO Try eta-expansion if tp1.isLambdaSub && !tp1.isAnyKind
-        level4(tp1, tp2)
+      else if tp1.isLambdaSub then isSubType(tp1, etaExpand(tp2, tparams2))
+      else level4(tp1, tp2)
 
     case tp2: TypeRef =>
       isSubType(tp1, tp2.bounds.low)

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -283,8 +283,8 @@ object Symbols {
     final def isPublic: Boolean =
       !flags.isAnyOf(Private | Protected | Local) && privateWithin.isEmpty
 
-    private[Symbols] final def isPrivateThis: Boolean =
-      flags.isAllOf(Private | Local)
+    private[Symbols] final def isPrivateParamAccessor: Boolean =
+      flags.isAllOf(Private | Local | ParamAccessor)
 
     /** The declared visibility of this symbol. */
     final def visibility: Visibility =
@@ -1495,7 +1495,7 @@ object Symbols {
         case _                                => false
 
       getDecl(name) match
-        case some @ Some(sym) if !sym.isPrivateThis || isOwnThis =>
+        case some @ Some(sym) if !sym.isPrivateParamAccessor || isOwnThis =>
           some
         case _ =>
           if name == nme.Constructor then None

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -1156,9 +1156,9 @@ object Symbols {
           if owner == defn.scalaPackage then
             // The classes with special erasures that are loaded from Scala 2 pickles or .tasty files
             name match
-              case tpnme.AnyVal | tpnme.TupleCons    => defn.ObjectClass.erasure
-              case tpnme.Tuple | tpnme.NonEmptyTuple => defn.ProductClass.erasure
-              case _                                 => ErasedTypeRef.ClassRef(this)
+              case tpnme.AnyVal                                        => defn.ObjectClass.erasure
+              case tpnme.Tuple | tpnme.NonEmptyTuple | tpnme.TupleCons => defn.ProductClass.erasure
+              case _                                                   => ErasedTypeRef.ClassRef(this)
           else ErasedTypeRef.ClassRef(this)
     end computeErasure
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -163,6 +163,9 @@ object Types {
     def erase(tpe: Type, language: SourceLanguage)(using Context): ErasedTypeRef =
       Erasure.erase(tpe, language)
 
+    def erase(tpe: Type, language: SourceLanguage, keepUnit: Boolean)(using Context): ErasedTypeRef =
+      Erasure.erase(tpe, language, keepUnit)
+
     extension (typeRef: ArrayTypeRef)
       def elemType: ErasedTypeRef =
         if typeRef.dimensions == 1 then typeRef.base

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -2342,10 +2342,38 @@ object Types {
       val myJoin = this.myJoin
       if (myJoin != null) then myJoin
       else
-        val computedJoin = defn.ObjectType // TypeOps.orDominator(this)
+        val computedJoin = computeJoin()
         this.myJoin = computedJoin
         computedJoin
     }
+
+    private def computeJoin()(using Context): Type =
+      /** The minimal set of classes in `classes` which derive all other classes in `classes` */
+      def dominators(classes: List[ClassSymbol], acc: List[ClassSymbol]): List[ClassSymbol] = classes match
+        case cls :: rest =>
+          if acc.exists(_.isSubClass(cls)) then dominators(rest, acc)
+          else dominators(rest, cls :: acc)
+        case Nil =>
+          acc
+      end dominators
+
+      val prunedNulls = tryPruneNulls(this)
+
+      val commonBaseClasses = TypeOps.baseClasses(prunedNulls)
+      val doms = dominators(commonBaseClasses, Nil)
+      doms.flatMap(cls => prunedNulls.baseType(cls)).reduceLeft(AndType.make(_, _))
+    end computeJoin
+
+    private def tryPruneNulls(tp: Type)(using Context): Type = tp match
+      case tp: OrType =>
+        val first = tryPruneNulls(tp.first)
+        val second = tryPruneNulls(tp.second)
+        if first.isSubType(defn.NullType) && defn.NullType.isSubType(second) then second
+        else if second.isSubType(defn.NullType) && defn.NullType.isSubType(first) then first
+        else tp.derivedOrType(first, second)
+      case _ =>
+        tp
+    end tryPruneNulls
 
     private[tastyquery] def resolveMember(name: Name, pre: Type)(using Context): ResolveMemberResult =
       join.resolveMember(name, pre)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -70,6 +70,9 @@ private[reader] final class ReaderContext(underlying: Context):
 
   def createStringMagicMethods(cls: ClassSymbol): Unit =
     underlying.defn.createStringMagicMethods(cls)
+
+  def createPredefMagicMethods(cls: ClassSymbol): Unit =
+    underlying.defn.createPredefMagicMethods(cls)
 end ReaderContext
 
 private[reader] object ReaderContext:

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -71,6 +71,9 @@ private[reader] final class ReaderContext(underlying: Context):
   def createStringMagicMethods(cls: ClassSymbol): Unit =
     underlying.defn.createStringMagicMethods(cls)
 
+  def createEnumMagicMethods(cls: ClassSymbol): Unit =
+    underlying.defn.createEnumMagicMethods(cls)
+
   def createPredefMagicMethods(cls: ClassSymbol): Unit =
     underlying.defn.createPredefMagicMethods(cls)
 end ReaderContext

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -237,6 +237,7 @@ private[reader] object ClassfileParser {
     if cls.owner == rctx.javaLangPackage then
       if cls.name == tpnme.Object then rctx.createObjectMagicMethods(cls)
       else if cls.name == tpnme.String then rctx.createStringMagicMethods(cls)
+      else if cls.name == tpnme.Enum then rctx.createEnumMagicMethods(cls)
 
     for (sym, javaFlags, sigOrDesc) <- loadMembers() do
       val parsedType = sigOrDesc match

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -243,7 +243,8 @@ private[reader] object ClassfileParser {
         case SigOrDesc.Desc(desc) => Descriptors.parseDescriptor(sym, desc)
         case SigOrDesc.Sig(sig)   => JavaSignatures.parseSignature(sym, sig, allRegisteredSymbols)
       val adaptedType =
-        if sym.isMethod && javaFlags.isVarargsIfMethod then patchForVarargs(sym, parsedType)
+        if sym.isMethod && sym.name == nme.Constructor then cls.makePolyConstructorType(parsedType)
+        else if sym.isMethod && javaFlags.isVarargsIfMethod then patchForVarargs(sym, parsedType)
         else parsedType
       sym.withDeclaredType(adaptedType)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -302,6 +302,7 @@ private[pickles] class PickleReader {
         val givenSelfType = if atEnd then None else Some(readTrueTypeRef())
         cls.withParentsDirect(parentTypes)
         cls.withGivenSelfType(givenSelfType)
+        if cls.owner == rctx.scalaPackage && tname == tpnme.PredefModule then rctx.createPredefMagicMethods(cls)
         cls
       case VALsym =>
         /* Discard symbols that should not be seen from a Scala 3 point of view:

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -362,19 +362,7 @@ private[pickles] class PickleReader {
           rctx.UnitType
 
     val tpe1 = resultToUnit(tpe)
-
-    val typeParams = cls.typeParams
-    if typeParams.isEmpty then tpe1
-    else
-      /* Make a PolyType with the same type parameters as the class, and
-       * substitute references to them of the form `C.this.T` by the
-       * corresponding `paramRefs` of the `PolyType`.
-       */
-      PolyType(typeParams.map(_.name))(
-        pt =>
-          typeParams.map(p => Substituters.substLocalThisClassTypeParams(p.declaredBounds, typeParams, pt.paramRefs)),
-        pt => Substituters.substLocalThisClassTypeParams(tpe1, typeParams, pt.paramRefs)
-      )
+    cls.makePolyConstructorType(tpe1)
   end patchConstructorType
 
   def readChildren()(using ReaderContext, PklStream, Entries, Index): Unit =

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -295,6 +295,18 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
 
     val arrayOfUnion = UnionType.findNonOverloadedDecl(name"arrayOfUnion")
     assertSigned(arrayOfUnion, "(java.lang.Object[]):java.lang.Object[]")
+
+    val unitOrNull = UnionType.findNonOverloadedDecl(termName("unitOrNull"))
+    assertSigned(unitOrNull, "(scala.runtime.BoxedUnit):scala.runtime.BoxedUnit")
+
+    val intOrNull = UnionType.findNonOverloadedDecl(termName("intOrNull"))
+    assertSigned(intOrNull, "(java.lang.Object):java.lang.Object")
+
+    val optionOrNull = UnionType.findNonOverloadedDecl(termName("optionOrNull"))
+    assertSigned(optionOrNull, "(scala.Option):scala.Option")
+
+    val optionOrUnit = UnionType.findNonOverloadedDecl(termName("optionOrUnit"))
+    assertSigned(optionOrUnit, "(java.lang.Object):java.lang.Object")
   }
 
   testWithContext("refined types") {

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -170,6 +170,28 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertSigned(withArrayExactAnyVal, "(java.lang.Object[]):scala.Unit")
   }
 
+  testWithContext("unit-erasure") {
+    val UnitErasureClass = ctx.findTopLevelClass("simple_trees.UnitErasure")
+
+    val unitVal = UnitErasureClass.findNonOverloadedDecl(termName("unitVal"))
+    assertNotSigned(unitVal, "():scala.Unit")
+
+    val unitVar = UnitErasureClass.findNonOverloadedDecl(termName("unitVar"))
+    assertNotSigned(unitVar, "():scala.Unit")
+
+    val unitVarSetter = UnitErasureClass.findNonOverloadedDecl(termName("unitVar_="))
+    assertSigned(unitVarSetter, "(scala.runtime.BoxedUnit):scala.Unit")
+
+    val unitParamelessDef = UnitErasureClass.findNonOverloadedDecl(termName("unitParamelessDef"))
+    assertNotSigned(unitParamelessDef, "():scala.Unit")
+
+    val unitResult = UnitErasureClass.findNonOverloadedDecl(termName("unitResult"))
+    assertSigned(unitResult, "():scala.Unit")
+
+    val unitParam = UnitErasureClass.findNonOverloadedDecl(termName("unitParam"))
+    assertSigned(unitParam, "(scala.runtime.BoxedUnit):java.lang.Object")
+  }
+
   testWithContext("type-member") {
     val TypeMember = ctx.findTopLevelClass("simple_trees.TypeMember")
 

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -364,10 +364,18 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertSigned(takeNonEmptyTupleSig, "(scala.Product):scala.Unit")
 
     val takeStarColonSig = TuplesClass.findNonOverloadedDecl(termName("takeStarColon"))
-    assertSigned(takeStarColonSig, "(java.lang.Object):scala.Unit")
+    assertSigned(takeStarColonSig, "(scala.Product):scala.Unit")
 
     val takeEmptyTupleSig = TuplesClass.findNonOverloadedDecl(termName("takeEmptyTuple"))
     assertSigned(takeEmptyTupleSig, "(scala.Tuple$package.EmptyTuple):scala.Unit")
+
+    val TupleClass = ctx.findTopLevelClass("scala.Tuple")
+
+    val colonStar = TupleClass.findNonOverloadedDecl(termName(":*"))
+    assertSigned(colonStar, "(2,java.lang.Object):scala.Product")
+
+    val starColon = TupleClass.findNonOverloadedDecl(termName("*:"))
+    assertSigned(starColon, "(2,java.lang.Object):scala.Product")
   }
 
   testWithContext("local object") {

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -91,6 +91,19 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     assertSigned(getFirstEntry, "():java.util.TreeMap.Entry")
   }
 
+  testWithContext("Java bounded generic") {
+    val FilesModuleClass = ctx.findTopLevelModuleClass("java.nio.file.Files")
+
+    val readAttributes = FilesModuleClass
+      .findAllOverloadedDecls(termName("readAttributes"))
+      .find(_.declaredType.isInstanceOf[PolyType])
+      .get
+    assertSigned(
+      readAttributes,
+      "(1,java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption[]):java.nio.file.attribute.BasicFileAttributes"
+    )
+  }
+
   testWithContext("RichInt") {
     val RichInt = ctx.findTopLevelClass("scala.runtime.RichInt")
 

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -1119,6 +1119,21 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
     )
   }
 
+  testWithContext("class-type-constructors") {
+    val GenIterableClass = ctx.findTopLevelClass("scala.collection.Iterable")
+    val ImmutableIterableClass = ctx.findTopLevelClass("scala.collection.immutable.Iterable")
+    val MutableIterableClass = ctx.findTopLevelClass("scala.collection.mutable.Iterable")
+
+    // No withRef's because these are not proper types
+
+    assertEquiv(GenIterableClass.staticRef, GenIterableClass.newStaticRef)
+
+    assertStrictSubtype(ImmutableIterableClass.staticRef, GenIterableClass.staticRef)
+    assertStrictSubtype(MutableIterableClass.staticRef, GenIterableClass.staticRef)
+
+    assertNeitherSubtype(ImmutableIterableClass.staticRef, MutableIterableClass.staticRef)
+  }
+
   testWithContext("annotated-types") {
     import scala.annotation.unchecked.uncheckedVariance as uV
 

--- a/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -17,7 +17,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
   /** Needed for correct resolving of ctor signatures */
   val fundamentalClasses: Seq[String] =
-    Seq("java.lang.Object", "scala.Unit", "scala.AnyVal", "scala.annotation.targetName")
+    Seq("java.lang.Object", "scala.Unit", "scala.AnyVal", "scala.annotation.targetName", "scala.runtime.BoxedUnit")
 
   def testWithContext(name: String, rootSymbolPath: String, extraRootSymbolPaths: String*)(using munit.Location)(
     body: Context ?=> Unit

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -826,7 +826,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       val tpe = refInterface.declaredType.asInstanceOf[TypeLambdaType]
       val List(tparamRefA) = tpe.paramRefs: @unchecked
       assert(
-        tparamRefA.bounds.high.isIntersectionOf(_.isFromJavaObject, _.isRef(JavaInterface1), _.isRef(JavaInterface2)),
+        tparamRefA.bounds.high.isIntersectionOf(_.isRef(JavaInterface1), _.isRef(JavaInterface2)),
         clues(tparamRefA.bounds)
       )
     }

--- a/test-sources/src/main/scala/simple_trees/UnionType.scala
+++ b/test-sources/src/main/scala/simple_trees/UnionType.scala
@@ -6,4 +6,21 @@ class UnionType {
   def classesOrType(x: List[Int] | Vector[String]): Seq[Int | String] = x
 
   def arrayOfUnion(x: Array[AnyRef | Null]): Array[AnyRef | Null] = x
+
+  def unitOrNull(x: Unit | Null): Unit | Null = x
+
+  def intOrNull(x: Int | Null): Int | Null = x
+
+  def optionOrNull(x: Option[Int] | Null): Option[Int] | Null = x
+
+  def optionOrUnit(x: Option[Int] | Unit): Option[Int] | Unit = x
+
+  def calls(): Unit =
+    argWithOrType(5)
+    classesOrType(Nil)
+    arrayOfUnion(Array())
+    unitOrNull(())
+    intOrNull(5)
+    optionOrNull(None)
+    optionOrUnit(())
 }

--- a/test-sources/src/main/scala/simple_trees/UnionTypeJoin.scala
+++ b/test-sources/src/main/scala/simple_trees/UnionTypeJoin.scala
@@ -1,0 +1,9 @@
+package simple_trees
+
+object UnionTypeJoin:
+  trait C[+T]
+  trait D
+  trait E
+  class A extends C[A] with D
+  class B extends C[B] with D with E
+end UnionTypeJoin

--- a/test-sources/src/main/scala/simple_trees/UnitErasure.scala
+++ b/test-sources/src/main/scala/simple_trees/UnitErasure.scala
@@ -1,0 +1,22 @@
+package simple_trees
+
+class UnitErasure:
+  val unitVal: Unit = ()
+
+  var unitVar: Unit = ()
+
+  def unitParamelessDef: Unit = ()
+
+  def unitResult(): Unit = ()
+
+  def unitParam(x: Unit): Any = x
+
+  def calls(): Unit =
+    val _ = unitVal
+    val _ = unitVar
+    unitVar = ()
+    unitParamelessDef
+    unitResult()
+    unitParam(())
+  end calls
+end UnitErasure


### PR DESCRIPTION
After these changes, the `.symbol` of *every* `TermReferenceTree` (`Ident` or `Select`) in the `dotty` package (and subpackages) resolves without exception.