### PR TITLE
Replace the magic `<repeated>` class by a dedicated `RepeatedType`.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -60,9 +60,6 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   val SeqTypeUnapplied: TypeRef = TypeRef(scalaCollectionImmutablePackage.packageRef, typeName("Seq"))
   def SeqTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(SeqTypeUnapplied, List(tpe))
 
-  val RepeatedTypeUnapplied: TypeRef = TypeRef(scalaPackage.packageRef, tpnme.RepeatedParamClassMagic)
-  def RepeatedTypeOf(tpe: TypeOrWildcard): AppliedType = AppliedType(RepeatedTypeUnapplied, List(tpe))
-
   val IntType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Int"))
   val LongType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Long"))
   val FloatType: TypeRef = TypeRef(scalaPackage.packageRef, typeName("Float"))
@@ -297,30 +294,6 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     createSpecialMethod(cls, termName("eq"), eqNeMethodType, Inline | Final | Extension)
     createSpecialMethod(cls, termName("ne"), eqNeMethodType, Inline | Final | Extension)
   end createPredefMagicMethods
-
-  private def createSpecialPolyClass(
-    name: SimpleTypeName,
-    paramFlags: FlagSet,
-    parentConstrs: Type => List[Type]
-  ): ClassSymbol =
-    val cls = ClassSymbol.create(name, scalaPackage)
-
-    val tparam = ClassTypeParamSymbol.create(typeName("T"), cls)
-    tparam.withFlags(ClassTypeParam | paramFlags, None)
-    tparam.setDeclaredBounds(NothingAnyBounds)
-    tparam.setAnnotations(Nil)
-    tparam.checkCompleted()
-
-    cls.withTypeParams(tparam :: Nil)
-    cls.withFlags(EmptyFlagSet | Artifact, None)
-
-    val parents = parentConstrs(TypeRef(cls.thisType, tparam))
-    cls.withParentsDirect(parents)
-    cls
-  end createSpecialPolyClass
-
-  val RepeatedParamClass: ClassSymbol =
-    createSpecialPolyClass(tpnme.RepeatedParamClassMagic, Covariant, tp => List(ObjectType, SeqTypeOf(tp)))
 
   /** Creates one of the `ContextFunctionNClass` classes.
     *

--- a/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
@@ -85,6 +85,9 @@ private[tastyquery] object Printers:
       case tpe: ByNameType =>
         print("=> ")
         print(tpe.resultType)
+      case tpe: RepeatedType =>
+        print(tpe.elemType)
+        print("*")
       case tpe: TypeLambda =>
         print("([")
         print(tpe.typeLambdaParams.head)

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -243,6 +243,11 @@ private[tastyquery] object Subtyping:
         case tp1: ByNameType => isSubType(tp1.resultType, tp2.resultType)
         case _               => level4(tp1, tp2)
 
+    case tp2: RepeatedType =>
+      tp1 match
+        case tp1: RepeatedType => isSubType(tp1.elemType, tp2.elemType)
+        case _                 => level4(tp1, tp2)
+
     case tp2: MatchType =>
       tp2.reduced match
         case Some(reduced) => isSubType(tp1, reduced)
@@ -476,6 +481,9 @@ private[tastyquery] object Subtyping:
     case tp1: AndType =>
       // TODO Try and simplify first
       isSubType(tp1.first, tp2) || isSubType(tp1.second, tp2)
+
+    case tp1: RepeatedType =>
+      isSubType(tp1.underlying, tp2)
 
     case tp1: MatchType =>
       def isSubMatchType: Boolean = tp2 match

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -940,7 +940,6 @@ object Symbols {
     private[tastyquery] def isArray: Boolean = specialKind == SpecialKind.Array
     private[tastyquery] def isNull: Boolean = specialKind == SpecialKind.Null
     private[tastyquery] def isSingleton: Boolean = specialKind == SpecialKind.Singleton
-    private[tastyquery] def isRepeatedParamMagic: Boolean = specialKind == SpecialKind.RepeatedParamMagic
     private[tastyquery] def isRefinementClass: Boolean = specialKind == SpecialKind.Refinement
 
     /** Get the companion class of this class, if it exists:
@@ -1113,8 +1112,6 @@ object Symbols {
           defn.ObjectClass.erasure
         case SpecialKind.Tuple | SpecialKind.NonEmptyTuple | SpecialKind.TupleCons =>
           defn.ProductClass.erasure
-        case SpecialKind.RepeatedParamMagic =>
-          defn.SeqClass.erasure
         case SpecialKind.ContextFunctionN =>
           val correspondingFunctionNName = typeName(name.asInstanceOf[SimpleTypeName].name.stripPrefix("Context"))
           defn.scalaPackage.findDecl(correspondingFunctionNName).asClass.erasure
@@ -1607,8 +1604,7 @@ object Symbols {
       inline val ContextFunctionN = 17
       inline val TupleN = 18
       inline val JavaEnum = 19
-      inline val RepeatedParamMagic = 20
-      inline val Refinement = 21
+      inline val Refinement = 20
     end SpecialKind
 
     private def computeSpecialKind(name: ClassTypeName, owner: Symbol): SpecialKind =
@@ -1638,8 +1634,6 @@ object Symbols {
                     case tpnme.Tuple         => SpecialKind.Tuple
                     case tpnme.NonEmptyTuple => SpecialKind.NonEmptyTuple
                     case tpnme.TupleCons     => SpecialKind.TupleCons
-
-                    case tpnme.RepeatedParamClassMagic => SpecialKind.RepeatedParamMagic
 
                     case _ =>
                       if name.name.startsWith("ContextFunction") then SpecialKind.ContextFunctionN

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -55,6 +55,8 @@ private[tastyquery] object TypeMaps {
       tp.derivedMatchType(bound, scrutinee, cases)
     protected def derivedByNameType(tp: ByNameType, restpe: Type): Type =
       tp.derivedByNameType(restpe)
+    protected def derivedRepeatedType(tp: RepeatedType, elemType: Type): Type =
+      tp.derivedRepeatedType(elemType)
     protected def derivedLambdaType(tp: LambdaType, formals: List[tp.PInfo], restpe: tp.ResultType): tp.This =
       tp.derivedLambdaType(tp.paramNames, formals, restpe)
     protected def derivedSkolemType(tp: SkolemType, tpe: Type): SkolemType =
@@ -123,6 +125,9 @@ private[tastyquery] object TypeMaps {
 
         case tp: ByNameType =>
           derivedByNameType(tp, this(tp.resultType))
+
+        case tp: RepeatedType =>
+          derivedRepeatedType(tp, this(tp.elemType))
 
         case tp: AnnotatedType =>
           derivedAnnotatedType(tp, this(tp.typ), tp.annotation) // tp.annotation.mapWith(this)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -34,7 +34,6 @@ private[reader] final class ReaderContext(underlying: Context):
   def UnitType: TypeRef = underlying.defn.UnitType
 
   def ArrayTypeOf(tpe: TypeOrWildcard): AppliedType = underlying.defn.ArrayTypeOf(tpe)
-  def RepeatedTypeOf(tpe: TypeOrWildcard): AppliedType = underlying.defn.RepeatedTypeOf(tpe)
 
   def GenericTupleTypeOf(elementTypes: List[TypeOrWildcard]): Type = underlying.defn.GenericTupleTypeOf(elementTypes)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -299,7 +299,7 @@ private[reader] object ClassfileParser {
       case tpe: MethodType if tpe.paramNames.sizeIs >= 1 =>
         val patchedLast = tpe.paramTypes.last match
           case ArrayTypeExtractor(lastElemType) =>
-            rctx.RepeatedTypeOf(lastElemType)
+            RepeatedType(lastElemType.requireType)
           case _ =>
             throw ClassfileFormatException(s"Found ACC_VARARGS on $sym but its last param type was not an array: $tpe")
         tpe.derivedLambdaType(tpe.paramNames, tpe.paramTypes.init :+ patchedLast, tpe.resultType)

--- a/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
@@ -74,6 +74,7 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
 
     testShowBasic(defn.SeqTypeOf(defn.IntType), "scala.collection.immutable.Seq[scala.Int]")
     testShowBasic(ByNameType(defn.IntType), "=> scala.Int")
+    testShowBasic(RepeatedType(defn.IntType), "scala.Int*")
 
     testShowBasic(
       TypeLambda(List(typeName("A"), typeName("B")))(

--- a/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ReadTreeSuite.scala
@@ -125,6 +125,9 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
     object ByNameType:
       def unapply(tpe: Types.ByNameType): Some[Type] = Some(tpe.resultType)
 
+    object RepeatedType:
+      def unapply(tpe: Types.RepeatedType): Some[Type] = Some(tpe.elemType)
+
     object OrType:
       def unapply(tpe: Types.OrType): (Type, Type) = (tpe.first, tpe.second)
 
@@ -550,12 +553,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                   List(TypeRefInternal(_, SimpleTypeName("Any")))
                 )
               ),
-              TypeWrapper(
-                ty.AppliedType(
-                  TypeRefInternal(_, tpnme.RepeatedParamClassMagic),
-                  List(TypeRefInternal(_, SimpleTypeName("Any")))
-                )
-              )
+              TypeWrapper(ty.RepeatedType(TypeRefInternal(_, SimpleTypeName("Any"))))
             ),
             _
           ) =>
@@ -713,12 +711,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
               Literal(c1) :: Literal(c2) :: Literal(c3) :: Nil,
               TypeWrapper(TypeRefInternal(ScalaPackageRef(), SimpleTypeName("Int")))
             ),
-            TypeWrapper(
-              ty.AppliedType(
-                TypeRefInternal(ScalaPackageRef(), SimpleTypeName("<repeated>")),
-                TypeRefInternal(ScalaPackageRef(), SimpleTypeName("Int")) :: Nil
-              )
-            )
+            TypeWrapper(ty.RepeatedType(TypeRefInternal(ScalaPackageRef(), SimpleTypeName("Int"))))
           ) =>
     }
     assert(containsSubtree(typedRepeated)(clue(tree)))
@@ -1684,12 +1677,6 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
           false
     end RepeatedAnnot
 
-    object RepeatedTypeRef:
-      def unapply(tree: TypeRef): Boolean = tree match
-        case TypeRefInternal(ScalaPackageRef(), tpnme.RepeatedParamClassMagic) => true
-        case _                                                                 => false
-    end RepeatedTypeRef
-
     val takesVarargs: StructureCheck = {
       case DefDef(
             SimpleName("takesVarargs"),
@@ -1738,7 +1725,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             Some(
               Apply(
                 Select(_, SignedName(SimpleName("takesVarargs"), _, _)),
-                List(Typed(SimpleIdent("xs"), TypeWrapper(ty.AppliedType(RepeatedTypeRef(), List(_)))))
+                List(Typed(SimpleIdent("xs"), TypeWrapper(ty.RepeatedType(_))))
               )
             ),
             _
@@ -1760,7 +1747,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                       List(SimpleIdent("x"), Literal(Constant(1))),
                       TypeWrapper(TypeRefInternal(_, SimpleTypeName("Int")))
                     ),
-                    TypeWrapper(ty.AppliedType(RepeatedTypeRef(), List(_)))
+                    TypeWrapper(ty.RepeatedType(_))
                   )
                 )
               )
@@ -1789,7 +1776,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
             Some(
               Apply(
                 TypeApply(Select(_, SignedName(SimpleName("asList"), _, _)), _),
-                List(Typed(SimpleIdent("xs"), TypeWrapper(ty.AppliedType(RepeatedTypeRef(), List(_)))))
+                List(Typed(SimpleIdent("xs"), TypeWrapper(ty.RepeatedType(_))))
               )
             ),
             _
@@ -1811,7 +1798,7 @@ class ReadTreeSuite extends RestrictedUnpicklingSuite {
                       List(SimpleIdent("x"), Literal(Constant(1))),
                       TypeWrapper(TypeRefInternal(_, SimpleTypeName("Int")))
                     ),
-                    TypeWrapper(ty.AppliedType(RepeatedTypeRef(), List(_)))
+                    TypeWrapper(ty.RepeatedType(_))
                   )
                 )
               )

--- a/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SubtypingSuite.scala
@@ -356,15 +356,15 @@ class SubtypingSuite extends UnrestrictedUnpicklingSuite:
   }
 
   testWithContext("repeated-type") {
-    assertEquiv(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.IntType))
-    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.IntType))
+    assertEquiv(RepeatedType(defn.IntType), RepeatedType(defn.IntType))
+    assertStrictSubtype(RepeatedType(defn.IntType), defn.SeqTypeOf(defn.IntType))
 
-    assertNeitherSubtype(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.StringType))
-    assertNeitherSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.StringType))
+    assertNeitherSubtype(RepeatedType(defn.IntType), RepeatedType(defn.StringType))
+    assertNeitherSubtype(RepeatedType(defn.IntType), defn.SeqTypeOf(defn.StringType))
 
     // Covariance
-    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.RepeatedTypeOf(defn.AnyValType))
-    assertStrictSubtype(defn.RepeatedTypeOf(defn.IntType), defn.SeqTypeOf(defn.AnyValType))
+    assertStrictSubtype(RepeatedType(defn.IntType), RepeatedType(defn.AnyValType))
+    assertStrictSubtype(RepeatedType(defn.IntType), defn.SeqTypeOf(defn.AnyValType))
   }
 
   testWithContext("polymorphic-opaque-type-alias") {

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -89,6 +89,11 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
         case tpe: ByNameType => arg(tpe.resultType)
         case _               => false
 
+    def isRepeated(elemType: Type => Boolean)(using Context): Boolean =
+      tpe match
+        case tpe: RepeatedType => elemType(tpe.elemType)
+        case _                 => false
+
     def isArrayOf(arg: TypeOrWildcard => Boolean)(using Context): Boolean =
       isApplied(_.isTypeRefOf(defn.ArrayClass), Seq(arg))
 
@@ -1398,7 +1403,7 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
     end assertAnnotatedSeqOfInt
 
     def assertRepeatedOfInt(tpe: TypeMappable): Unit =
-      assert(clue(tpe).isApplied(_.isRef(defn.RepeatedParamClass), List(_.isRef(defn.IntClass))))
+      assert(clue(tpe).isRepeated(_.isRef(defn.IntClass)))
 
     locally {
       val dd = getDefOf("takesVarargs")


### PR DESCRIPTION
This removes the last magic class (i.e., class that is not spec-related) from `Definitions`.