### PR TITLE
Avoid `Any.hashCode`

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Constants.scala
@@ -180,7 +180,8 @@ object Constants {
       val seed = 17
       var h = seed
       h = mix(h, tag.##) // include tag in the hash, otherwise 0, 0d, 0L, 0f collide.
-      if tag != NullTag then h = mix(h, value.hashCode) // use hashCode instead of ## to correctly handle Float/Double
+      if tag != NullTag then
+        h = mix(h, java.util.Objects.hashCode(value)) // use hashCode instead of ## to correctly handle Float/Double
       finalizeHash(h, length = 2)
     }
 


### PR DESCRIPTION
Now that this produces a warning, use `Objects.hashCode` instead.