### PR TITLE
Scala 2 pickle reader: first read all symbols, then all their types.

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -27,6 +27,9 @@ private[reader] object Unpickler {
         }
       }
 
+      // Now read the types of symbols
+      reader.completeAllSymbolTypes(structure)
+
       // Read children after reading the symbols themselves, fix for SI-3951
       index.loopWithIndices { (offset, i) =>
         if (reader.missingEntry(i)) {


### PR DESCRIPTION
This mimics how we ready .tasty files. First, we create all the symbols defined in the pickle, without reading their types. Only then do we read all the types of all the symbols.

This avoids tricky recursive situations, notably in the presence of complicated existentials and refinement classes mixed together.

Some of the hacks we had to do for refinement classes disappear as a result, because they are not needed anymore.

We can also treat `MODULEsym`'s like other term symbols, without separate code paths.