### PR TITLE
Upgrade to sbt 1.11.3 and sbt-ci-release 1.11.0.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.19.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.10")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.0")
 addSbtPlugin("ch.epfl.scala"  % "sbt-version-policy" % "2.1.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.3.0")


### PR DESCRIPTION
This is necessary to publish to the new Maven Central Portal.