### PR TITLE
Post release v1.5.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryCompatible,
+  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))
@@ -129,8 +129,8 @@ lazy val tastyQuery =
         )
       },
 
-      // Temporarily disabled until we have a published version of tasty-query that can handle 3.4.x.
-      //tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
+      tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
+      tastyMiMaTastyQueryVersionOverride := Some("1.5.0"),
       tastyMiMaConfig ~= { prev =>
         import tastymima.intf._
         prev


### PR DESCRIPTION
Set `versionPolicyIntention` to `BinaryAndSourceCompatible` for the upcoming v1.5.1.

Re-enable TASTy-MiMa by forcing a newer version of the underlying tasty-query.