### PR TITLE
Introduce `UnsignedName` and `UnsignedTermName`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -108,7 +108,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   private def createSpecialMethod(
     owner: ClassSymbol,
-    name: TermName,
+    name: UnsignedTermName,
     tpe: TypeOrMethodic,
     flags: FlagSet = EmptyFlagSet
   ): TermSymbol =

--- a/tasty-query/shared/src/main/scala/tastyquery/Names.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Names.scala
@@ -166,13 +166,17 @@ object Names {
     def toDebugString: String = toString
   }
 
+  sealed trait UnsignedName extends Name
+
   sealed abstract class TermName extends Name
 
-  sealed trait SignatureNameItem extends TermName:
+  sealed abstract class UnsignedTermName extends TermName with UnsignedName
+
+  sealed trait SignatureNameItem extends UnsignedTermName:
     def toTypeName: ClassTypeName
   end SignatureNameItem
 
-  final case class SimpleName(name: String) extends TermName with SignatureNameItem {
+  final case class SimpleName(name: String) extends UnsignedTermName with SignatureNameItem {
     override def toString: String = name
 
     lazy val toTypeName: SimpleTypeName = SimpleTypeName(name)(this)
@@ -189,7 +193,7 @@ object Names {
       name == "package" || name.endsWith(str.topLevelSuffix)
   }
 
-  final case class SignedName(underlying: TermName, sig: Signature, target: TermName) extends TermName {
+  final case class SignedName(underlying: UnsignedTermName, sig: Signature, target: UnsignedTermName) extends TermName {
     override def toString: String = s"$underlying[with sig $sig @$target]"
 
     override def toDebugString: String =
@@ -197,43 +201,45 @@ object Names {
   }
 
   object SignedName:
-    def apply(underlying: TermName, sig: Signature): SignedName =
+    def apply(underlying: UnsignedTermName, sig: Signature): SignedName =
       SignedName(underlying, sig, underlying)
   end SignedName
 
-  final case class ExpandedName(prefix: TermName, name: SimpleName) extends TermName {
+  final case class ExpandedName(prefix: UnsignedTermName, name: SimpleName) extends UnsignedTermName {
     override def toDebugString: String =
       s"${prefix.toDebugString}[Expanded $$$$ $name]"
 
     override def toString: String = s"$prefix$$$$$name"
   }
 
-  final case class ExpandPrefixName(prefix: TermName, name: SimpleName) extends TermName {
+  final case class ExpandPrefixName(prefix: UnsignedTermName, name: SimpleName) extends UnsignedTermName {
     override def toDebugString: String =
       s"${prefix.toDebugString}[ExpandPrefix $$ $name]"
 
     override def toString: String = s"$prefix$$$name"
   }
 
-  final case class SuperAccessorName(underlying: TermName) extends TermName {
+  final case class SuperAccessorName(underlying: UnsignedTermName) extends UnsignedTermName {
     override def toString: String = s"super$underlying"
 
     override def toDebugString: String = s"<super:${underlying.toDebugString}>"
   }
 
-  final case class InlineAccessorName(underlying: TermName) extends TermName {
+  final case class InlineAccessorName(underlying: UnsignedTermName) extends UnsignedTermName {
     override def toString: String = s"inline$underlying"
 
     override def toDebugString: String = s"<inline:${underlying.toDebugString}>"
   }
 
-  final case class BodyRetainerName(underlying: TermName) extends TermName {
+  final case class BodyRetainerName(underlying: UnsignedTermName) extends UnsignedTermName {
     override def toString: String = s"<bodyretainer$underlying>" // probably wrong but print something without crashing
 
     override def toDebugString: String = s"<bodyretainer:$underlying>"
   }
 
-  final case class ObjectClassName private[Names] (underlying: SimpleName) extends TermName with SignatureNameItem {
+  final case class ObjectClassName private[Names] (underlying: SimpleName)
+      extends UnsignedTermName
+      with SignatureNameItem {
     override def toString: String = underlying.toString + "$"
 
     override def toDebugString: String = s"${underlying.toDebugString}[$$]"
@@ -242,21 +248,21 @@ object Names {
       underlying.toTypeName.withObjectSuffix
   }
 
-  final case class UniqueName(underlying: TermName, separator: String, num: Int) extends TermName {
+  final case class UniqueName(underlying: UnsignedTermName, separator: String, num: Int) extends UnsignedTermName {
     override def toString: String = s"$underlying$separator$num"
 
     override def toDebugString: String = s"${underlying.toDebugString}[unique $separator $num]"
   }
 
   // can't instantiate directly, might have to nest the other way
-  final case class DefaultGetterName(underlying: TermName, num: Int) extends TermName {
+  final case class DefaultGetterName(underlying: UnsignedTermName, num: Int) extends UnsignedTermName {
     override def toString: String = s"$underlying$$default$$${num + 1}"
 
     override def toDebugString: String = s"${underlying.toDebugString}[default $num]"
   }
 
-  sealed abstract class TypeName extends Name:
-    def toTermName: TermName
+  sealed abstract class TypeName extends Name with UnsignedName:
+    def toTermName: UnsignedTermName
   end TypeName
 
   sealed trait ClassTypeName extends TypeName:

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -139,7 +139,7 @@ object Trees {
   }
 
   /** An identifier appearing in an `import` clause; it has no type. */
-  final case class ImportIdent(name: TermName)(pos: SourcePosition) extends Tree(pos) {
+  final case class ImportIdent(name: UnsignedTermName)(pos: SourcePosition) extends Tree(pos) {
     override final def withPos(pos: SourcePosition): ImportIdent = ImportIdent(name)(pos)
   }
 
@@ -154,10 +154,10 @@ object Trees {
     val isWildcard: Boolean = isGiven || imported.name == nme.Wildcard
 
     /** The imported name, EmptyTermName if it's a given selector */
-    val name: TermName = imported.name
+    val name: UnsignedTermName = imported.name
 
     /** The renamed part (which might be `_`), if present, or `name`, if missing */
-    val rename: TermName = renamed match {
+    val rename: UnsignedTermName = renamed match {
       case Some(ImportIdent(rename)) => rename
       case None                      => name
     }
@@ -222,7 +222,7 @@ object Trees {
   }
 
   sealed abstract class ValOrDefDef()(pos: SourcePosition) extends StatementTree(pos) with DefTree:
-    val name: TermName
+    val name: UnsignedTermName
 
     val symbol: TermSymbol
 
@@ -230,13 +230,14 @@ object Trees {
   end ValOrDefDef
 
   /** mods val name: tpt = rhs */
-  final case class ValDef(name: TermName, tpt: TypeTree, rhs: Option[TermTree], symbol: TermSymbol)(pos: SourcePosition)
-      extends ValOrDefDef()(pos) {
+  final case class ValDef(name: UnsignedTermName, tpt: TypeTree, rhs: Option[TermTree], symbol: TermSymbol)(
+    pos: SourcePosition
+  ) extends ValOrDefDef()(pos) {
     override final def withPos(pos: SourcePosition): ValDef = ValDef(name, tpt, rhs, symbol)(pos)
   }
 
   /** Self type definition `name: tpt =>`. */
-  final case class SelfDef(name: TermName, tpt: TypeTree)(pos: SourcePosition) extends Tree(pos):
+  final case class SelfDef(name: UnsignedTermName, tpt: TypeTree)(pos: SourcePosition) extends Tree(pos):
     override def withPos(pos: SourcePosition): SelfDef = SelfDef(name, tpt)(pos)
   end SelfDef
 
@@ -260,7 +261,7 @@ object Trees {
 
   /** mods def name[tparams](vparams_1)...(vparams_n): tpt = rhs */
   final case class DefDef(
-    name: TermName,
+    name: UnsignedTermName,
     paramLists: List[ParamsClause],
     resultTpt: TypeTree,
     rhs: Option[TermTree],
@@ -288,7 +289,8 @@ object Trees {
   end TermReferenceTree
 
   /** name */
-  final case class Ident(name: TermName)(tpe: TermReferenceType)(pos: SourcePosition) extends TermReferenceTree(pos):
+  final case class Ident(name: UnsignedTermName)(tpe: TermReferenceType)(pos: SourcePosition)
+      extends TermReferenceTree(pos):
     override protected def computeAsTypePrefix: NonEmptyPrefix = tpe
 
     protected final def calculateType(using Context): TermReferenceType = tpe
@@ -515,7 +517,7 @@ object Trees {
   }
 
   /** name = arg, in a parameter list */
-  final case class NamedArg(name: Name, arg: TermTree)(pos: SourcePosition) extends TermTree(pos) {
+  final case class NamedArg(name: UnsignedTermName, arg: TermTree)(pos: SourcePosition) extends TermTree(pos) {
     protected final def calculateType(using Context): TermType =
       arg.tpe
 
@@ -624,7 +626,7 @@ object Trees {
   end TypeTest
 
   /** pattern in {@link Unapply} */
-  final case class Bind(name: Name, body: PatternTree, symbol: TermSymbol)(pos: SourcePosition)
+  final case class Bind(name: UnsignedTermName, body: PatternTree, symbol: TermSymbol)(pos: SourcePosition)
       extends PatternTree(pos)
       with DefTree {
     override final def withPos(pos: SourcePosition): Bind = Bind(name, body, symbol)(pos)

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -878,7 +878,7 @@ object Types {
     protected type AnyDesignatorType = TermOrTypeSymbol | Name | LookupIn | LookupTypeIn | Scala2ExternalSymRef
 
     type ThisName <: Name
-    type ThisSymbolType <: TermOrTypeSymbol { type ThisNameType = ThisName }
+    type ThisSymbolType <: TermOrTypeSymbol { type ThisNameType <: ThisName }
     type ThisNamedType >: this.type <: NamedType
     protected type ThisDesignatorType >: ThisSymbolType <: AnyDesignatorType
 
@@ -1626,7 +1626,7 @@ object Types {
   }
 
   sealed trait TermLambdaType extends LambdaType:
-    type ThisName = TermName
+    type ThisName = UnsignedTermName
     type PInfo = Type
     type This >: this.type <: TermLambdaType & ResultType
     type ParamRefType = TermParamRef
@@ -1669,7 +1669,7 @@ object Types {
       Substituters.substLocalParams(bounds, tparams, paramRefs)
   end TypeLambdaType
 
-  final class MethodType private[Types] (val companion: MethodTypeCompanion, val paramNames: List[TermName])(
+  final class MethodType private[Types] (val companion: MethodTypeCompanion, val paramNames: List[UnsignedTermName])(
     @constructorOnly paramTypesExp: MethodType => List[Type],
     @constructorOnly resultTypeExp: MethodType => TypeOrMethodic
   ) extends MethodicType
@@ -1736,9 +1736,9 @@ object Types {
   end MethodType
 
   sealed abstract class MethodTypeCompanion(private[Types] val stringPrefix: String)
-      extends LambdaTypeCompanion[TermName, Type, TypeOrMethodic, MethodType]:
+      extends LambdaTypeCompanion[UnsignedTermName, Type, TypeOrMethodic, MethodType]:
     def apply(
-      paramNames: List[TermName]
+      paramNames: List[UnsignedTermName]
     )(paramInfosExp: MethodType => List[Type], resultTypeExp: MethodType => TypeOrMethodic): MethodType =
       new MethodType(this, paramNames)(paramInfosExp, resultTypeExp)
   end MethodTypeCompanion
@@ -2030,11 +2030,11 @@ object Types {
   final class TermRefinement(
     val parent: Type,
     val isStable: Boolean,
-    val refinedName: TermName,
+    val refinedName: UnsignedTermName,
     val refinedType: TypeOrMethodic
   ) extends RefinedType:
     @deprecated("use the overload with an explicit isStable argument", since = "0.7.4")
-    def this(parent: Type, refinedName: TermName, refinedType: Type) =
+    def this(parent: Type, refinedName: UnsignedTermName, refinedType: Type) =
       this(parent, isStable = false, refinedName, refinedType)
 
     // Cache fields
@@ -2098,7 +2098,7 @@ object Types {
 
     private[tastyquery] final def derivedTermRefinement(
       parent: Type,
-      refinedName: TermName,
+      refinedName: UnsignedTermName,
       refinedType: TypeOrMethodic
     ): Type =
       if ((parent eq this.parent) && (refinedName eq this.refinedName) && (refinedType eq this.refinedType)) this

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -16,7 +16,7 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   def assertSigned(sym: TermSymbol, expectedSignature: String)(using Context, Location): Unit =
     assertSigned(sym, expectedSignature, sym.name)
 
-  def assertSigned(sym: TermSymbol, expectedSignature: String, expectedTargetName: TermName)(
+  def assertSigned(sym: TermSymbol, expectedSignature: String, expectedTargetName: UnsignedTermName)(
     using Context,
     Location
   ): Unit =
@@ -29,7 +29,7 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
   def assertNotSigned(sym: TermSymbol, expectedSignature: String)(using Context, Location): Unit =
     assertNotSigned(sym, expectedSignature, sym.name)
 
-  def assertNotSigned(sym: TermSymbol, expectedSignature: String, expectedTargetName: TermName)(
+  def assertNotSigned(sym: TermSymbol, expectedSignature: String, expectedTargetName: UnsignedTermName)(
     using Context,
     Location
   ): Unit =

--- a/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SymbolSuite.scala
@@ -33,7 +33,7 @@ class SymbolSuite extends RestrictedUnpicklingSuite {
 
   def assertContainsExactly(
     owner: DeclaringSymbol,
-    expectedDeclNames: Set[Name]
+    expectedDeclNames: Set[UnsignedName]
   )(using Context, munit.Location): Unit = {
     val decls = owner.declarations
     val actualDeclNames = decls.map(_.name).toSet

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -553,7 +553,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val BagOfJavaDefinitionsClassMod = ctx.findTopLevelModuleClass("javadefined.BagOfJavaDefinitions")
     val javadefinedPackage = ctx.findPackage("javadefined")
 
-    def testDef(name: TermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
+    def testDef(name: UnsignedTermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
       op(BagOfJavaDefinitionsClassMod.findNonOverloadedDecl(name))
 
     def assertJavaPublic(sym: TermOrTypeSymbol)(using munit.Location) =
@@ -593,7 +593,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     def assertPrivateWithin(sym: TermOrTypeSymbol, expected: DeclaringSymbol)(using munit.Location) =
       assert(!clue(sym.isPrivate) && clue(sym.visibility) == clue(Visibility.ScopedPrivate(expected)))
 
-    def testDef(name: TermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
+    def testDef(name: UnsignedTermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
       op(BagOfJavaDefinitionsClass.findNonOverloadedDecl(name))
 
     testDef(name"x") { x =>
@@ -706,7 +706,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     val JavaInterface2 = ctx.findTopLevelClass("javadefined.JavaInterface2")
     val ExceptionClass = ctx.findTopLevelClass("java.lang.Exception")
 
-    def testDef(name: TermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
+    def testDef(name: UnsignedTermName)(op: munit.Location ?=> TermSymbol => Unit)(using munit.Location): Unit =
       op(BagOfGenJavaDefinitionsClass.findNonOverloadedDecl(name))
 
     extension (tpe: TypeMappable)


### PR DESCRIPTION
These include all kinds of names except `SignedName`. Having dedicated traits for these allows to make our API and implementation more type-safe.