### PR TITLE
Upgrade to Scala 3.7.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.util.ManagedLogger
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
-val usedScalaCompiler = "3.6.2"
+val usedScalaCompiler = "3.7.0"
 val usedTastyRelease = usedScalaCompiler
 val scala2Version = "2.13.16"
 
@@ -131,7 +131,8 @@ lazy val tastyQuery =
         )
       },
 
-      tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
+      // Temporarily disabled until we have a published version of tasty-query that can handle 3.7.x.
+      // tastyMiMaPreviousArtifacts := mimaPreviousArtifacts.value,
       tastyMiMaTastyQueryVersionOverride := Some("1.5.0"),
       tastyMiMaConfig ~= { prev =>
         import tastymima.intf._

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.internal.util.ManagedLogger
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
-val usedScalaCompiler = "3.7.0"
+val usedScalaCompiler = "3.7.1"
 val usedTastyRelease = usedScalaCompiler
 val scala2Version = "2.13.16"
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 val usedScalaCompiler = "3.6.2"
 val usedTastyRelease = usedScalaCompiler
-val scala2Version = "2.13.14"
+val scala2Version = "2.13.16"
 
 val SourceDeps = config("sourcedeps").hide
 
@@ -126,6 +126,8 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
+          // val in a private class; no issue
+          ProblemFilters.exclude[IncompatibleResultTypeProblem]("tastyquery.reader.tasties.TreeUnpickler#Caches.declaredTopLevelClasses"),
         )
       },
 
@@ -162,6 +164,13 @@ lazy val tastyQuery =
       scalaJSUseMainModuleInitializer := true,
       scalaJSLinkerConfig ~= (_.withModuleKind(ModuleKind.CommonJSModule)),
       jsEnv := new NodeJSEnv(NodeJSEnv.Config().withArgs(List("--enable-source-maps"))),
+
+      /* sbt-version-policy seems to think that the scalajs-scalalib is versioned
+       * according to the "strict" policy, although the pom files declare "semver-spec".
+       * We force it to "always" so that it does not report false positives.
+       * We trust Scala.js core to never break backward compatibility anyway.
+       */
+      libraryDependencySchemes += "org.scala-js" % "scalajs-scalalib_2.13" % "always",
     )
 
 def extractRTJar(targetRTJar: File): Unit = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.16.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.19.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.4")
 

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileParser.scala
@@ -132,7 +132,7 @@ private[reader] object ClassfileParser {
         .use(ClassfileReader.readAnnotation(Set(annot.ScalaLongSignature, annot.ScalaSignature)))
         .getOrElse(failNoAnnot())
 
-    val sigBytes = scalaSigAnnotation.tpe match {
+    val sigBytes = (scalaSigAnnotation.tpe: @unchecked) match {
       case annot.ScalaSignature =>
         val bytesArg = scalaSigAnnotation.values.head._2.asInstanceOf[AnnotationValue.Const]
         pool.sigbytes(bytesArg.valueIdx)

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -31,9 +31,9 @@ private[pickles] class PickleReader {
   private var frozenSymbols: Boolean = false
 
   /** The map from created local symbols to the address of their info, until it gets read. */
-  private val localSymbolInfoRefs = mutable.AnyRefMap.empty[TermOrTypeSymbol, Int]
+  private val localSymbolInfoRefs = mutable.HashMap.empty[TermOrTypeSymbol, Int]
 
-  private val localClassGivenSelfTypeRefs = mutable.AnyRefMap.empty[ClassSymbol, Int]
+  private val localClassGivenSelfTypeRefs = mutable.HashMap.empty[ClassSymbol, Int]
 
   final class Structure(using val myEntries: Entries, val myIndex: Index):
     def allRegisteredSymbols: Iterator[TermOrTypeSymbol] =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -42,7 +42,7 @@ private[reader] object Unpickler {
       }
 
       // Read the annotations to give to the symbols we read
-      val annotationMap = mutable.AnyRefMap.empty[TermOrTypeSymbol, List[Annotation]]
+      val annotationMap = mutable.HashMap.empty[TermOrTypeSymbol, List[Annotation]]
       index.loopWithIndices { (offset, i) =>
         if reader.isSymbolAnnotationEntry(i) then
           pkl.unsafeFork(offset) {

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
@@ -296,7 +296,7 @@ private[tasties] object TastyFormat:
     * compatibility, but remains backwards compatible, with all
     * preceeding `MinorVersion`.
     */
-  final val MinorVersion: Int = 6
+  final val MinorVersion: Int = 7
 
   /** Natural Number. The `ExperimentalVersion` allows for
     * experimentation with changes to TASTy without committing

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -1806,7 +1806,7 @@ private[tasties] object TreeUnpickler {
       *
       * This is used in `readWithin` to resolve top-level class references without a Context.
       */
-    val declaredTopLevelClasses = mutable.AnyRefMap.empty[(PackageSymbol, TypeName), ClassSymbol]
+    val declaredTopLevelClasses = mutable.HashMap.empty[(PackageSymbol, TypeName), ClassSymbol]
 
     def hasSymbolAt(addr: Addr): Boolean = localSymbols.contains(addr)
 

--- a/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/PrintersTest.scala
@@ -229,7 +229,7 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowBasicMember(
       MatchTypeClass,
       typeName("MTWithBind"),
-      "type MTWithBind[X] <: t = X match { case List[t] => t }"
+      "type MTWithBind[X] = X match { case List[t] => t }"
     )
   }
 
@@ -315,7 +315,7 @@ class PrintersTest extends UnrestrictedUnpicklingSuite:
     testShowMultilineMember(
       MatchTypeClass,
       typeName("MTWithBind"),
-      """type MTWithBind[X] <: t = X match {
+      """type MTWithBind[X] = X match {
         |  case List[t] => t
         |}""".stripMargin
     )


### PR DESCRIPTION
Upgrades to Scala 3.7.0 and 2.13.16 for Scala 2 tests. Also upgrades Scala.js to 1.19.0 to match the compiler upgrade in https://github.com/scala/scala3/pull/23026.