### PR TITLE
Upgrade to Scala 3.5.0 and support its TASTy format.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.util.ManagedLogger
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
-val usedScalaCompiler = "3.4.3"
+val usedScalaCompiler = "3.5.0"
 val usedTastyRelease = usedScalaCompiler
 val scala2Version = "2.13.14"
 
@@ -52,7 +52,7 @@ val strictCompileSettings = Seq(
   scalacOptions ++= Seq(
     "-Xfatal-warnings",
     "-Yexplicit-nulls",
-    "-Ysafe-init",
+    "-Wsafe-init",
     "-source:future",
   ),
 )
@@ -129,7 +129,8 @@ lazy val tastyQuery =
         )
       },
 
-      tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
+      // Temporarily disabled until we have a published version of tasty-query that can handle 3.4.x.
+      //tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
       tastyMiMaConfig ~= { prev =>
         import tastymima.intf._
         prev

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.util.ManagedLogger
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
-val usedScalaCompiler = "3.4.0"
+val usedScalaCompiler = "3.4.3"
 val usedTastyRelease = usedScalaCompiler
 val scala2Version = "2.13.14"
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -43,6 +43,8 @@ final class Definitions private[tastyquery] (
     scalaPackage.getPackageDeclOrCreate(termName("compiletime"))
   private val scalaCollectionImmutablePackage =
     scalaCollectionPackage.getPackageDeclOrCreate(termName("immutable"))
+  private val scalaQuotedPackage =
+    scalaPackage.getPackageDeclOrCreate(termName("quoted"))
   private val scalaRuntimePackage =
     scalaPackage.getPackageDeclOrCreate(termName("runtime"))
 
@@ -439,6 +441,8 @@ final class Definitions private[tastyquery] (
   lazy val SeqClass = scalaCollectionImmutablePackage.requiredClass("Seq")
   lazy val Function0Class = scalaPackage.requiredClass("Function0")
 
+  private[tastyquery] lazy val ContextFunction1Class = scalaPackage.requiredClass("ContextFunction1")
+
   def FunctionNClass(n: Int): ClassSymbol =
     withRestrictedContext(scalaPackage.findDecl(typeName(s"Function$n")).asClass)
 
@@ -481,6 +485,9 @@ final class Definitions private[tastyquery] (
   private[tastyquery] lazy val TupleNClasses = (1 to 22).map(n => scalaPackage.requiredClass(s"Tuple$n")).toSet
 
   private[tastyquery] lazy val PolyFunctionClass = scalaPackage.optionalClass("PolyFunction")
+
+  private[tastyquery] lazy val QuotedExprClass = scalaQuotedPackage.requiredClass("Expr")
+  private[tastyquery] lazy val QuotesClass = scalaQuotedPackage.requiredClass("Quotes")
 
   private[tastyquery] def isPolyFunctionSub(tpe: Type)(using Context): Boolean =
     PolyFunctionClass.exists(cls => tpe.baseType(cls).isDefined)

--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -111,6 +111,8 @@ private[tastyquery] object Erasure:
         preErase(tpe.parent, keepUnit)
       case tpe: RecType =>
         preErase(tpe.parent, keepUnit)
+      case tpe: FlexibleType =>
+        preErase(tpe.nonNullableType, keepUnit)
       case _: ByNameType =>
         defn.Function0Class.erasure
       case tpe: RepeatedType =>

--- a/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Printers.scala
@@ -77,6 +77,9 @@ private[tastyquery] object Printers:
         print("[")
         printCommaSeparatedList(tpe.args)(print(_))
         print("]")
+      case tpe: FlexibleType =>
+        print(tpe.nonNullableType)
+        print("?")
       case tpe: ByNameType =>
         print("=> ")
         print(tpe.resultType)
@@ -445,6 +448,32 @@ private[tastyquery] object Printers:
           print(c)
           print(">")
         printBlock(bindings, expr)(print(_))
+
+      case Quote(body, bodyType) =>
+        print("'[")
+        print(bodyType)
+        print("]")
+        printBlock(Nil, body)(print(_))
+
+      case Splice(expr, spliceType) =>
+        print("$[")
+        print(spliceType)
+        print("]")
+        printBlock(Nil, expr)(print(_))
+
+      case SplicePattern(pattern, targs, args, spliceType) =>
+        print("$[")
+        print(spliceType)
+        print("]")
+        print(pattern)
+        if targs.nonEmpty then
+          print("[")
+          printCommaSeparatedList(targs)(print(_))
+          print("]")
+        if args.nonEmpty then
+          print("(")
+          printCommaSeparatedList(args)(print(_))
+          print(")")
     end print
 
     def print(caze: CaseDef): Unit =
@@ -577,6 +606,26 @@ private[tastyquery] object Printers:
 
       case ExprPattern(expr) =>
         print(expr)
+
+      case QuotePattern(bindings, body, quotes, patternType) =>
+        print("'<")
+        print(quotes)
+        print(">")
+        body match
+          case Left(termBody) =>
+            print("{ ")
+            for binding <- bindings do
+              print(binding)
+              print("; ")
+            print(termBody)
+            print(" }")
+          case Right(typeBody) =>
+            print("[ ")
+            for binding <- bindings do
+              print(binding)
+              print("; ")
+            print(typeBody)
+            print(" ]")
     end print
 
     def print(tree: TypeTree): Unit = tree match

--- a/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Subtyping.scala
@@ -238,6 +238,9 @@ private[tastyquery] object Subtyping:
       isSubType(tp1, tp2.first) || isSubType(tp1, tp2.second)
         || level4(tp1, tp2)
 
+    case tp2: FlexibleType =>
+      isSubType(tp1, tp2.nullableType)
+
     case tp2: ByNameType =>
       tp1 match
         case tp1: ByNameType => isSubType(tp1.resultType, tp2.resultType)
@@ -477,6 +480,9 @@ private[tastyquery] object Subtyping:
 
     case tp1: RecType =>
       isSubType(tp1.parent, tp2)
+
+    case tp1: FlexibleType =>
+      isSubType(tp1.nonNullableType, tp2)
 
     case tp1: AndType =>
       // TODO Try and simplify first

--- a/tasty-query/shared/src/main/scala/tastyquery/Traversers.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Traversers.scala
@@ -120,6 +120,14 @@ object Traversers:
         traverse(expr)
         traverse(caller)
         traverse(bindings)
+      case Quote(body, bodyType) =>
+        traverse(body)
+      case Splice(expr, spliceType) =>
+        traverse(expr)
+      case SplicePattern(pattern, targs, args, spliceType) =>
+        traverse(pattern)
+        traverse(targs)
+        traverse(args)
       case _: ImportIdent | _: Ident | _: This | _: Literal =>
         ()
 
@@ -139,6 +147,10 @@ object Traversers:
         traverse(expr)
       case WildcardPattern(tpe) =>
         ()
+      case QuotePattern(bindings, body, quotes, patternType) =>
+        traverse(bindings)
+        body.fold(traverse(_), traverse(_))
+        traverse(quotes)
 
       // TypeTree-ish
       case TypeIdent(tpe) =>

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -53,6 +53,8 @@ private[tastyquery] object TypeMaps {
       tp.derivedAnnotatedType(underlying, annot)
     protected def derivedMatchType(tp: MatchType, bound: Type, scrutinee: Type, cases: List[MatchTypeCase]): Type =
       tp.derivedMatchType(bound, scrutinee, cases)
+    protected def derivedFlexibleType(tp: FlexibleType, nonNullableType: Type): Type =
+      tp.derivedFlexibleType(nonNullableType)
     protected def derivedByNameType(tp: ByNameType, restpe: Type): Type =
       tp.derivedByNameType(restpe)
     protected def derivedRepeatedType(tp: RepeatedType, elemType: Type): Type =
@@ -122,6 +124,9 @@ private[tastyquery] object TypeMaps {
 
         case tp: TypeLambda =>
           mapOverLambda(tp)
+
+        case tp: FlexibleType =>
+          derivedFlexibleType(tp, this(tp.nonNullableType))
 
         case tp: ByNameType =>
           derivedByNameType(tp, this(tp.resultType))

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
@@ -114,6 +114,8 @@ private[tastyquery] object TypeOps:
         apply(z, tp.thistpe)
       case tp: AppliedType =>
         tp.args.foldLeft(apply(z, tp.tycon))(this)
+      case tp: FlexibleType =>
+        apply(z, tp.nonNullableType)
       case tp: ByNameType =>
         apply(z, tp.resultType)
       case tp: RepeatedType =>

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyReader.scala
@@ -131,17 +131,21 @@ private[tasties] class TastyReader(val bytes: Array[Byte], start: Int, end: Int,
   def goto(addr: Addr): Unit =
     bp = index(addr)
 
+  /** Is the current read address before the given end address? */
+  def isBefore(end: Addr): Boolean =
+    bp < index(end)
+
   /** Perform `op` until `end` address is reached and collect results in a list. */
   def until[T](end: Addr)(op: => T): List[T] =
     val buf = new mutable.ListBuffer[T]
-    while bp < index(end) do buf += op
+    while isBefore(end) do buf += op
     assert(bp == index(end))
     buf.toList
   end until
 
   /** If before given `end` address, the result of `op`, otherwise `default` */
   def ifBefore[T](end: Addr)(op: => T, default: T): T =
-    if bp < index(end) then op
+    if isBefore(end) then op
     else default
 
   /** Perform `op` while cindition `cond` holds and collect results in a list. */

--- a/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PositionSuite.scala
@@ -186,11 +186,7 @@ class PositionSuite extends RestrictedUnpicklingSuite {
   }
 
   testUnpickle("lambda", "simple_trees.Function") { tree =>
-    assertEquals(
-      collectCode[Lambda](tree),
-      // NoSpan is the expected behavior
-      Nil
-    )
+    assertEquals(collectCode[Lambda](tree), List("(x: Int) => x + 1", "() => ()", "[T] => (x: T) => x", "x => x"))
   }
 
   testUnpickle("return", "simple_trees.Return") { tree =>

--- a/tasty-query/shared/src/test/scala/tastyquery/WholeClasspathSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/WholeClasspathSuite.scala
@@ -80,8 +80,8 @@ class WholeClasspathSuite extends UnrestrictedUnpicklingSuite:
     traverseEveryTopLevelClassDef(_ != RuntimeLazyValsClass)(traverser)
 
     tracker.finalize(
-      // As of this writing, there were 15293 successes
-      minExpectedSuccessCount = 15000,
+      // As of this writing, there were 11617 successes
+      minExpectedSuccessCount = 11000,
       errorTitle = "Could not resolve the `symbol` of some trees on the classpath:"
     )
   }
@@ -116,8 +116,8 @@ class WholeClasspathSuite extends UnrestrictedUnpicklingSuite:
     traverseEveryTopLevelClassDef(_ != RuntimeLazyValsClass)(traverser)
 
     tracker.finalize(
-      // As of this writing, there were 44959 successes
-      minExpectedSuccessCount = 44000,
+      // As of this writing, there were 38337 successes
+      minExpectedSuccessCount = 38000,
       errorTitle = "Could not compute the `tpe` of some term trees on the classpath:"
     )
   }
@@ -144,7 +144,10 @@ object WholeClasspathSuite:
       val errors = errorsBuilder.result()
       if errors.nonEmpty then fail(errors.mkString(errorTitle + "\n", "\n", "\n"))
 
-      assert(clue(successCount) >= clue(minExpectedSuccessCount))
+      assert(
+        clue(successCount) >= clue(minExpectedSuccessCount),
+        "There were no failures, but there were not as many successes as expected."
+      )
     end finalize
   end Tracker
 end WholeClasspathSuite

--- a/test-sources/src/main/scala/simple_trees/AccessModifiers.scala
+++ b/test-sources/src/main/scala/simple_trees/AccessModifiers.scala
@@ -2,7 +2,7 @@ package simple_trees
 
 import scala.annotation.nowarn
 
-@nowarn("msg=The \\[this\\] qualifier will be deprecated")
+@nowarn("msg=Ignoring \\[this\\] qualifier")
 class AccessModifiers(
   localParam: Int,
   private[this] val privateThisParam: Int,

--- a/test-sources/src/main/scala/simple_trees/QuotesAndSplices.scala
+++ b/test-sources/src/main/scala/simple_trees/QuotesAndSplices.scala
@@ -3,7 +3,23 @@ package simple_trees
 import scala.quoted.*
 
 object QuotesAndSplices:
-  def typeQuoteMatching(using quotes: Quotes): Expr[Unit] =
+  def termQuote(using Quotes): Expr[String] =
+    '{ "hello" }
+
+  def termSplice(using Quotes)(s: Expr[String]): Expr[String] =
+    '{ $s + "foo" }
+
+  /* Reading only -- mostly making sure that there isn't a separate TYPESPLICE
+   * tag that we don't know about.
+   */
+  def typeSplice[T: Type](using Quotes)(e: Expr[T]): Expr[T] =
+    '{ $e: T }
+
+  def termQuotePattern(using quotes: Quotes)(e: Expr[Int]): Expr[Int] =
+    e match
+      case '{ ($a: Int) + 1 } => a
+
+  def typeQuotePattern(using quotes: Quotes): Expr[Unit] =
     Type.of[Any] match
       case '[Map[t, u]] => '{ () }
 end QuotesAndSplices


### PR DESCRIPTION
Changes notably include:

* Support `Quote` and `QuotePattern` nodes.
* Support `FlexibleType`s.