### PR TITLE
Upgrade to Scala 3.6.3.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.util.ManagedLogger
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
-val usedScalaCompiler = "3.5.0"
+val usedScalaCompiler = "3.6.2"
 val usedTastyRelease = usedScalaCompiler
 val scala2Version = "2.13.14"
 
@@ -129,7 +129,8 @@ lazy val tastyQuery =
         )
       },
 
-      tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
+      // Temporarily disabled until we have a published version of tasty-query that can handle 3.4.x.
+      //tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
       tastyMiMaConfig ~= { prev =>
         import tastymima.intf._
         prev

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
@@ -296,7 +296,7 @@ private[tasties] object TastyFormat:
     * compatibility, but remains backwards compatible, with all
     * preceeding `MinorVersion`.
     */
-  final val MinorVersion: Int = 5
+  final val MinorVersion: Int = 6
 
   /** Natural Number. The `ExperimentalVersion` allows for
     * experimentation with changes to TASTy without committing

--- a/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
@@ -211,7 +211,11 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     )
 
     val MatchTypeClass = ctx.findTopLevelClass("simple_trees.MatchType")
-    testShowBasicMember(MatchTypeClass, typeName("MT"), "type MT[X] = X match { case Int => String }")
+    testShowBasicMember(
+      MatchTypeClass,
+      typeName("MT"),
+      "type MT[X] <: scala.Predef.String = X match { case Int => String }"
+    )
     testShowBasicMember(
       MatchTypeClass,
       typeName("MTWithBound"),
@@ -220,9 +224,13 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowBasicMember(
       MatchTypeClass,
       typeName("MTWithWildcard"),
-      "type MTWithWildcard[X] = X match { case _ => Int }"
+      "type MTWithWildcard[X] <: scala.Int = X match { case _ => Int }"
     )
-    testShowBasicMember(MatchTypeClass, typeName("MTWithBind"), "type MTWithBind[X] = X match { case List[t] => t }")
+    testShowBasicMember(
+      MatchTypeClass,
+      typeName("MTWithBind"),
+      "type MTWithBind[X] <: t = X match { case List[t] => t }"
+    )
   }
 
   testWithContext("multiline tree printers") {
@@ -286,7 +294,7 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowMultilineMember(
       MatchTypeClass,
       typeName("MT"),
-      """type MT[X] = X match {
+      """type MT[X] <: scala.Predef.String = X match {
         |  case Int => String
         |}""".stripMargin
     )
@@ -300,14 +308,14 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowMultilineMember(
       MatchTypeClass,
       typeName("MTWithWildcard"),
-      """type MTWithWildcard[X] = X match {
+      """type MTWithWildcard[X] <: scala.Int = X match {
         |  case _ => Int
         |}""".stripMargin
     )
     testShowMultilineMember(
       MatchTypeClass,
       typeName("MTWithBind"),
-      """type MTWithBind[X] = X match {
+      """type MTWithBind[X] <: t = X match {
         |  case List[t] => t
         |}""".stripMargin
     )

--- a/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/SignatureSuite.scala
@@ -408,7 +408,7 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     val MatchType = ctx.findTopLevelClass("simple_trees.MatchType")
 
     val unboundUnreducibleSig = MatchType.findNonOverloadedDecl(termName("unboundUnreducibleSig"))
-    assertSigned(unboundUnreducibleSig, "(1,java.lang.Object):java.lang.Object")
+    assertSigned(unboundUnreducibleSig, "(1,java.lang.Object):java.lang.String")
 
     val unboundReducibleSig = MatchType.findNonOverloadedDecl(termName("unboundReducibleSig"))
     assertSigned(unboundReducibleSig, "(1,scala.Int):java.lang.String")
@@ -419,9 +419,9 @@ class SignatureSuite extends UnrestrictedUnpicklingSuite:
     val boundReducibleSig = MatchType.findNonOverloadedDecl(termName("boundReducibleSig"))
     assertSigned(boundReducibleSig, "(1,scala.Int):scala.Some")
 
-    // this one is suspicious, but it is what dotc does (I expected `Object` instead of `Object[]`)
+    // this one is suspicious, but it is what dotc does (I expected `Object` instead of `String[]`)
     val arrayOfUnboundUnreducibleSig = MatchType.findNonOverloadedDecl(termName("arrayOfUnboundUnreducibleSig"))
-    assertSigned(arrayOfUnboundUnreducibleSig, "(1,java.lang.Object):java.lang.Object[]")
+    assertSigned(arrayOfUnboundUnreducibleSig, "(1,java.lang.Object):java.lang.String[]")
 
     val arrayOfUnboundReducibleSig = MatchType.findNonOverloadedDecl(termName("arrayOfUnboundReducibleSig"))
     assertSigned(arrayOfUnboundReducibleSig, "(1,scala.Int):java.lang.String[]")


### PR DESCRIPTION
With changes to the inferred bound of match types.