### PR TITLE
Implement reading annotations from Scala 2 pickles.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -91,6 +91,9 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
   def GenericTupleTypeOf(elementTypes: List[TypeOrWildcard]): Type =
     elementTypes.foldRight[Type](EmptyTupleType)(TupleConsTypeOf(_, _))
 
+  /** The `scala.annotation.Annotation` class type. */
+  val AnnotationType: TypeRef = TypeRef(scalaAnnotationPackage.packageRef, typeName("Annotation"))
+
   // Magic symbols that are not found on the classpath, but rather created by hand
 
   private def createSpecialClass(name: SimpleTypeName, parents: List[Type], flags: FlagSet): ClassSymbol =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -33,6 +33,8 @@ private[reader] final class ReaderContext(underlying: Context):
   def CharType: TypeRef = underlying.defn.CharType
   def UnitType: TypeRef = underlying.defn.UnitType
 
+  def AnnotationType: TypeRef = underlying.defn.AnnotationType
+
   def ArrayTypeOf(tpe: TypeOrWildcard): AppliedType = underlying.defn.ArrayTypeOf(tpe)
 
   def GenericTupleTypeOf(elementTypes: List[TypeOrWildcard]): Type = underlying.defn.GenericTupleTypeOf(elementTypes)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleFormat.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleFormat.scala
@@ -186,7 +186,7 @@ private[pickles] object PickleFormat {
   inline val IFtree = 23
   inline val MATCHtree = 24
   inline val RETURNtree = 25
-  inline val TREtree = 26
+  inline val TRYtree = 26
   inline val THROWtree = 27
   inline val NEWtree = 28
   inline val TYPEDtree = 29


### PR DESCRIPTION
We do not read all kinds of trees. Only the ones that do not contain definitions nor pattern matches (which means no `try`s either). If we encounter a kind of tree we do not support, we bail and replace the annotation argument with a placeholder.

We have to cheat for the selection of the constructor because the pickles do not contain a signed name reference. However, we have enough information for the most important methods of `Annotation` to actually work.