### PR TITLE
Post release v1.2.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))
@@ -126,12 +126,6 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
-          // private, not an issue
-          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Erasure$ErasedValueClass"),
-          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Erasure$ErasedValueClass$"),
-          ProblemFilters.exclude[MissingClassProblem]("tastyquery.TypeOps$TypeFold"),
-          // private[tastyquery], not an issue
-          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Signatures#Signature.toSigName"),
           // Everything in tastyquery.reader is private[tastyquery] at most
           ProblemFilters.exclude[Problem]("tastyquery.reader.*"),
         )


### PR DESCRIPTION
Set `versionPolicyIntention` to `BinaryAndSourceCompatible` for the upcoming v1.2.1.

Remove previous MiMa filters.