### PR TITLE
Fix #401: Avoid asSeenFrom for types/bounds that don't depend on the prefix.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,8 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
+          // private, not an issue
+          ProblemFilters.exclude[MissingClassProblem]("tastyquery.TypeOps$TypeFold"),
           // Everything in tastyquery.reader is private[tastyquery] at most
           ProblemFilters.exclude[Problem]("tastyquery.reader.*"),
         )

--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,6 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
-          // !!! Compatibility breach, but there was no way someone could have maningfully extended `Constant`
-          ProblemFilters.exclude[FinalClassProblem]("tastyquery.Constants$Constant"),
           // Everything in tastyquery.reader is private[tastyquery] at most
           ProblemFilters.exclude[Problem]("tastyquery.reader.*"),
         )
@@ -126,10 +124,6 @@ lazy val tastyQuery =
         prev
           .withMoreArtifactPrivatePackages(java.util.Arrays.asList(
             "tastyquery",
-          ))
-          .withMoreProblemFilters(java.util.Arrays.asList(
-            // !!! Compatibility breach, but there was no way someone could have maningfully extended `Constant`
-            ProblemMatcher.make(ProblemKind.RestrictedOpenLevelChange, "tastyquery.Constants.Constant"),
           ))
       },
     )

--- a/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
@@ -393,8 +393,13 @@ private[tastyquery] object Printers:
         print(")")
 
       case InlineMatch(selector, cases) =>
-        print("inline ")
-        print(InlineMatch(selector, cases)(tree.pos))
+        print("(inline ")
+        selector match
+          case Some(sel) => print(sel)
+          case None      => print("_")
+        print(" match")
+        printBlock(cases)(print(_))
+        print(")")
 
       case SeqLiteral(elems, elemtpt) =>
         print("[")

--- a/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/TypeSuite.scala
@@ -3635,4 +3635,16 @@ class TypeSuite extends UnrestrictedUnpicklingSuite {
       assert(clue(c.declaredType).isApplied(_.isRef(JCollectionClass), List(_.isBounded(_.isNothing, _.isRef(e)))))
     }
   }
+
+  testWithContext("recursive-match-types-bounds-as-seen-from-issue-401") {
+    val RecursiveMatchTypeSym =
+      ctx.findStaticType("simple_trees.RecursiveMatchType$package.RecursiveMatchType").asInstanceOf[TypeMemberSymbol]
+    val staticRef = RecursiveMatchTypeSym.staticRef
+
+    /* Here, we only make sure that calls below terminate.
+     * More elaborate resolution is tested through `WholeClasspathSuite` over `RecursiveMatchTypeTest`.
+     */
+    RecursiveMatchTypeSym.boundsAsSeenFrom(staticRef.prefix)
+    staticRef.underlying
+  }
 }

--- a/test-sources/src/main/scala/simple_trees/RecursiveMatchType.scala
+++ b/test-sources/src/main/scala/simple_trees/RecursiveMatchType.scala
@@ -1,0 +1,18 @@
+package simple_trees
+
+type RecursiveMatchType[A <: Tuple] <: Tuple = A match
+  case hd *: tl => hd *: RecursiveMatchType[tl]
+  case EmptyTuple => EmptyTuple
+
+object RecursiveMatchType:
+  inline def rec[A <: Tuple](a: A): RecursiveMatchType[A] =
+    inline a match
+      case b: (hd *: tl) => b.head *: rec(b.tail)
+      case _: EmptyTuple => EmptyTuple
+end RecursiveMatchType
+
+// must be in a separate TASTy file to trigger issue #401
+object RecursiveMatchTypeTest:
+  inline def rec[A <: Tuple](x: A): RecursiveMatchType[A] =
+    RecursiveMatchType.rec(x)
+end RecursiveMatchTypeTest


### PR DESCRIPTION
This mostly acts as a fast path. However, for the particular case of static recursive match types, it more critically cuts some infinite recursion.

Normally, when a match type refers to itself, it would do so through a `ThisType`. Computing `asSeenFrom` for a `ThisType` prefix already cuts the infinite recursion because it is, by construction, a no-op.

However, for static recursive match types, the compiler makes them refer to themselves through their public, static prefix. This caused the infinite recursion observed in https://github.com/scalacenter/tasty-query/issues/401.

To avoid the issue, we use another shortcut to `asSeenFrom`: if the type we map over does not contain any `ThisType`, we also know it will be a no-op. We store that as a lazy val `isPrefixDependent` of `TermSymbol` and `TypeMemberSymbol`, so that they can take a short cut in `{type,bounds}AsSeenFrom`.