### PR TITLE
Redesign Classpaths so that they could lazily read their files.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
@@ -71,7 +71,7 @@ object Contexts {
       sourceFiles.getOrElseUpdate(path, new SourceFile(path))
 
     /** For a given classpath entry, return a lazy view over all the roots covered by the entry. */
-    def findSymbolsByClasspathEntry(entry: Classpath.Entry): Iterable[TermOrTypeSymbol] =
+    def findSymbolsByClasspathEntry(entry: ClasspathEntry): Iterable[TermOrTypeSymbol] =
       classloader.lookupByEntry(entry).getOrElse {
         throw new UnknownClasspathEntry(entry)
       }

--- a/tasty-query/shared/src/main/scala/tastyquery/Exceptions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Exceptions.scala
@@ -6,7 +6,7 @@ import tastyquery.Types.*
 import tastyquery.Classpaths.*
 
 object Exceptions:
-  final class UnknownClasspathEntry(entry: Classpath.Entry)
+  final class UnknownClasspathEntry(entry: ClasspathEntry)
       extends Exception(s"Unknown classpath entry: $entry, it is probably from another Classpath.")
 
   class InvalidProgramStructureException(msg: String, cause: Throwable | Null) extends Exception(msg, cause):

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
@@ -555,7 +555,7 @@ private[classfiles] object ClassfileReader {
   }
 
   def unpickle[T](classRoot: ClassData)(op: ClassfileReader => DataStream ?=> T): T =
-    ClassfileBuffer.Root(classRoot.bytes, 0).use { s ?=>
+    ClassfileBuffer.Root(classRoot.readClassFileBytes(), 0).use { s ?=>
       op(ClassfileReader())
     }
 }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
@@ -85,9 +85,9 @@ private[reader] class TastyUnpickler(reader: TastyReader) {
 
   import reader.*
 
-  def this(bytes: Array[Byte]) =
+  def this(bytes: IArray[Byte]) =
     // ok to use as Array because TastyReader is readOnly
-    this(new TastyReader(bytes))
+    this(new TastyReader(bytes.unsafeArray))
 
   private val sectionReader = new mutable.HashMap[String, TastyReader]
   val nameAtRef: NameTable = new NameTable

--- a/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
@@ -1,16 +1,17 @@
 package tastyquery
 
-import Contexts.*
-import Symbols.*
+import tastyquery.Classpaths.*
+import tastyquery.Contexts.*
+import tastyquery.Symbols.*
 
 import tastyquery.testutil.TestPlatform
-import tastyquery.Classpaths.Classpath
 
 class ClasspathEntrySuite extends UnrestrictedUnpicklingSuite:
 
-  def scala3ClasspathEntry(using Context) = ctx.classloader.classpath.entries(TestPlatform.scala3ClasspathIndex)
+  def scala3ClasspathEntry(using Context): ClasspathEntry =
+    ctx.classloader.classpath(TestPlatform.scala3ClasspathIndex)
 
-  def lookupSyms(entry: Classpath.Entry)(using Context): IArray[Symbol] =
+  def lookupSyms(entry: ClasspathEntry)(using Context): IArray[Symbol] =
     IArray.from(ctx.findSymbolsByClasspathEntry(entry))
 
   testWithContext("scala-library-by-entry") {

--- a/tasty-query/shared/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
@@ -3,6 +3,7 @@ package tastyquery
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
+import tastyquery.Classpaths.*
 import tastyquery.Contexts.*
 import tastyquery.Symbols.*
 import tastyquery.Trees.*
@@ -27,6 +28,41 @@ abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
 
   private def initRestrictedContext(rootSymbolPath: String, extraRootSymbolPaths: Seq[String]): Future[Context] =
     for classpath <- testClasspath yield
-      val filtered = classpath.withFilter((rootSymbolPath :: extraRootSymbolPaths.toList).map(_.stripSuffix("$")))
+      val allowedBinaryNames = (rootSymbolPath :: extraRootSymbolPaths.toList).map(_.stripSuffix("$"))
+      val filtered = classpath.map(FilteredClasspathEntry(_, allowedBinaryNames))
       Context.initialize(filtered)
+
+  private class FilteredClasspathEntry(base: ClasspathEntry, allowedBinaryNames: List[String]) extends ClasspathEntry:
+    private def packageAndClass(binaryName: String): (String, String) =
+      val lastSep = binaryName.lastIndexOf('.')
+      if lastSep == -1 then ("", binaryName)
+      else
+        import scala.language.unsafeNulls
+        val packageName = binaryName.substring(0, lastSep)
+        val className = binaryName.substring(lastSep + 1)
+        (packageName, className)
+
+    private val lookup = allowedBinaryNames.map(packageAndClass).groupMap((pkg, _) => pkg)((_, cls) => cls)
+
+    override def toString(): String = base.toString()
+
+    def listAllPackages(): List[PackageData] =
+      for
+        pkg <- base.listAllPackages()
+        allowedClassBinaryNames <- lookup.get(pkg.dotSeparatedName)
+      yield FilteredPackageData(pkg, allowedClassBinaryNames)
+  end FilteredClasspathEntry
+
+  private class FilteredPackageData(base: PackageData, allowedClassBinaryNames: List[String]) extends PackageData:
+    val dotSeparatedName = base.dotSeparatedName
+
+    override def toString(): String = base.toString()
+
+    def listAllClassDatas(): List[ClassData] =
+      base.listAllClassDatas().filter(c => allowedClassBinaryNames.contains(c.binaryName))
+
+    def getClassDataByBinaryName(binaryName: String): Option[ClassData] =
+      if allowedClassBinaryNames.contains(binaryName) then base.getClassDataByBinaryName(binaryName)
+      else None
+  end FilteredPackageData
 }


### PR DESCRIPTION
The implementation in `jdk.ClasspathLoaders` and
`nodejs.ClasspathLoaders` still actually reads everything eagerly. However, a third-party implementation that wants to read things differently could now do so.