### PR TITLE
Fix #398: Include inherited members in the PackageRef fallback lookup.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -1190,7 +1190,7 @@ object Types {
             .allPackageObjectDecls()
             .iterator
             .map { cls =>
-              cls.getDecl(name) match
+              cls.getMember(name) match
                 case None       => ResolveMemberResult.NotFound
                 case Some(decl) => makeResult(decl, cls.moduleValue.get.staticRef)
             }


### PR DESCRIPTION
If we have a `package object` that extends other classes, we may have to look member selections among inherited members. This is done by `getMember` instead of `getDecl`.

To test this, we need a Scala 2 `package object` with an `extends` clause. There is no such thing in the standard library, which is our only source of Scala 2 code, unfortunately. So we don't add a test for that.

---

Locally, given the following dependency in the `testSources`:
```scala
libraryDependencies += "com.softwaremill.sttp.client" % "core_2.13" % "2.0.4",
```
the following `TypeSuite` test used to fail before, and now works:
```scala
  testWithContext("test") {
    import Signatures.*

    val sttpClientPackage = ctx.findPackage("sttp.client")
    val UriContextName = termName("UriContext")
    val UriInterpolatorClass = ctx.findTopLevelClass("sttp.model.UriInterpolator")
    val UriContextClass = UriInterpolatorClass.findDecl(typeName("UriContext")).asClass
    val StringContextClass = ctx.findTopLevelClass("scala.StringContext")

    val sig = Signature(List(ParamSig.Term(StringContextClass.signatureName)), UriContextClass.signatureName)
    val signedName = SignedName(UriContextName, sig)
    println(signedName)
    val tpRef = TermRef(sttpClientPackage.packageRef, signedName)
    val sym = tpRef.symbol
    println(sym)
    val tpe = tpRef.underlyingOrMethodic
    println(tpe.showBasic)
  }
```