### PR TITLE
Remove useless flags.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -322,14 +322,14 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
     val inputTypeParams = List.tabulate(n) { i =>
       ClassTypeParamSymbol
         .create(typeName("T" + i), cls)
-        .withFlags(ClassTypeParam | Contravariant, None)
+        .withFlags(Contravariant, None)
         .setDeclaredBounds(NothingAnyBounds)
         .setAnnotations(Nil)
     }
     val resultTypeParam =
       ClassTypeParamSymbol
         .create(typeName("R"), cls)
-        .withFlags(ClassTypeParam | Covariant, None)
+        .withFlags(Covariant, None)
         .setDeclaredBounds(NothingAnyBounds)
         .setAnnotations(Nil)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Flags.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Flags.scala
@@ -78,16 +78,10 @@ private[tastyquery] object Flags:
   val SignaturePolymorphic: Flag = newFlag("SignaturePolymorphic")
   val SuperParamAlias: Flag = newFlag("SuperParamAlias")
   val Static: Flag = newFlag("Static")
-  private[tastyquery] val StableRealizable: Flag = newFlag("StableRealizable")
+  val StableRealizable: Flag = newFlag("StableRealizable")
   val Synthetic: Flag = newFlag("Synthetic")
   val Trait: Flag = newFlag("Trait")
   val Transparent: Flag = newFlag("Transparent")
-  val TypeParameter: Flag = newFlag("TypeParameter")
-
-  val VarianceFlags: FlagSet = Covariant | Contravariant
-
-  /** A symbol is a class' type parameter iff it has all of these flags. */
-  val ClassTypeParam: FlagSet = Private | TypeParameter
 
   /** Modules always have these flags set */
   val ModuleValCreationFlags: FlagSet = Module | Lazy | Final | StableRealizable

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/JavaSignatures.scala
@@ -281,7 +281,7 @@ private[classfiles] object JavaSignatures:
         val tparams = tparamNames.map { tname =>
           val paramSym = ClassTypeParamSymbol.create(tname, cls)
           allRegisteredSymbols += paramSym
-          paramSym.withFlags(ClassTypeParam | JavaDefined, None).setAnnotations(Nil)
+          paramSym.withFlags(JavaDefined, None).setAnnotations(Nil)
           paramSym
         }
         val lookup = tparamNames.lazyZip(tparams).toMap

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -193,7 +193,6 @@ private[tasties] class TreeUnpickler private (
         flags |= ParamAccessor
         if !rhsIsEmpty then // param alias
           flags |= Method
-    if tag == TYPEPARAM then flags |= TypeParameter
     flags
 
   private def posErrorMsg: String = s"at address ${reader.currentAddr} in file $filename"


### PR DESCRIPTION
`VarianceFlags` was dead code.

`TypeParameter` and `ClassTypeParam` are redundant with the actual classes of type symbols.