### PR TITLE
Remove `myParentsInit`/`withParentsDelayed`; use the `tree` instead.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -686,15 +686,6 @@ private[tasties] class TreeUnpickler private (
           case _     => readTypeTree
         }
       }
-    cls.withParentsDelayed { () =>
-      parents.map {
-        case parent: TermTree =>
-          Apply.computeAppliedNewType(parent).getOrElse {
-            throw InvalidProgramStructureException(s"Unexpected super call $parent in class $cls")
-          }
-        case parent: TypeTree => parent.toType
-      }
-    }
     val self = readSelf
     cls.withGivenSelfType(self.map(_.tpt.toType))
     // The first entry is the constructor


### PR DESCRIPTION
The information stored in `myParentsInit` can be found in the `tree` of the symbol, so we directly get it from there. This avoids storing a lambda with delayed evaluation in the symbols, which is more in line with our model of only storing *data*, not *computations*.

Note that we cannot do this for the other information we store in symbols, because they can come from Scala 2 pickles and Java class files, which have no trees. `myParentsInit` is the odd one in that it is already a TASTy-specific alternative to `myParents`. `myParents` is directly filled in for Scala 2 and Java.