### PR TITLE
Re-enable `-source:future`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val strictCompileSettings = Seq(
     "-Yexplicit-nulls",
     "-Werror",
     "-Wsafe-init",
-    // "-source:future",
+    "-source:future",
   ),
 )
 

--- a/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
+++ b/tasty-query/js/src/main/scala/tastyquery/nodejs/ClasspathLoaders.scala
@@ -82,7 +82,7 @@ object ClasspathLoaders:
     for allEntries <- allEntriesFuture yield classpath.lazyZip(allEntries).map(makeEntry(_, _))
   end read
 
-  private def fromDirectory(dir: String, relPath: String)(implicit ec: ExecutionContext): Future[Seq[FileContent]] =
+  private def fromDirectory(dir: String, relPath: String)(using ec: ExecutionContext): Future[Seq[FileContent]] =
     cbFuture[js.Array[Dirent]](readdir(dir, ReadDirOpt, _)).flatMap { entries =>
       val (dirs, files) = entries.toSeq.partition(_.isDirectory())
 
@@ -119,7 +119,7 @@ object ClasspathLoaders:
   end fromJarFile
 
   private def loadFromZip(jarPath: String, obj: JSZip.JSZip)(
-    implicit ec: ExecutionContext
+    using ec: ExecutionContext
   ): Future[Iterator[FileContent]] =
     val entries = obj.files.valuesIterator
       .filter(e => isClassOrTasty(e.name) && !e.dir)

--- a/tasty-query/js/src/main/scala/tastyquery/nodejs/NodeFS.scala
+++ b/tasty-query/js/src/main/scala/tastyquery/nodejs/NodeFS.scala
@@ -15,10 +15,8 @@ private[nodejs] object NodeFS {
     def cb(err: js.Error, v: A): Unit = {
       import js.DynamicImplicits.truthValue
 
-      if (err.asInstanceOf[js.Dynamic])
-        promise.failure(new js.JavaScriptException(err))
-      else
-        promise.success(v)
+      if err.asInstanceOf[js.Dynamic] then promise.failure(new js.JavaScriptException(err))
+      else promise.success(v)
     }
 
     op(cb(_, _))

--- a/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
+++ b/tasty-query/jvm/src/main/scala/tastyquery/jdk/ClasspathLoaders.scala
@@ -53,7 +53,7 @@ object ClasspathLoaders {
 
     def classAndPackage(binaryName: String): (String, String) = {
       val lastSep = binaryName.lastIndexOf('.')
-      if (lastSep == -1) ("", binaryName)
+      if lastSep == -1 then ("", binaryName)
       else
         import scala.language.unsafeNulls
         val packageName = binaryName.substring(0, lastSep)

--- a/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
@@ -84,7 +84,7 @@ object Constants {
     }
 
     def booleanValue: Boolean =
-      if (tag == BooleanTag) value.asInstanceOf[Boolean]
+      if tag == BooleanTag then value.asInstanceOf[Boolean]
       else throw new Error("value " + value + " is not a boolean")
 
     def byteValue: Byte = tag match {

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -795,8 +795,8 @@ object Symbols {
           var tparams = cls.typeParams
           var args = base.args
           var idx = 0
-          while (tparams.nonEmpty && args.nonEmpty) {
-            if (tparams.head.eq(this))
+          while tparams.nonEmpty && args.nonEmpty do {
+            if tparams.head.eq(this) then
               return Some(args.head match {
                 case _: WildcardTypeArg if !widenAbstract => TypeRef(pre, this)
                 case arg                                  => arg
@@ -811,9 +811,9 @@ object Symbols {
           None
 
         case None =>
-          /*if (pre.termSymbol.isPackage) argForParam(pre.select(nme.PACKAGE))
+          /*if pre.termSymbol.isPackage then argForParam(pre.select(nme.PACKAGE))
           else*/
-          if (pre.isExactlyNothing) Some(pre)
+          if pre.isExactlyNothing then Some(pre)
           else None
       }
     end argForParam

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeMaps.scala
@@ -198,7 +198,7 @@ private[tastyquery] object TypeMaps {
                */
               atVariance(variance * tparams.head.variance.sign)(this(arg: TypeOrWildcard))
           val otherArgs1 = mapArgs(otherArgs, tparams.tail)
-          if ((arg1 eq arg) && (otherArgs1 eq otherArgs)) args
+          if (arg1 eq arg) && (otherArgs1 eq otherArgs) then args
           else arg1 :: otherArgs1
         case nil =>
           nil
@@ -225,9 +225,9 @@ private[tastyquery] object TypeMaps {
   abstract class ApproximatingTypeMap(using Context) extends NormalizingTypeMap { thisMap =>
 
     protected def range(lo: Type, hi: Type): Type =
-      if (variance > 0) hi
-      else if (variance < 0) lo
-      else if (lo `eq` hi) lo
+      if variance > 0 then hi
+      else if variance < 0 then lo
+      else if lo `eq` hi then lo
       else Range(lower(lo), upper(hi))
 
     protected def emptyRange: Type = range(defn.NothingType, defn.AnyType)
@@ -311,7 +311,7 @@ private[tastyquery] object TypeMaps {
       * @pre   the (upper bound of) prefix `pre` has a member named `tp.name`.
       */
     override protected def derivedSelect(tp: NamedType, pre: Type): Type =
-      if (pre eq tp.prefix) tp
+      if pre eq tp.prefix then tp
       else
         pre match {
           case Range(preLo, preHi) =>
@@ -335,18 +335,18 @@ private[tastyquery] object TypeMaps {
         }
 
     /*override protected def derivedRefinedType(tp: RefinedType, parent: Type, info: Type): Type =
-      if ((parent eq tp.parent) && (info eq tp.refinedInfo)) tp
+      if (parent eq tp.parent) && (info eq tp.refinedInfo) then tp
       else parent match {
         case Range(parentLo, parentHi) =>
           range(derivedRefinedType(tp, parentLo, info), derivedRefinedType(tp, parentHi, info))
         case _ =>
           def propagate(lo: Type, hi: Type) =
             range(derivedRefinedType(tp, parent, lo), derivedRefinedType(tp, parent, hi))
-          if (parent.isExactlyNothing) parent
+          if parent.isExactlyNothing then parent
           else info match {
             case Range(infoLo: TypeBounds, infoHi: TypeBounds) =>
               assert(variance == 0)
-              if (!infoLo.isTypeAlias && !infoHi.isTypeAlias) propagate(infoLo, infoHi)
+              if !infoLo.isTypeAlias && !infoHi.isTypeAlias then propagate(infoLo, infoHi)
               else range(defn.NothingType, parent)
             case Range(infoLo, infoHi) =>
               propagate(infoLo, infoHi)
@@ -356,18 +356,18 @@ private[tastyquery] object TypeMaps {
       }*/
 
     /*override protected def derivedRecType(tp: RecType, parent: Type): Type =
-      if (parent eq tp.parent) tp
+      if parent eq tp.parent then tp
       else parent match {
         case Range(lo, hi) => range(tp.rebind(lo), tp.rebind(hi))
         case _ => tp.rebind(parent)
       }*/
 
     override protected def derivedTypeAlias(tp: TypeAlias, alias: Type): TypeBounds =
-      if (alias eq tp.alias) tp
+      if alias eq tp.alias then tp
       else
         alias match {
           case Range(lo, hi) =>
-            if (variance > 0) AbstractTypeBounds(lo, hi)
+            if variance > 0 then AbstractTypeBounds(lo, hi)
             else TypeAlias(range(lo, hi))
           case _ => tp.derivedTypeAlias(alias)
         }
@@ -387,7 +387,7 @@ private[tastyquery] object TypeMaps {
       else tp.derivedWildcardTypeArg(bounds)
 
     /*override protected def derivedSuperType(tp: SuperType, thistp: Type, supertp: Type): Type =
-      if (isRange(thistp) || isRange(supertp)) emptyRange
+      if isRange(thistp) || isRange(supertp) then emptyRange
       else tp.derivedSuperType(thistp, supertp)*/
 
     override protected def derivedAppliedType(tp: AppliedType, tycon: Type, args: List[TypeOrWildcard]): Type =
@@ -416,9 +416,9 @@ private[tastyquery] object TypeMaps {
             def distributeArgs(args: List[TypeOrWildcard], tparams: List[TypeConstructorParam]): Boolean = args match {
               case Range(lo, hi) :: args1 =>
                 val v = tparams.head.variance.sign
-                if (v == 0) false
+                if v == 0 then false
                 else {
-                  if (v > 0) { loBuf += lo; hiBuf += hi }
+                  if v > 0 then { loBuf += lo; hiBuf += hi }
                   else { loBuf += hi; hiBuf += lo }
                   distributeArgs(args1, tparams.tail)
                 }
@@ -429,7 +429,7 @@ private[tastyquery] object TypeMaps {
               case Nil =>
                 true
             }
-            if (distributeArgs(args, tp.tyconTypeParams))
+            if distributeArgs(args, tp.tyconTypeParams) then
               range(tp.derivedAppliedType(tycon, loBuf.toList), tp.derivedAppliedType(tycon, hiBuf.toList))
             else if tycon.isLambdaSub || args.exists(isRangeOfNonTermTypes) then range(defn.NothingType, defn.AnyType)
             else
@@ -443,11 +443,11 @@ private[tastyquery] object TypeMaps {
       case _             => false
 
     override protected def derivedAndType(tp: AndType, tp1: Type, tp2: Type): Type =
-      if (isRange(tp1) || isRange(tp2)) range(lower(tp1) & lower(tp2), upper(tp1) & upper(tp2))
+      if isRange(tp1) || isRange(tp2) then range(lower(tp1) & lower(tp2), upper(tp1) & upper(tp2))
       else tp.derivedAndType(tp1, tp2)
 
     override protected def derivedOrType(tp: OrType, tp1: Type, tp2: Type): Type =
-      if (isRange(tp1) || isRange(tp2)) range(lower(tp1) | lower(tp2), upper(tp1) | upper(tp2))
+      if isRange(tp1) || isRange(tp2) then range(lower(tp1) | lower(tp2), upper(tp1) | upper(tp2))
       else tp.derivedOrType(tp1, tp2)
 
     /*override protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Annotation): Type =
@@ -455,7 +455,7 @@ private[tastyquery] object TypeMaps {
         case Range(lo, hi) =>
           range(tp.derivedAnnotatedType(lo, annot), tp.derivedAnnotatedType(hi, annot))
         case _ =>
-          if (underlying.isExactlyNothing) underlying
+          if underlying.isExactlyNothing then underlying
           else tp.derivedAnnotatedType(underlying, annot)
       }*/
 

--- a/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/TypeOps.scala
@@ -47,7 +47,7 @@ private[tastyquery] object TypeOps:
               case cls: PackageSymbol =>
                 origTp
               case cls: ClassSymbol =>
-                if (thiscls.isSubClass(cls) && pre.baseType(thiscls).isDefined)
+                if thiscls.isSubClass(cls) && pre.baseType(thiscls).isDefined then
                   /*if (variance <= 0 && !isLegalPrefix(pre)) // isLegalPrefix always true?
                   if (variance < 0) {
                     approximated = true

--- a/tasty-query/shared/src/main/scala/tastyquery/Types.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Types.scala
@@ -605,8 +605,7 @@ object Types {
     final def appliedTo(args: List[TypeOrWildcard])(using Context): Type = {
       val typParams = this.typeParams
       val dealiased = this.dealias
-      if (args.isEmpty)
-        this
+      if args.isEmpty then this
       else
         dealiased match {
           case dealiased: TypeLambda =>
@@ -621,7 +620,7 @@ object Types {
     }
 
     private[tastyquery] final def applyIfParameterized(args: List[TypeOrWildcard])(using Context): Type =
-      if (args.nonEmpty /*typeParams.nonEmpty*/ ) appliedTo(args) else this
+      if args.nonEmpty /*typeParams.nonEmpty*/ then appliedTo(args) else this
 
     /** Substitute class type params by some other types. */
     private[tastyquery] final def substClassTypeParams(from: List[ClassTypeParamSymbol], to: List[TypeOrWildcard])(
@@ -958,8 +957,8 @@ object Types {
       *    T#A --> B    if A is bound to an alias `= B` in T
       */
     private[tastyquery] final def normalizedDerivedSelect(prefix: Type)(using Context): Type =
-      if (prefix eq this.prefix) this
-      else if (prefix.isExactlyNothing) prefix
+      if prefix eq this.prefix then this
+      else if prefix.isExactlyNothing then prefix
       else normalizedDerivedSelectImpl(prefix)
 
     protected def normalizedDerivedSelectImpl(prefix: Type)(using Context): Type
@@ -1526,7 +1525,7 @@ object Types {
     end resolveMatchingMember
 
     private[tastyquery] final def derivedAppliedType(tycon: Type, args: List[TypeOrWildcard]): AppliedType =
-      if ((tycon eq this.tycon) && (args eq this.args)) this
+      if (tycon eq this.tycon) && (args eq this.args) then this
       else AppliedType(tycon, args)
 
     private[tastyquery] final def map(tyconOp: Type => Type, argsOp: TypeOrWildcard => TypeOrWildcard): AppliedType =
@@ -1556,7 +1555,7 @@ object Types {
     override def underlying(using Context): Type = resultType
 
     private[tastyquery] final def derivedByNameType(resultType: Type): ByNameType =
-      if (resultType eq this.resultType) this else ByNameType(resultType)
+      if resultType eq this.resultType then this else ByNameType(resultType)
 
     override def toString(): String = s"ByNameType($resultType)"
   }
@@ -2011,7 +2010,7 @@ object Types {
     override def underlying(using Context): Type = typ
 
     private[tastyquery] final def derivedAnnotatedType(typ: Type, annotation: Annotation): AnnotatedType =
-      if ((typ eq this.typ) && (annotation eq this.annotation)) this
+      if (typ eq this.typ) && (annotation eq this.annotation) then this
       else AnnotatedType(typ, annotation)
 
     override def toString(): String = s"AnnotatedType($typ, $annotation)"
@@ -2047,7 +2046,7 @@ object Types {
       refinedName: TypeName,
       refinedBounds: TypeBounds
     ): Type =
-      if ((parent eq this.parent) && (refinedName eq this.refinedName) && (refinedBounds eq this.refinedBounds)) this
+      if (parent eq this.parent) && (refinedName eq this.refinedName) && (refinedBounds eq this.refinedBounds) then this
       else TypeRefinement(parent, refinedName, refinedBounds)
     end derivedTypeRefinement
 
@@ -2124,7 +2123,7 @@ object Types {
       refinedName: UnsignedTermName,
       refinedType: TypeOrMethodic
     ): Type =
-      if ((parent eq this.parent) && (refinedName eq this.refinedName) && (refinedType eq this.refinedType)) this
+      if (parent eq this.parent) && (refinedName eq this.refinedName) && (refinedType eq this.refinedType) then this
       else TermRefinement(parent, isStable, refinedName, refinedType)
 
     override def toString(): String = s"TermRefinement($parent, $refinedName, $refinedType)"
@@ -2279,7 +2278,7 @@ object Types {
 
     /** The non-alias type bounds type with given bounds */
     private[tastyquery] def derivedTypeBounds(low: Type, high: Type): TypeBounds =
-      if ((low eq this.low) && (high eq this.high)) this
+      if (low eq this.low) && (high eq this.high) then this
       else AbstractTypeBounds(low, high)
 
     final def contains(tp: TypeOrWildcard)(using Context): Boolean = tp match
@@ -2340,7 +2339,7 @@ object Types {
     override def underlying(using Context): Type = tpe
 
     private[tastyquery] def derivedSkolemType(tpe: Type): SkolemType =
-      if (tpe eq this.tpe) this else SkolemType(tpe)
+      if tpe eq this.tpe then this else SkolemType(tpe)
 
     override def toString: String = s"SkolemType@$debugID($tpe)"
 
@@ -2416,7 +2415,7 @@ object Types {
 
   object OrType {
     private[tastyquery] def make(first: Type, second: Type): Type =
-      if (first eq second) first
+      if first eq second then first
       else OrType(first, second)
   }
 
@@ -2436,7 +2435,7 @@ object Types {
     end resolveMatchingMember
 
     private[tastyquery] def derivedAndType(first: Type, second: Type): Type =
-      if ((first eq this.first) && (second eq this.second)) this
+      if (first eq this.first) && (second eq this.second) then this
       else AndType.make(first, second)
 
     private[tastyquery] def parts: List[Type] =

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/classfiles/ClassfileReader.scala
@@ -189,8 +189,7 @@ private[reader] object ClassfileReader {
     }
 
     def apply(index: Index): ConstantInfo = {
-      if (index < 1 || index >= infos.length)
-        throw ClassfileFormatException(s"Invalid constant pool index $index")
+      if index < 1 || index >= infos.length then throw ClassfileFormatException(s"Invalid constant pool index $index")
       infos(index)
     }
 
@@ -491,7 +490,7 @@ private[reader] object ClassfileReader {
 
   private inline def loop(times: Int)(inline op: => Unit): Unit = {
     var i = 0
-    while (i < times) {
+    while i < times do {
       op
       i += 1
     }
@@ -500,7 +499,7 @@ private[reader] object ClassfileReader {
   private inline def accumulateAnnotValues[A: ClassTag](size: Int)(inline op: => A): IArray[A] = {
     val arr = new Array[A](size)
     var i = 0
-    while (i < size) {
+    while i < size do {
       arr(i) = op
       i += 1
     }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/ByteCodecs.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/ByteCodecs.scala
@@ -21,12 +21,12 @@ private[reader] object ByteCodecs {
     var i = 0
     val srclen = src.length
     var j = 0
-    while (i < srclen) {
+    while i < srclen do {
       val in: Int = src(i) & 0xff
-      if (in == 0xc0 && (src(i + 1) & 0xff) == 0x80) {
+      if in == 0xc0 && (src(i + 1) & 0xff) == 0x80 then {
         src(j) = 0x7f
         i += 2
-      } else if (in == 0) {
+      } else if in == 0 then {
         src(j) = 0x7f
         i += 1
       } else {
@@ -43,7 +43,7 @@ private[reader] object ByteCodecs {
     var i = 0
     var j = 0
     val dstlen = (srclen * 7 + 7) / 8
-    while (i + 7 < srclen) {
+    while i + 7 < srclen do {
       var out: Int = src(i).toInt
       var in: Byte = src(i + 1)
       src(j) = (out | (in & 0x01) << 7).toByte
@@ -68,29 +68,29 @@ private[reader] object ByteCodecs {
       i += 8
       j += 7
     }
-    if (i < srclen) {
+    if i < srclen then {
       var out: Int = src(i).toInt
-      if (i + 1 < srclen) {
+      if i + 1 < srclen then {
         var in: Byte = src(i + 1)
         src(j) = (out | (in & 0x01) << 7).toByte; j += 1
         out = in >>> 1
-        if (i + 2 < srclen) {
+        if i + 2 < srclen then {
           in = src(i + 2)
           src(j) = (out | (in & 0x03) << 6).toByte; j += 1
           out = in >>> 2
-          if (i + 3 < srclen) {
+          if i + 3 < srclen then {
             in = src(i + 3)
             src(j) = (out | (in & 0x07) << 5).toByte; j += 1
             out = in >>> 3
-            if (i + 4 < srclen) {
+            if i + 4 < srclen then {
               in = src(i + 4)
               src(j) = (out | (in & 0x0f) << 4).toByte; j += 1
               out = in >>> 4
-              if (i + 5 < srclen) {
+              if i + 5 < srclen then {
                 in = src(i + 5)
                 src(j) = (out | (in & 0x1f) << 3).toByte; j += 1
                 out = in >>> 5
-                if (i + 6 < srclen) {
+                if i + 6 < srclen then {
                   in = src(i + 6)
                   src(j) = (out | (in & 0x3f) << 2).toByte; j += 1
                   out = in >>> 6
@@ -100,7 +100,7 @@ private[reader] object ByteCodecs {
           }
         }
       }
-      if (j < dstlen) src(j) = out.toByte
+      if j < dstlen then src(j) = out.toByte
     }
     dstlen
   }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleBuffer.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleBuffer.scala
@@ -37,7 +37,7 @@ private[pickles] class PickleBuffer(val bytes: IArray[Byte], from: Int) {
   def readLong(len: Int): Long = {
     var x = 0L
     var i = 0
-    while (i < len) {
+    while i < len do {
       x = (x << 8) + (readByte() & 0xff)
       i += 1
     }
@@ -73,13 +73,13 @@ private[pickles] class PickleBuffer(val bytes: IArray[Byte], from: Int) {
     *  Concatenate results into a list.
     */
   def until[T](end: Int, op: () => T): List[T] =
-    if (readIndex == end) List() else op() :: until(end, op)
+    if readIndex == end then List() else op() :: until(end, op)
 
   /** Perform operation `op` the number of
     *  times specified.  Concatenate the results into a list.
     */
   def times[T](n: Int, op: () => T): List[T] =
-    if (n == 0) List() else op() :: times(n - 1, op)
+    if n == 0 then List() else op() :: times(n - 1, op)
 
   /** Pickle = majorVersion_Nat minorVersion_Nat nbEntries_Nat {Entry}
     *  Entry  = type_Nat length_Nat [actual entries]

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala
@@ -66,7 +66,7 @@ private[pickles] class PickleReader {
   private def checkVersion()(using PklStream): Unit = {
     val major = pkl.readNat()
     val minor = pkl.readNat()
-    if (major != MajorVersion || minor > MinorVersion)
+    if major != MajorVersion || minor > MinorVersion then
       throw Scala2PickleFormatException(
         s"Bad pickles version, expected: $MajorVersion.$MinorVersion, found: $major.$minor"
       )
@@ -137,7 +137,7 @@ private[pickles] class PickleReader {
 
     def readExtSymbol(): MaybeExternalSymbol =
       val name = decodeName(readNameRef())
-      val owner = if (atEnd) rctx.RootPackage else readMaybeExternalSymbolRef()
+      val owner = if atEnd then rctx.RootPackage else readMaybeExternalSymbolRef()
       name match
         case nme.RootName | nme.UserLandRootPackageName =>
           rctx.RootPackage
@@ -190,7 +190,7 @@ private[pickles] class PickleReader {
 
     val (privateWithin, infoRef) = {
       val ref = pkl.readNat()
-      if (!isSymbolRef(ref)) (None, ref)
+      if !isSymbolRef(ref) then (None, ref)
       else {
         val pw = readLocalSymbolAt(ref) match
           case pw: DeclaringSymbol => pw
@@ -729,7 +729,7 @@ private[pickles] class PickleReader {
   private def readTypeParams()(using ReaderContext, PklStream, Entries, Index): List[ClassTypeParamSymbol] = {
     val tag = pkl.readByte()
     val end = pkl.readEnd()
-    if (tag == POLYtpe) {
+    if tag == POLYtpe then {
       val unusedRestperef = pkl.readNat()
       pkl.until(end, () => readLocalSymbolRef().asInstanceOf[ClassTypeParamSymbol])
     } else Nil

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/Unpickler.scala
@@ -20,7 +20,7 @@ private[reader] object Unpickler {
 
       // Read the symbol themselves
       index.loopWithIndices { (offset, i) =>
-        if (reader.missingSymbolEntry(i)) {
+        if reader.missingSymbolEntry(i) then {
           pkl.unsafeFork(offset) {
             reader.readMaybeExternalSymbolAt(i)
           }
@@ -32,8 +32,8 @@ private[reader] object Unpickler {
 
       // Read children after reading the symbols themselves, fix for SI-3951
       index.loopWithIndices { (offset, i) =>
-        if (reader.missingEntry(i)) {
-          if (reader.isChildrenEntry(i)) {
+        if reader.missingEntry(i) then {
+          if reader.isChildrenEntry(i) then {
             pkl.unsafeFork(offset) {
               reader.readChildren()
             }

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/PositionUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/PositionUnpickler.scala
@@ -27,7 +27,7 @@ private[reader] class PositionUnpickler(reader: TastyReader, nameAtRef: TastyUnp
   private var isDefined = false
 
   def ensureDefined(): Unit =
-    if (!isDefined) {
+    if !isDefined then {
       // Read the line sizes array; we will attach it to the first SOURCE directive we encounter
 
       val lines = readNat()

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
@@ -125,10 +125,8 @@ private[reader] class TastyUnpickler(reader: TastyReader) {
 
   private def readParamSig(): ParamSig = {
     val ref = readInt()
-    if (ref < 0)
-      ParamSig.TypeLen(ref.abs)
-    else
-      ParamSig.Term(nameAtRef.signatureName(new NameRef(ref)))
+    if ref < 0 then ParamSig.TypeLen(ref.abs)
+    else ParamSig.Term(nameAtRef.signatureName(new NameRef(ref)))
   }
 
   private def readNameContents(): nameAtRef.EitherName = {
@@ -152,13 +150,13 @@ private[reader] class TastyUnpickler(reader: TastyReader) {
         val separator = readName().toString
         val num = readNat()
         val originals = reader.until(end)(readUnsignedName())
-        val original = if (originals.isEmpty) nme.EmptyTermName else originals.head
+        val original = if originals.isEmpty then nme.EmptyTermName else originals.head
         new UniqueName(original, separator, num)
       case NameTags.DEFAULTGETTER =>
         new DefaultGetterName(readUnsignedName(), readNat())
       case NameTags.SIGNED | NameTags.TARGETSIGNED =>
         val original = readUnsignedName()
-        val target = if (tag == NameTags.TARGETSIGNED) readUnsignedName() else original
+        val target = if tag == NameTags.TARGETSIGNED then readUnsignedName() else original
         val result = readSignatureName()
         val paramsSig = reader.until(end)(readParamSig())
         val sig = Signature(paramsSig, result)
@@ -189,7 +187,7 @@ private[reader] class TastyUnpickler(reader: TastyReader) {
 
   locally {
     reader.until(readEnd())(nameAtRef.add(readNameContents()))
-    while (!isAtEnd) {
+    while !isAtEnd do {
       val secName = readString()
       val secEnd: Addr = readEnd()
       sectionReader(secName) = new TastyReader(bytes, currentAddr.index, secEnd.index, currentAddr.index)


### PR DESCRIPTION
Re-enables `-source:future` (which was disabled in #461) and fixes all warnings. There were four types of changes necessary:

1. Change `implicit` to `using`
2. Change `if (pred) ... else ...` to `if pred then ... else ...`
3. Change `while (pred) ...` to `while pred do ...`
4. Change `implicit def` conversions to instances of `Conversion`