### PR TITLE
Implement Symbol.docComment returning docstring and its span

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ inThisBuild(Def.settings(
     Developer("sjrd", "Sébastien Doeraene", "sjrdoeraene@gmail.com", url("https://github.com/sjrd/")),
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r)
 ))
@@ -127,6 +127,8 @@ lazy val tastyQuery =
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core.*
         Seq(
+          // constructor of a class nested in a private[reader] object; no issue
+          ProblemFilters.exclude[DirectMissingMethodProblem]("tastyquery.reader.tasties.TastyUnpickler#TreeSectionUnpickler.this"),
         )
       },
 

--- a/tasty-query/shared/src/main/scala/tastyquery/DocComment.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/DocComment.scala
@@ -1,0 +1,20 @@
+package tastyquery
+
+import tastyquery.Spans.Span
+
+/** A documentation comment attached to a definition.
+  *
+  * @param raw
+  *   the comment verbatim, including its `/**` and `*/` delimiters
+  * @param span
+  *   the span of the comment in the source file of the documented symbol
+  */
+final class DocComment private[tastyquery] (val raw: String, private val span: Span):
+  /** The offset of the start of this comment. */
+  def startOffset: Int = span.start
+
+  /** The offset of the end of this comment. */
+  def endOffset: Int = span.end
+
+  override def toString(): String = s"DocComment($raw, $span)"
+end DocComment

--- a/tasty-query/shared/src/main/scala/tastyquery/Spans.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Spans.scala
@@ -167,6 +167,9 @@ private[tastyquery] object Spans {
   /** A synthetic zero-extent span that starts and ends at given `start`. */
   def Span(start: Int): Span = Span(start, start)
 
+  /** A span from its raw coordinates, as pickled in TASTy */
+  def spanFromCoord(coords: Long): Span = new Span(coords)
+
   /** A sentinel for a non-existing span */
   val NoSpan: Span = Span(1, 0)
 

--- a/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/Symbols.scala
@@ -78,6 +78,7 @@ object Symbols {
     private var myTree: Option[DefiningTreeType] = None
     private var myPrivateWithin: SingleAssign[Option[DeclaringSymbol]] = uninitializedSingleAssign
     private var myAnnotations: SingleAssign[List[Annotation]] = uninitializedSingleAssign
+    private var myDocComment: Option[DocComment] = None
 
     /** Checks that this `Symbol` has been completely initialized.
       *
@@ -132,6 +133,17 @@ object Symbols {
 
     final def annotations: List[Annotation] =
       getAssignedOnce(myAnnotations)(s"annotations of $this have not been initialized")
+
+    private[tastyquery] final def setDocComment(docComment: Option[DocComment]): this.type =
+      myDocComment = docComment
+      this
+
+    /** The documentation comment of this symbol, if any.
+      *
+      * Only symbols read from TASTy can have a documentation comment.
+      */
+    final def docComment: Option[DocComment] =
+      myDocComment
 
     protected final def privateWithin: Option[DeclaringSymbol] =
       getAssignedOnce(myPrivateWithin)(s"privateWithin of $this has not been initialized")

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/Loaders.scala
@@ -172,13 +172,10 @@ private[tastyquery] object Loaders {
     private def doLoadTasty(classData: ClassData)(using ReaderContext): Unit =
       val unpickler = TastyUnpickler(classData.readTastyFileBytes())
       val debugPath = classData.toString()
+      val posUnpickler = unpickler.unpickle(debugPath, new TastyUnpickler.PositionSectionUnpickler)
+      val commentUnpickler = unpickler.unpickle(debugPath, new TastyUnpickler.CommentSectionUnpickler)
       unpickler
-        .unpickle(
-          debugPath,
-          TastyUnpickler.TreeSectionUnpickler(
-            unpickler.unpickle(debugPath, new TastyUnpickler.PositionSectionUnpickler)
-          )
-        )
+        .unpickle(debugPath, TastyUnpickler.TreeSectionUnpickler(posUnpickler, commentUnpickler))
         .get
         .unpickle()
     end doLoadTasty

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/CommentUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/CommentUnpickler.scala
@@ -1,0 +1,26 @@
+package tastyquery.reader.tasties
+
+import tastyquery.DocComment
+import tastyquery.Spans.*
+
+import tastyquery.reader.UTF8Utils
+
+import TastyReader.Addr
+
+private[reader] class CommentUnpickler(reader: TastyReader) {
+  import reader.*
+
+  private val comments: Map[Addr, DocComment] =
+    val builder = Map.newBuilder[Addr, DocComment]
+    while !isAtEnd do
+      val addr = readAddr()
+      val length = readNat()
+      val start = currentAddr
+      goto(start + length)
+      val span = spanFromCoord(readLongInt())
+      builder += addr -> DocComment(UTF8Utils.decode(bytes, index(start), length), span)
+    builder.result()
+
+  def commentAt(addr: Addr): Option[DocComment] =
+    comments.get(addr)
+}

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyFormat.scala
@@ -270,7 +270,8 @@ import scala.annotation.switch
   *
   * Standard Section: "Comments" Comment*
   * ```none
-  *  Comment       = Length Bytes LongInt      // Raw comment's bytes encoded as UTF-8, followed by the comment's coordinates.
+  *  Comment       = Addr Length UTF8-CodePoint* LongInt // Address of the commented definition, raw comment's bytes
+  *                                                      // encoded as UTF-8, followed by the comment's coordinates.
   * ```
   * ************************************************************************************
   */

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TastyUnpickler.scala
@@ -18,14 +18,20 @@ private[reader] object TastyUnpickler {
     def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): R
   }
 
-  class TreeSectionUnpickler(posUnpickler: Option[PositionUnpickler]) extends SectionUnpickler[TreeUnpickler]("ASTs") {
+  class TreeSectionUnpickler(posUnpickler: Option[PositionUnpickler], commentUnpickler: Option[CommentUnpickler])
+      extends SectionUnpickler[TreeUnpickler]("ASTs") {
     def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): TreeUnpickler =
-      new TreeUnpickler(filename, reader, nameAtRef, posUnpickler)
+      new TreeUnpickler(filename, reader, nameAtRef, posUnpickler, commentUnpickler)
   }
 
   class PositionSectionUnpickler extends SectionUnpickler[PositionUnpickler]("Positions") {
     def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): PositionUnpickler =
       new PositionUnpickler(reader, nameAtRef)
+  }
+
+  class CommentSectionUnpickler extends SectionUnpickler[CommentUnpickler]("Comments") {
+    def unpickle(filename: String, reader: TastyReader, nameAtRef: NameTable)(using ReaderContext): CommentUnpickler =
+      new CommentUnpickler(reader)
   }
 
   final class NameTable {

--- a/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
+++ b/tasty-query/shared/src/main/scala/tastyquery/reader/tasties/TreeUnpickler.scala
@@ -36,13 +36,19 @@ private[tasties] class TreeUnpickler private (
   protected val reader: TastyReader,
   nameAtRef: NameTable,
   posUnpicklerOpt: Option[PositionUnpickler],
+  commentUnpicklerOpt: Option[CommentUnpickler],
   caches: TreeUnpickler.Caches
 )(using ReaderContext) {
   import TreeUnpickler.*
 
-  def this(filename: String, reader: TastyReader, nameAtRef: NameTable, posUnpicklerOpt: Option[PositionUnpickler])(
-    using ReaderContext
-  ) = this(filename, reader, nameAtRef, posUnpicklerOpt, new TreeUnpickler.Caches)
+  def this(
+    filename: String,
+    reader: TastyReader,
+    nameAtRef: NameTable,
+    posUnpicklerOpt: Option[PositionUnpickler],
+    commentUnpicklerOpt: Option[CommentUnpickler]
+  )(using ReaderContext) =
+    this(filename, reader, nameAtRef, posUnpicklerOpt, commentUnpicklerOpt, new TreeUnpickler.Caches)
 
   def unpickle(): Unit =
     @tailrec
@@ -100,6 +106,7 @@ private[tasties] class TreeUnpickler private (
             cls
           else TypeMemberSymbol.create(name, owner)
         caches.registerSym(start, sym)
+        sym.setDocComment(commentUnpicklerOpt.flatMap(_.commentAt(start)))
         readSymbolModifiers(sym, tag, end)
         reader.until(end)(createSymbols(owner = sym))
       case DEFDEF | VALDEF | PARAM =>
@@ -107,6 +114,7 @@ private[tasties] class TreeUnpickler private (
         val name = readUnsignedName()
         val sym = TermSymbol.create(name, owner)
         caches.registerSym(start, sym)
+        sym.setDocComment(commentUnpicklerOpt.flatMap(_.commentAt(start)))
         readSymbolModifiers(sym, tag, end)
         reader.until(end)(createSymbols(owner = sym))
       case TYPEPARAM =>
@@ -116,6 +124,7 @@ private[tasties] class TreeUnpickler private (
           if owner.isClass then ClassTypeParamSymbol.create(name, owner.asClass)
           else LocalTypeParamSymbol.create(name, owner)
         caches.registerSym(start, sym)
+        sym.setDocComment(commentUnpicklerOpt.flatMap(_.commentAt(start)))
         readSymbolModifiers(sym, tag, end)
         reader.until(end)(createSymbols(owner = sym))
       case BIND =>
@@ -226,7 +235,14 @@ private[tasties] class TreeUnpickler private (
       assert(!posUnpickler.hasSourceFileAt(reader.currentAddr), s"unexpected source file change $posErrorMsg")
 
   def forkAt(start: Addr): TreeUnpickler =
-    new TreeUnpickler(filename, reader.subReader(start, reader.endAddr), nameAtRef, posUnpicklerOpt, caches)
+    new TreeUnpickler(
+      filename,
+      reader.subReader(start, reader.endAddr),
+      nameAtRef,
+      posUnpicklerOpt,
+      commentUnpicklerOpt,
+      caches
+    )
 
   def fork: TreeUnpickler =
     forkAt(reader.currentAddr)

--- a/tasty-query/shared/src/test/scala/tastyquery/DocstringSuite.scala
+++ b/tasty-query/shared/src/test/scala/tastyquery/DocstringSuite.scala
@@ -1,0 +1,150 @@
+package tastyquery
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import tastyquery.Contexts.*
+import tastyquery.Names.*
+import tastyquery.Symbols.*
+
+import TestUtils.*
+
+class DocstringSuite extends UnrestrictedUnpicklingSuite {
+  def assertDocString(sym: Symbol, expected: String)(using munit.Location): Unit =
+    assertEquals(sym.docComment.map(_.raw), Some(expected), sym.toString)
+
+  def assertNoDocString(sym: Symbol)(using munit.Location): Unit =
+    assertEquals(sym.docComment, None, sym.toString)
+
+  def assertDocCommentPositionMatchesText(sym: Symbol)(using munit.Location): Unit =
+    val docComment = sym.docComment.get
+    val sourceFile = sym.tree.get.pos.sourceFile
+    val relPath = sourceFile.path.stripPrefix("test-sources/src/")
+    val code = tastyquery.testutil.TestPlatform.readResourceCodeFile(relPath)
+    assertEquals(code.slice(docComment.startOffset, docComment.endOffset), docComment.raw)
+
+  testWithContext("class-and-members") {
+    val Docstrings = ctx.findTopLevelClass("simple_trees.Docstrings")
+
+    assertDocString(
+      Docstrings,
+      """/** Doc of class Docstrings.
+        |  *
+        |  * @param ctorParam doc of ctorParam
+        |  */""".stripMargin
+    )
+
+    assertDocString(Docstrings.findNonOverloadedDecl(name"method"), "/** Doc of method. */")
+    assertDocString(Docstrings.findDecl(name"value"), "/** Doc of value. */")
+    assertDocString(Docstrings.findDecl(name"variable"), "/** Doc of variable. */")
+    assertDocString(Docstrings.findNonOverloadedDecl(name"variable_="), "/** Doc of variable. */")
+    assertDocString(Docstrings.findDecl(name"lazyValue"), "/** Doc of lazy value. */")
+    assertDocString(Docstrings.findDecl(tname"TypeMember"), "/** Doc of type member. */")
+    assertDocString(Docstrings.findDecl(tname"AbstractTypeMember"), "/** Doc of abstract type member. */")
+    assertDocString(Docstrings.findDecl(tname"NestedClass"), "/** Doc of nested class. */")
+    assertDocString(Docstrings.findDecl(name"NestedObject"), "/** Doc of nested object. */")
+    assertDocString(Docstrings.findDecl(moduleClassName("NestedObject")), "/** Doc of nested object. */")
+    assertDocString(Docstrings.findDecl(name"given_Ordering_Docstrings"), "/** Doc of given. */")
+    assertDocString(Docstrings.findDecl(name"withLocal"), "/** Doc of local. */")
+
+    assertNoDocString(Docstrings.findDecl(name"undocumented"))
+    assertNoDocString(Docstrings.findDecl(name"ctorParam"))
+    assertNoDocString(Docstrings.typeParams.head)
+
+    val method = Docstrings.findNonOverloadedDecl(name"method")
+    assertNoDocString(method.paramSymss.head.left.toOption.get.head)
+
+    val ctors = Docstrings.findAllOverloadedDecls(nme.Constructor)
+    assertEquals(ctors.map(_.docComment.map(_.raw)).toSet, Set(None, Some("/** Doc of secondary constructor. */")))
+  }
+
+  testWithContext("positions") {
+    val Docstrings = ctx.findTopLevelClass("simple_trees.Docstrings")
+    assertDocCommentPositionMatchesText(Docstrings)
+    assertDocCommentPositionMatchesText(Docstrings.findNonOverloadedDecl(name"method"))
+    assertDocCommentPositionMatchesText(Docstrings.findDecl(tname"NestedClass"))
+    assertDocCommentPositionMatchesText(ctx.findTopLevelModuleClass("simple_trees.Docstrings"))
+
+    val classDoc = Docstrings.docComment.get
+    val classDef = Docstrings.tree.get.pos
+    assert(classDoc.endOffset <= classDef.startOffset, clue((classDoc, classDef)))
+  }
+
+  testWithContext("companion-object") {
+    val DocstringsModule = ctx.findTopLevelModuleClass("simple_trees.Docstrings")
+    assertDocString(DocstringsModule, "/** Doc of object Docstrings. */")
+    assertDocString(DocstringsModule.moduleValue.get, "/** Doc of object Docstrings. */")
+    assertDocString(DocstringsModule.findDecl(name"objectMember"), "/** Doc of object member. */")
+  }
+
+  testWithContext("trait-enum-standalone-object") {
+    assertDocString(ctx.findTopLevelClass("simple_trees.DocstringsTrait"), "/** Doc of trait. */")
+
+    val DocstringsEnum = ctx.findTopLevelClass("simple_trees.DocstringsEnum")
+    assertDocString(DocstringsEnum, "/** Doc of enum. */")
+    val DocstringsEnumModule = ctx.findTopLevelModuleClass("simple_trees.DocstringsEnum")
+    assertDocString(DocstringsEnumModule.findDecl(name"Case1"), "/** Doc of enum case. */")
+    assertDocString(DocstringsEnumModule.findDecl(tname"Case2"), "/** Doc of parameterized enum case. */")
+    assertDocString(DocstringsEnumModule, "/** Doc of enum. */")
+    assertDocString(
+      DocstringsEnumModule.findNonOverloadedDecl(name"fromOrdinal"),
+      "/** Doc of parameterized enum case. */"
+    )
+
+    assertDocString(
+      ctx.findTopLevelModuleClass("simple_trees.DocstringsStandaloneObject"),
+      "/** Doc of standalone object. */"
+    )
+  }
+
+  testWithContext("no-docstrings-outside-tasty") {
+    val JavaDefined = ctx.findTopLevelClass("javadefined.JavaDefined")
+    assertNoDocString(JavaDefined)
+    for decl <- JavaDefined.declarations do assertNoDocString(decl)
+
+    val MacrosClass = ctx.findTopLevelModuleClass("scalatwo.Macros")
+    assertNoDocString(MacrosClass)
+    for decl <- MacrosClass.declarations do assertNoDocString(decl)
+
+    assertNoDocString(ctx.findPackage("javadefined"))
+  }
+
+  testWithContext("non-ascii") {
+    val Docstrings = ctx.findTopLevelClass("simple_trees.Docstrings")
+    val nonAscii = Docstrings.findDecl(name"nonAscii")
+    assertDocString(nonAscii, "/** Doc with non-ASCII: café — ünïcödé ✓ 日本語 */")
+    assertDocCommentPositionMatchesText(nonAscii)
+  }
+
+  testWithContext("case-class") {
+    val DocstringsCaseClass = ctx.findTopLevelClass("simple_trees.DocstringsCaseClass")
+    assertDocString(DocstringsCaseClass, "/** Doc of case class. */")
+    assertNoDocString(DocstringsCaseClass.findDecl(name"x"))
+    assertNoDocString(DocstringsCaseClass.findNonOverloadedDecl(name"copy"))
+    assertNoDocString(DocstringsCaseClass.findNonOverloadedDecl(name"_1"))
+
+    val DocstringsCaseClassModule = ctx.findTopLevelModuleClass("simple_trees.DocstringsCaseClass")
+    assertDocString(DocstringsCaseClassModule, "/** Doc of case class. */")
+    assertDocString(DocstringsCaseClassModule.moduleValue.get, "/** Doc of case class. */")
+    assertNoDocString(DocstringsCaseClassModule.findNonOverloadedDecl(name"apply"))
+    assertNoDocString(DocstringsCaseClassModule.findNonOverloadedDecl(name"unapply"))
+  }
+
+  testWithContext("top-level-definitions") {
+    val packageObject = ctx.findTopLevelModuleClass("simple_trees.DocstringsTopLevel$package")
+    assertNoDocString(packageObject)
+    assertDocString(packageObject.findDecl(name"docstringsTopLevelDef"), "/** Doc of top-level def. */")
+    assertDocString(packageObject.findDecl(name"docstringsTopLevelVal"), "/** Doc of top-level val. */")
+  }
+
+  testWithContext("local-definition") {
+    val Docstrings = ctx.findTopLevelClass("simple_trees.Docstrings")
+    val withLocal = Docstrings.findNonOverloadedDecl(name"withLocal")
+    val local = findLocalValDef(withLocal.tree.get, name"local")
+    assertDocString(local, "/** Doc of local value. */")
+  }
+
+  testWithContext("scala-3-standard-library") {
+    val ListClass = ctx.findTopLevelClass("scala.collection.immutable.List")
+    assert(ListClass.docComment.exists(_.raw.startsWith("/**")), clue(ListClass.docComment))
+  }
+}

--- a/test-sources/src/main/scala/simple_trees/Docstrings.scala
+++ b/test-sources/src/main/scala/simple_trees/Docstrings.scala
@@ -1,0 +1,70 @@
+package simple_trees
+
+/** Doc of class Docstrings.
+  *
+  * @param ctorParam doc of ctorParam
+  */
+class Docstrings[/** Doc of T. */ T](/** Doc of ctorParam. */ val ctorParam: Int):
+  /** Doc of secondary constructor. */
+  def this() = this(0)
+
+  /** Doc of method. */
+  def method(/** Doc of param. */ param: Int): Int = param
+
+  /** Doc of value. */
+  val value: Int = 1
+
+  /** Doc of variable. */
+  var variable: Int = 2
+
+  /** Doc of lazy value. */
+  lazy val lazyValue: Int = 3
+
+  /** Doc of type member. */
+  type TypeMember = Int
+
+  /** Doc of abstract type member. */
+  type AbstractTypeMember
+
+  /** Doc of nested class. */
+  class NestedClass
+
+  /** Doc of nested object. */
+  object NestedObject
+
+  /** Doc of given. */
+  given Ordering[Docstrings[?]] = Ordering.by(_.ctorParam)
+
+  def undocumented: Int = 4
+
+  /** Doc with non-ASCII: café — ünïcödé ✓ 日本語 */
+  def nonAscii: Int = 7
+
+  /** Doc of local. */
+  def withLocal: Int =
+    /** Doc of local value. */
+    val local = 5
+    local
+end Docstrings
+
+/** Doc of object Docstrings. */
+object Docstrings:
+  /** Doc of object member. */
+  def objectMember: Int = 6
+
+/** Doc of trait. */
+trait DocstringsTrait
+
+/** Doc of enum. */
+enum DocstringsEnum:
+  /** Doc of enum case. */
+  case Case1
+
+  /** Doc of parameterized enum case. */
+  case Case2(x: Int)
+
+/** Doc of standalone object. */
+object DocstringsStandaloneObject
+
+/** Doc of case class. */
+case class DocstringsCaseClass(/** Doc of case class param. */ x: Int)

--- a/test-sources/src/main/scala/simple_trees/DocstringsTopLevel.scala
+++ b/test-sources/src/main/scala/simple_trees/DocstringsTopLevel.scala
@@ -1,0 +1,7 @@
+package simple_trees
+
+/** Doc of top-level def. */
+def docstringsTopLevelDef: Int = 1
+
+/** Doc of top-level val. */
+val docstringsTopLevelVal: Int = 2


### PR DESCRIPTION
Original implementation in dotc:
```scala
package dotty.tools.dotc
package core.tasty

import core.Comments.Comment
import util.Spans.Span
import util.HashMap

import dotty.tools.tasty.{TastyReader, TastyBuffer}
import TastyBuffer.Addr

import java.nio.charset.StandardCharsets

class CommentUnpickler(reader: TastyReader) {
  import reader.*

  private[tasty] lazy val comments: HashMap[Addr, Comment] = {
    val comments = new HashMap[Addr, Comment]
    while (!isAtEnd) {
      val addr = readAddr()
      val rawComment = readUtf8()
      val position = new Span(readLongInt())
      comments(addr) = Comment(position, rawComment)
    }
    comments
  }

  def commentAt(addr: Addr): Option[Comment] =
    comments.get(addr)
}
```

We put it in immutable collection + we use SourcePosition vs Span, if you want it 1-1 aligned let me know, ~~but I think this is better shape~~ (Actually lets keep it aligned, SourceFile can be easily extracted via `Symbol.tree.get.pos.sourceFile`).
Written with help of Claude