### PR TITLE
Use ubuntu-latest in the 'release' CI job, like in 'scala'.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["*"]
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.0.2
         with:


### PR DESCRIPTION
The previous version was retired.