### PR TITLE
Introduce TermSymbol.paramSymss.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -114,6 +114,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
       .withFlags(Method | flags, privateWithin = None)
       .withDeclaredType(tpe)
       .setAnnotations(Nil)
+      .autoFillParamSymss()
     sym.checkCompleted()
     sym
   end createSpecialMethod
@@ -341,6 +342,7 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
         mt => resultTypeParam.localRef
       )
     )
+    applyMethod.autoFillParamSymss()
     applyMethod.setAnnotations(Nil)
     applyMethod.checkCompleted()
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -271,6 +271,7 @@ private[reader] object ClassfileParser {
         else if sym.isMethod && javaFlags.isVarargsIfMethod then patchForVarargs(sym, parsedType)
         else parsedType
       sym.withDeclaredType(adaptedType)
+      sym.autoFillParamSymss()
 
       // Verify after the fact that we don't mark signature-polymorphic methods that should not be
       if sym.isSignaturePolymorphicMethod then

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -768,9 +768,14 @@ private[tasties] class TreeUnpickler private (
           if name == nme.Constructor then normalizeCtorParamClauses(params)
           else params
         symbol.withDeclaredType(ParamsClause.makeDefDefType(normalizedParams, tpt))
+        symbol.setParamSymss(normalizedParams.map(paramsClauseToParamSymbolsClause(_)))
         definingTree(symbol, DefDef(name, normalizedParams, tpt, rhs, symbol)(spn))
     }
   }
+
+  private def paramsClauseToParamSymbolsClause(clause: ParamsClause): ParamSymbolsClause = clause match
+    case Left(termParams)  => Left(termParams.map(_.symbol))
+    case Right(typeParams) => Right(typeParams.map(_.symbol.asInstanceOf[LocalTypeParamSymbol]))
 
   /** Normalizes the param clauses of a constructor definition.
     *

--- a/test-sources/src/main/scala/simple_trees/Annotations.scala
+++ b/test-sources/src/main/scala/simple_trees/Annotations.scala
@@ -26,4 +26,6 @@ class Annotations:
 
   @JavaAnnotWithDefault(false)
   def javaAnnotWithDefaultExplicit(): Int = 1
+
+  def renamedParam(@deprecatedName("oldName", since = "forever") newName: Int): Int = newName
 end Annotations


### PR DESCRIPTION
It gives access to the symbols of the declared type and term parameters of a method. This is useful for information that is not available in the `MethodicType`s, such as modifiers and annotations.