### PR TITLE
Do not eagerly create the scala.caps package

### DIFF
--- a/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Definitions.scala
@@ -32,7 +32,6 @@ final class Definitions private[tastyquery] (
   private val javaPackage = RootPackage.getPackageDeclOrCreate(nme.javaPackageName)
   val javaLangPackage = javaPackage.getPackageDeclOrCreate(nme.langPackageName)
   private[tastyquery] val javaLangInvokePackage = javaLangPackage.getPackageDeclOrCreate(termName("invoke"))
-  private val capsPackage = scalaPackage.getPackageDeclOrCreate(termName("caps"))
 
   private val scalaAnnotationPackage =
     scalaPackage.getPackageDeclOrCreate(termName("annotation"))
@@ -498,7 +497,24 @@ final class Definitions private[tastyquery] (
 
   lazy val ProductClass = scalaPackage.requiredClass("Product")
 
-  lazy val PureClass = capsPackage.requiredClass("Pure")
+  /** `scala.caps.Pure`, depending on the standard library on the classpath:
+    *   - Scala 3.0 and 3.1: `scala.caps` does not exist, so `None`
+    *   - Scala 3.2 to 3.6: `scala.caps` is an object and `Pure` a member of it
+    *   - Scala 3.7 and later: `scala.caps` is a package
+    */
+  private[tastyquery] lazy val PureClassOpt: Option[ClassSymbol] = withRestrictedContext {
+    def fromPackage = scalaPackage.getPackageDecl(termName("caps")).flatMap(_.getDecl(typeName("Pure")))
+    def fromObject = scalaPackage
+      .getDecl(termName("caps"))
+      .collect { case caps: TermSymbol => caps }
+      .flatMap(_.moduleClass)
+      .flatMap(_.getDecl(typeName("Pure")))
+    // Package first: `getDecl` loads the `caps` root, which asserts if a `caps` package already exists.
+    fromPackage.orElse(fromObject).map(_.asClass)
+  }
+
+  lazy val PureClass: ClassSymbol =
+    PureClassOpt.getOrElse(throw new NoSuchElementException("scala.caps.Pure is not on the classpath"))
 
   lazy val ErasedNothingClass = scalaRuntimePackage.requiredClass("Nothing$")
   lazy val ErasedBoxedUnitClass = scalaRuntimePackage.requiredClass("BoxedUnit")

--- a/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Erasure.scala
@@ -101,8 +101,10 @@ private[tastyquery] object Erasure:
          * This also work for [T <: Pure] `T & A` or `A & T`.
          * The root problem is described here: https://github.com/scala/scala3/issues/24113
          */
-        if tpe.first.dealias.classSymbol.contains(defn.PureClass) then preErase(tpe.second, keepUnit)
-        else if tpe.second.dealias.classSymbol.contains(defn.PureClass) then preErase(tpe.first, keepUnit)
+        if defn.PureClassOpt.exists(pure => tpe.first.dealias.classSymbol.contains(pure)) then
+          preErase(tpe.second, keepUnit)
+        else if defn.PureClassOpt.exists(pure => tpe.second.dealias.classSymbol.contains(pure)) then
+          preErase(tpe.first, keepUnit)
         else
           summon[SourceLanguage] match
             case SourceLanguage.Java =>


### PR DESCRIPTION
Fixes #474

The one thing missing here is test coverage. I decided that it is not worth to implement it as it will require us to either create a test source that is built using Scala <3.0, ..., 3.6> because afterwards it resulted in compilation error thus we can't recreate it without new module or some other hacks. Other way we could test it is to bundle one of <3.2, ..., 3.6> stdlibs and just try to read from it.

As mentioned in AI policy:
Implementation done by Fable 5.1, Comments revised and created by me left for the future contributors unless you don't want it.

Also it breaks MiMa because PureClass is now Option, release will require version bump I think ?