### PR TITLE
Add JDK 21 to the CI and use the Temurin distribution.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'sbt'
       - name: sbt ci-release

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
 
     runs-on: ubuntu-latest
 
@@ -22,7 +22,7 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'sbt'
     - name: npm install

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.6


### PR DESCRIPTION
Temurin is the successor of AdoptJDK.

Closes #353.