### PR TITLE
Make the entire API thread-safe.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,6 +129,10 @@ lazy val tastyQuery =
           // private[tastyquery], not an issue
           ProblemFilters.exclude[MissingClassProblem]("tastyquery.Utils"),
           ProblemFilters.exclude[MissingClassProblem]("tastyquery.Utils$"),
+          // private, not an issue
+          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Types$TermRef$Resolved"),
+          ProblemFilters.exclude[MissingClassProblem]("tastyquery.Types$TypeRef$Resolved"),
+
           // Everything in tastyquery.reader is private[tastyquery] at most
           ProblemFilters.exclude[Problem]("tastyquery.reader.*"),
         )

--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,7 @@ lazy val tastyQuery =
         import com.typesafe.tools.mima.core.*
         Seq(
           // private[tastyquery], not an issue
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.Contexts#Context.classloader"),
           ProblemFilters.exclude[MissingClassProblem]("tastyquery.Utils"),
           ProblemFilters.exclude[MissingClassProblem]("tastyquery.Utils$"),
           // private, not an issue

--- a/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
+++ b/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
@@ -31,6 +31,9 @@ object ClasspathLoaders:
     * to create a [[Contexts.Context]]. The latter gives semantic access to all
     * the definitions on the classpath.
     *
+    * The entries of the resulting [[Classpaths.Classpath]] can be considered
+    * thread-safe, since the JavaScript environment is always single-threaded.
+    *
     * @note the resulting [[Classpaths.ClasspathEntry ClasspathEntry]] entries of
     *       the returned [[Classpaths.Classpath]] correspond to the elements of `classpath`.
     */

--- a/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
+++ b/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
@@ -40,6 +40,9 @@ object ClasspathLoaders {
     * to create a [[Contexts.Context]]. The latter gives semantic access to all
     * the definitions on the classpath.
     *
+    * The entries of the resulting [[Classpaths.Classpath]] are all guaranteed
+    * to be thread-safe.
+    *
     * @note the resulting [[Classpaths.ClasspathEntry ClasspathEntry]] entries of
     *       the returned [[Classpaths.Classpath]] correspond to the elements of `classpath`.
     */

--- a/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Annotations.scala
@@ -13,16 +13,16 @@ import tastyquery.Utils.*
 
 object Annotations:
   final class Annotation(val tree: TermTree):
-    private var mySymbol: Memo[ClassSymbol] = uninitializedMemo
-    private var mySafeSymbol: Memo[Option[ClassSymbol]] = uninitializedMemo
-    private var myArguments: Memo[List[TermTree]] = uninitializedMemo
+    private val mySymbol: Memo[ClassSymbol] = uninitializedMemo
+    private val mySafeSymbol: Memo[Option[ClassSymbol]] = uninitializedMemo
+    private val myArguments: Memo[List[TermTree]] = uninitializedMemo
 
     /** The annotation class symbol. */
     def symbol(using Context): ClassSymbol =
-      memoized2(mySymbol, mySymbol = _) {
+      memoized2(mySymbol) {
         computeAnnotSymbol(tree)
       } { computed =>
-        initializeMemo[Option[ClassSymbol]](mySafeSymbol = _, Some(computed))
+        initializeMemo(mySafeSymbol, Some(computed))
       }
     end symbol
 
@@ -31,10 +31,10 @@ object Annotations:
       * If the class of this annotation cannot be successfully resolved, returns `false`.
       */
     private[tastyquery] def safeHasSymbol(cls: ClassSymbol)(using Context): Boolean =
-      val safeSymbol = memoized2(mySafeSymbol, mySafeSymbol = _) {
+      val safeSymbol = memoized2(mySafeSymbol) {
         computeSafeAnnotSymbol(tree)
       } { computed =>
-        computed.foreach(sym => initializeMemo[ClassSymbol](mySymbol = _, sym))
+        computed.foreach(sym => initializeMemo(mySymbol, sym))
       }
 
       safeSymbol.contains(cls)
@@ -56,7 +56,7 @@ object Annotations:
       * `NamedArg`s are not visible with this method. They are replaced by
       * their right-hand-side.
       */
-    def arguments: List[TermTree] = memoized(myArguments, myArguments = _) {
+    def arguments: List[TermTree] = memoized(myArguments) {
       computeAnnotArguments(tree)
     }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Classpaths.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Classpaths.scala
@@ -23,6 +23,11 @@ object Classpaths:
     * All the methods of `ClasspathEntry` and its components may throw
     * `java.io.IOException`s to indicate I/O errors.
     *
+    * A `ClasspathEntry` is encouraged to be thread-safe, along with all its
+    * components, but it is not a strong requirement. Implementations that are
+    * thread-safe should be documented as such. [[Contexts.Context]]s created
+    * only from thread-safe `ClasspathEntry`s are thread-safe themselves.
+    *
     * Implementations of this class are encouraged to define a `toString()`
     * method that helps identifying the entry for debugging purposes.
     */
@@ -99,16 +104,21 @@ object Classpaths:
     def readClassFileBytes(): IArray[Byte]
   end ClassData
 
-  /** In-memory representation of classpath entries. */
+  /** In-memory representation of classpath entries.
+    *
+    * In-memory classpath entries are thread-safe.
+    */
   object InMemory:
     import Classpaths as generic
 
+    /** A thread-safe, immutable classpath entry. */
     final class ClasspathEntry(debugString: String, val packages: List[PackageData]) extends generic.ClasspathEntry:
       override def toString(): String = debugString
 
       def listAllPackages(): List[generic.PackageData] = packages
     end ClasspathEntry
 
+    /** A thread-safe, immutable package information within a classpath entry. */
     final class PackageData(debugString: String, val dotSeparatedName: String, val classes: List[ClassData])
         extends generic.PackageData:
       private lazy val byBinaryName = classes.map(c => c.binaryName -> c).toMap
@@ -120,6 +130,7 @@ object Classpaths:
       def getClassDataByBinaryName(binaryName: String): Option[generic.ClassData] = byBinaryName.get(binaryName)
     end PackageData
 
+    /** A thread-safe, immutable class information within a classpath entry. */
     final class ClassData(
       debugString: String,
       val binaryName: String,

--- a/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
@@ -58,14 +58,18 @@ object Contexts {
     * The same instance of [[Classpaths.Classpath]] can be reused to create
     * several [[Context]]s, if necessary.
     */
-  final class Context private[Contexts] (private[tastyquery] val classloader: Loader) {
+  final class Context private[Contexts] (classloader: Loader) {
     private given Context = this
 
     private val sourceFiles = mutable.HashMap.empty[String, SourceFile]
 
     private val (RootPackage @ _, EmptyPackage @ _) = PackageSymbol.createRoots()
 
+    private[tastyquery] def hasGenericTuples: Boolean = classloader.hasGenericTuples
+
     val defn: Definitions = Definitions(this: @unchecked, RootPackage, EmptyPackage)
+
+    private[tastyquery] def internalClasspathForTestsOnly: Classpath = classloader.classpath
 
     private[tastyquery] def getSourceFile(path: String): SourceFile =
       sourceFiles.getOrElseUpdate(path, new SourceFile(path))

--- a/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Contexts.scala
@@ -27,11 +27,22 @@ object Contexts {
 
   /** Factory methods for [[Context]]. */
   object Context:
-    /** Creates a new [[Context]] for the given [[Classpaths.Classpath]]. */
+    /** Creates a new [[Context]] for the given [[Classpaths.Classpath]].
+      *
+      * If all the [[Classpaths.ClasspathEntry ClasspathEntries]] in the classpath
+      * are thread-safe, then the resulting [[Context]] is thread-safe.
+      */
     def initialize(classpath: Classpath): Context =
       val classloader = Loader(classpath)
       val ctx = new Context(classloader)
       classloader.initPackages()(using ctx)
+
+      /* Exploit the portable releaseFence() call inside the `::` constructor,
+       * in order to publish all the mutations that were done during the
+       * above initialization to other threads.
+       */
+      new ::(Nil, Nil)
+
       ctx
     end initialize
   end Context

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -517,7 +517,7 @@ final class Definitions private[tastyquery] (
     end functionClassOf
   end PolyFunctionType
 
-  lazy val hasGenericTuples = withRestrictedContext(ctx.classloader.hasGenericTuples)
+  lazy val hasGenericTuples = withRestrictedContext(ctx.hasGenericTuples)
 
   lazy val uninitializedMethod: Option[TermSymbol] =
     withRestrictedContext {

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -910,6 +910,7 @@ object Symbols {
 
     // Optional reference fields
     private var myScala2SealedChildren: Option[List[Symbol | Scala2ExternalSymRef]] = None
+    private var myTopLevelTasty: List[TopLevelTree] = Nil
 
     // DeclaringSymbol-related fields
     private val myDeclarations: mutable.HashMap[UnsignedName, mutable.HashSet[TermOrTypeSymbol]] =
@@ -1095,6 +1096,22 @@ object Symbols {
           if isModuleClass then givenSelf
           else AndType(givenSelf, appliedRefInsideThis)
     }
+
+    private[tastyquery] final def setTopLevelTasty(trees: List[TopLevelTree]): this.type =
+      require(owner.isPackage, "cannot set topLevelTasty to a non-top-level class")
+      require(!flags.isAnyOf(Scala2Defined | JavaDefined), "cannot set topLevelTasty to a non-Scala 3 class")
+      myTopLevelTasty = trees
+      this
+    end setTopLevelTasty
+
+    private[tastyquery] final def topLevelTasty: List[TopLevelTree] =
+      require(owner.isPackage, s"illegal call to topLevelTasty on the non-top-level class $this")
+      require(
+        !flags.isAnyOf(Scala2Defined | JavaDefined),
+        s"illegal call to topLevelTasty on the non-Scala 3 class $this"
+      )
+      myTopLevelTasty
+    end topLevelTasty
 
     final def linearization(using Context): List[ClassSymbol] = memoized(myLinearization, myLinearization = _) {
       val parentsLin = parentClasses.foldLeft[List[ClassSymbol]](Nil) { (lin, parent) =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -70,7 +70,7 @@ object Trees {
   end StatementTree
 
   sealed abstract class TermTree(pos: SourcePosition) extends StatementTree(pos):
-    private var myType: TermType | Null = null
+    private var myType: Memo[TermType] = uninitializedMemo
 
     def withPos(pos: SourcePosition): TermTree
 
@@ -716,7 +716,7 @@ object Trees {
   end TypeArgTree
 
   sealed abstract class TypeTree(pos: SourcePosition) extends TypeArgTree(pos) {
-    private var myType: NonEmptyPrefix | Null = null
+    private var myType: Memo[NonEmptyPrefix] = uninitializedMemo
 
     protected def calculateType: NonEmptyPrefix
 
@@ -882,7 +882,7 @@ object Trees {
   }
 
   final case class WildcardTypeArgTree(bounds: TypeBoundsTree)(pos: SourcePosition) extends TypeArgTree(pos) {
-    private var myTypeOrWildcard: WildcardTypeArg | Null = null
+    private var myTypeOrWildcard: Memo[WildcardTypeArg] = uninitializedMemo
 
     def toTypeOrWildcard: TypeOrWildcard = memoized(myTypeOrWildcard, myTypeOrWildcard = _) {
       WildcardTypeArg(bounds.toTypeBounds)

--- a/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Trees.scala
@@ -70,7 +70,7 @@ object Trees {
   end StatementTree
 
   sealed abstract class TermTree(pos: SourcePosition) extends StatementTree(pos):
-    private var myType: Memo[TermType] = uninitializedMemo
+    private val myType: Memo[TermType] = uninitializedMemo
 
     def withPos(pos: SourcePosition): TermTree
 
@@ -94,7 +94,7 @@ object Trees {
     protected def calculateType(using Context): TermType
 
     /** The term type of this tree. */
-    final def tpe(using Context): TermType = memoized(myType, myType = _) {
+    final def tpe(using Context): TermType = memoized(myType) {
       calculateType
     }
   end TermTree
@@ -341,16 +341,16 @@ object Trees {
   final case class Apply(fun: TermTree, args: List[TermTree])(pos: SourcePosition) extends TermTree(pos):
     import Apply.*
 
-    private var myMethodType: Memo[MethodType] = uninitializedMemo
+    private val myMethodType: Memo[MethodType] = uninitializedMemo
 
     protected[tastyquery] def this(
       fun: TermTree,
       args: List[TermTree]
     )(methodType: MethodType | Null, pos: SourcePosition) =
       this(fun, args)(pos)
-      if methodType != null then initializeMemo[MethodType](myMethodType = _, methodType)
+      if methodType != null then initializeMemo(myMethodType, methodType)
 
-    def methodType(using Context): MethodType = memoized(myMethodType, myMethodType = _) {
+    def methodType(using Context): MethodType = memoized(myMethodType) {
       fun.tpe.widenTermRef match
         case funTpe: MethodType => funTpe
         case funTpe             => throw NonMethodReferenceException(s"application to $funTpe")
@@ -715,13 +715,13 @@ object Trees {
   end TypeArgTree
 
   sealed abstract class TypeTree(pos: SourcePosition) extends TypeArgTree(pos) {
-    private var myType: Memo[NonEmptyPrefix] = uninitializedMemo
+    private val myType: Memo[NonEmptyPrefix] = uninitializedMemo
 
     protected def calculateType: NonEmptyPrefix
 
     def withPos(pos: SourcePosition): TypeTree
 
-    final def toPrefix: NonEmptyPrefix = memoized(myType, myType = _) {
+    final def toPrefix: NonEmptyPrefix = memoized(myType) {
       calculateType
     }
 
@@ -881,9 +881,9 @@ object Trees {
   }
 
   final case class WildcardTypeArgTree(bounds: TypeBoundsTree)(pos: SourcePosition) extends TypeArgTree(pos) {
-    private var myTypeOrWildcard: Memo[WildcardTypeArg] = uninitializedMemo
+    private val myTypeOrWildcard: Memo[WildcardTypeArg] = uninitializedMemo
 
-    def toTypeOrWildcard: TypeOrWildcard = memoized(myTypeOrWildcard, myTypeOrWildcard = _) {
+    def toTypeOrWildcard: TypeOrWildcard = memoized(myTypeOrWildcard) {
       WildcardTypeArg(bounds.toTypeBounds)
     }
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -1018,7 +1018,7 @@ object Types {
   /** The singleton type for path prefix#myDesignator. */
   final class TermRef private (
     val prefix: Prefix,
-    private var myDesignator: TermSymbol | TermName | LookupIn | Scala2ExternalSymRef
+    private val myDesignator: TermSymbol | TermName | LookupIn | Scala2ExternalSymRef
   ) extends NamedType
       with SingletonType
       with TermReferenceType {
@@ -1056,7 +1056,6 @@ object Types {
     private def resolve()(using Context): Unit =
       def storeResolved(sym: TermSymbol, tpe: TypeOrMethodic, isStable: Boolean): Unit =
         mySymbol = sym
-        myDesignator = sym
         myUnderlying = tpe
         myIsStable = isStable
 
@@ -1236,7 +1235,7 @@ object Types {
 
   final class TypeRef private (
     val prefix: Prefix,
-    private var myDesignator: TypeName | TypeSymbol | LookupTypeIn | Scala2ExternalSymRef
+    private val myDesignator: TypeName | TypeSymbol | LookupTypeIn | Scala2ExternalSymRef
   ) extends NamedType {
 
     protected type ThisName = TypeName
@@ -1257,7 +1256,6 @@ object Types {
       this(prefix, name)
       val optSymbol = resolved.symbols.headOption
       myOptSymbol = optSymbol
-      if optSymbol.isDefined then myDesignator = optSymbol.get
       myBounds = resolved.bounds
     end this
 
@@ -1274,11 +1272,9 @@ object Types {
     private def resolve()(using Context): Unit =
       def storeClass(cls: ClassSymbol): Unit =
         myOptSymbol = Some(cls)
-        myDesignator = cls
 
       def storeTypeMember(sym: Option[TypeSymbolWithBounds], bounds: TypeBounds): Unit =
         myOptSymbol = sym
-        if sym.isDefined then myDesignator = sym.get
         myBounds = bounds
 
       def storeSymbol(sym: TypeSymbol): Unit = sym match

--- a/tasty-query/shared/src/main/scala/tastyquery/Utils.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Utils.scala
@@ -1,8 +1,22 @@
 package tastyquery
 
+import scala.annotation.targetName
+
 private[tastyquery] object Utils:
+  opaque type Memo[A] = A | Null
+
+  opaque type SingleAssign[A] = A | Null
+
+  // Memo
+
+  inline def uninitializedMemo[A]: Memo[A] = null
+
+  extension [A](memo: Memo[A])
+    @targetName("isMemoInitialized")
+    def isInitialized: Boolean = memo != null
+
   /** A memoized computation `computed`, stored in `memo` using the `store` setter. */
-  inline def memoized[A](memo: A | Null, inline store: A => Unit)(inline compute: => A): A =
+  inline def memoized[A](memo: Memo[A], inline store: Memo[A] => Unit)(inline compute: => A): A =
     if memo != null then memo
     else
       // Extracted in a separate def for good jitting of the code calling `memoized`
@@ -13,12 +27,48 @@ private[tastyquery] object Utils:
       computeAndStore()
   end memoized
 
-  inline def assignOnce(existing: Any, inline assign: => Unit)(inline msgIfAlreadyAssigned: => String): Unit =
+  inline def memoized2[A](memo: Memo[A], inline store: Memo[A] => Unit)(
+    inline compute: => A
+  )(inline afterCompute: A => Unit): A =
+    if memo != null then memo
+    else
+      // Extracted in a separate def for good jitting of the code calling `memoized2`
+      def computeAndStore(): A =
+        val computed = compute
+        store(computed)
+        afterCompute(computed)
+        computed
+      computeAndStore()
+  end memoized2
+
+  inline def initializeMemo[A](inline store: Memo[A] => Unit, value: A): Unit =
+    store(value)
+
+  inline def assignOnceMemo[A](existing: Memo[A], inline assign: Memo[A] => Unit, value: A)(
+    inline msgIfAlreadyAssigned: => String
+  ): Unit =
+    if existing != null then throw IllegalStateException(msgIfAlreadyAssigned)
+    assign(value)
+
+  // SingleAssign
+
+  inline def uninitializedSingleAssign[A]: SingleAssign[A] = null
+
+  extension [A](singleAssign: SingleAssign[A])
+    @targetName("isSingleAssignInitialized")
+    def isInitialized: Boolean = singleAssign != null
+
+  inline def assignOnce[A](existing: SingleAssign[A], inline assign: SingleAssign[A] => Unit, value: A)(
+    inline msgIfAlreadyAssigned: => String
+  ): Unit =
     // Methods calling `assignOnce` are not in fast paths, so no need to extract the exception in a local def
     if existing != null then throw IllegalStateException(msgIfAlreadyAssigned)
-    assign
+    assign(value)
 
-  inline def getAssignedOnce[A](value: A | Null)(inline msgIfNotAssignedYet: => String): A =
+  inline def overwriteSingleAssign[A](inline assign: SingleAssign[A] => Unit, value: A): Unit =
+    assign(value)
+
+  inline def getAssignedOnce[A](value: SingleAssign[A])(inline msgIfNotAssignedYet: => String): A =
     if value != null then value
     else
       // Extracted in a separate def for good jitting of the code calling `getAssignedOnce`

--- a/tasty-query/shared/src/main/scala/tastyquery/Utils.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Utils.scala
@@ -2,53 +2,55 @@ package tastyquery
 
 import scala.annotation.targetName
 
+import java.util.concurrent.atomic.AtomicReference
+
 private[tastyquery] object Utils:
-  opaque type Memo[A] = A | Null
+  opaque type Memo[A] = AtomicReference[A]
 
   opaque type SingleAssign[A] = A | Null
 
   // Memo
 
-  inline def uninitializedMemo[A]: Memo[A] = null
+  inline def uninitializedMemo[A]: Memo[A] = new AtomicReference[A]()
 
   extension [A](memo: Memo[A])
     @targetName("isMemoInitialized")
-    def isInitialized: Boolean = memo != null
+    def isInitialized: Boolean = memo.get() != null
 
   /** A memoized computation `computed`, stored in `memo` using the `store` setter. */
-  inline def memoized[A](memo: Memo[A], inline store: Memo[A] => Unit)(inline compute: => A): A =
-    if memo != null then memo
+  inline def memoized[A](memo: Memo[A])(inline compute: => A): A =
+    val existing = memo.get()
+    if existing != null then existing
     else
       // Extracted in a separate def for good jitting of the code calling `memoized`
       def computeAndStore(): A =
         val computed = compute
-        store(computed)
-        computed
+        if memo.compareAndSet(null, computed) then computed
+        else memo.get().nn
       computeAndStore()
   end memoized
 
-  inline def memoized2[A](memo: Memo[A], inline store: Memo[A] => Unit)(
-    inline compute: => A
-  )(inline afterCompute: A => Unit): A =
-    if memo != null then memo
+  inline def memoized2[A](memo: Memo[A])(inline compute: => A)(inline afterCompute: A => Unit): A =
+    val existing = memo.get()
+    if existing != null then existing
     else
       // Extracted in a separate def for good jitting of the code calling `memoized2`
       def computeAndStore(): A =
         val computed = compute
-        store(computed)
-        afterCompute(computed)
-        computed
+        if memo.compareAndSet(null, computed) then
+          afterCompute(computed)
+          computed
+        else
+          // We wasted the computation; use the stored value so that only once instance survives for the GC
+          memo.get().nn
       computeAndStore()
   end memoized2
 
-  inline def initializeMemo[A](inline store: Memo[A] => Unit, value: A): Unit =
-    store(value)
+  inline def initializeMemo[A](memo: Memo[A], value: A): Unit =
+    memo.compareAndSet(null, value)
 
-  inline def assignOnceMemo[A](existing: Memo[A], inline assign: Memo[A] => Unit, value: A)(
-    inline msgIfAlreadyAssigned: => String
-  ): Unit =
-    if existing != null then throw IllegalStateException(msgIfAlreadyAssigned)
-    assign(value)
+  inline def assignOnceMemo[A](existing: Memo[A], value: A)(inline msgIfAlreadyAssigned: => String): Unit =
+    if !existing.compareAndSet(null, value) then throw IllegalStateException(msgIfAlreadyAssigned)
 
   // SingleAssign
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
@@ -189,7 +189,7 @@ private[tastyquery] object Loaders {
 
     private var initialized = false
     private var _hasGenericTuples: Boolean = false
-    private var byEntry: Memo[ByEntryMap] = uninitializedMemo
+    private val byEntry: Memo[ByEntryMap] = uninitializedMemo
 
     private def toPackageName(dotSeparated: String): PackageFullName =
       val parts =
@@ -217,7 +217,7 @@ private[tastyquery] object Loaders {
           case Some(pkgs) => Some(pkgs.view.flatMap(lookupRoots))
           case None       => None
 
-      val localByEntry = memoized(byEntry, byEntry = _) {
+      val localByEntry = memoized(byEntry) {
         computeByEntry()
       }
       computeLookup(localByEntry)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/ReaderContext.scala
@@ -69,7 +69,7 @@ private[reader] final class ReaderContext(underlying: Context):
   def getSourceFile(path: String): SourceFile =
     underlying.getSourceFile(path)
 
-  def hasGenericTuples: Boolean = underlying.classloader.hasGenericTuples
+  def hasGenericTuples: Boolean = underlying.hasGenericTuples
 
   def createObjectMagicMethods(cls: ClassSymbol): Unit =
     underlying.defn.createObjectMagicMethods(cls)

--- a/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/ClasspathEntrySuite.scala
@@ -9,7 +9,7 @@ import tastyquery.testutil.TestPlatform
 class ClasspathEntrySuite extends UnrestrictedUnpicklingSuite:
 
   def scala3ClasspathEntry(using Context): ClasspathEntry =
-    ctx.classloader.classpath(TestPlatform.scala3ClasspathIndex)
+    ctx.internalClasspathForTestsOnly(TestPlatform.scala3ClasspathIndex)
 
   def lookupSyms(entry: ClasspathEntry)(using Context): IArray[Symbol] =
     IArray.from(ctx.findSymbolsByClasspathEntry(entry))

--- a/tasty-query/shared/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/RestrictedUnpicklingSuite.scala
@@ -16,9 +16,9 @@ abstract class RestrictedUnpicklingSuite extends BaseUnpicklingSuite {
     for base <- initRestrictedContext(rootSymbolPath, extraRootSymbolPaths) yield
       given Context = base
       val rootSym = findTopLevelClassOrModuleClass(rootSymbolPath)
-      val tree = base.classloader.topLevelTasty(rootSym) match
-        case Some(trees) => trees.head
-        case _           => fail(s"Missing tasty for $rootSymbolPath, but resolved root $rootSym")
+      val tree = rootSym.topLevelTasty match
+        case firstTree :: _ => firstTree
+        case Nil            => fail(s"Missing tasty for $rootSymbolPath, but resolved root $rootSym")
       (base, tree)
   end findTopLevelTasty
 

--- a/tasty-query/shared/src/test/scala/tastyquery/UnrestrictedUnpicklingSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/UnrestrictedUnpicklingSuite.scala
@@ -5,13 +5,29 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import tastyquery.Contexts.*
 
 abstract class UnrestrictedUnpicklingSuite extends BaseUnpicklingSuite {
+  import UnrestrictedUnpicklingSuite.*
+
+  /** Set this to true to stress-test thread-safety by using a common `Context` across all test suites. */
+  private final val useParallelTesting = false
+
   def testWithContext(name: String)(using munit.Location)(body: Context ?=> Unit): Unit =
     testWithContext(new munit.TestOptions(name))(body)
 
   def testWithContext(options: munit.TestOptions)(using munit.Location)(body: Context ?=> Unit): Unit =
     test(options) {
-      for classpath <- testClasspath yield
-        val ctx = Context.initialize(classpath)
-        body(using ctx)
+      if useParallelTesting then
+        // use the common context
+        for ctx <- commonContextForParallelTesting yield body(using ctx)
+      else
+        // create an isolated context
+        for classpath <- testClasspath yield
+          val ctx = Context.initialize(classpath)
+          body(using ctx)
+      end if
     }
 }
+
+object UnrestrictedUnpicklingSuite:
+  private lazy val commonContextForParallelTesting =
+    tastyquery.testutil.TestPlatform.loadClasspath().map(Context.initialize(_))
+end UnrestrictedUnpicklingSuite


### PR DESCRIPTION
On the condition that the `ClasspathEntry`s used to create the `Context` are thread-safe.