### PR TITLE
Fix #397: Use a fake owner for orphan symbols in Scala 2 pickles.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -134,6 +134,16 @@ final class Definitions private[tastyquery] (ctx: Context, rootPackage: PackageS
 
   val NothingAnyBounds = AbstractTypeBounds(SyntacticNothingType, AnyClass.topLevelRef)
 
+  // See `case noRef: NoExternalSymbolRef` in PickleReader
+  private[tastyquery] val scala2FakeOwner: TermSymbol =
+    TermSymbol
+      .createNotDeclaration(termName("<nosymbol>"), scalaPackage)
+      .withFlags(Synthetic, None)
+      .withDeclaredType(AnyType)
+      .setAnnotations(Nil)
+      .checkCompleted()
+  end scala2FakeOwner
+
   private def createSpecialTypeAlias(
     name: TypeName,
     owner: DeclaringSymbol,

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -43,6 +43,8 @@ private[reader] final class ReaderContext(underlying: Context):
 
   def uninitializedMethodTermRef: TermRef = underlying.defn.uninitializedMethodTermRef
 
+  def scala2FakeOwner: TermSymbol = underlying.defn.scala2FakeOwner
+
   def findPackageFromRootOrCreate(fullyQualifiedName: PackageFullName): PackageSymbol =
     underlying.findPackageFromRootOrCreate(fullyQualifiedName)
 


### PR DESCRIPTION
We had a long-standing issue with "orphan" `TYPEsym`s and `VALsym`s in Scala 2 pickles. We were replacing them by "no symbol" themselves, because we did not know what to do with them.

Issue #397 finally provided a good setup to diagnose it. It turns out that those orphan symbols can be found as term and type params of method types and poly types, in particular, Scala 2's encoding of type lambdas, which can be produced by kind-projector.

Since we now have a good reason to have those orphan symbols, we bite the bullet and allocate one global symbol to "host" all those symbols coming from Scala 2.

---

Locally tested with `libraryDependencies += "org.scalaz" % "scalaz-core_2.13" % "7.3.5",` on the testSources classpath.