### PR TITLE
Update sbt-release-ci to fix worktree support + bump sbt

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.22.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.4.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.0")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.12.1")
 addSbtPlugin("ch.epfl.scala"  % "sbt-version-policy" % "2.1.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.3.0")


### PR DESCRIPTION
While working on those issuses I found that worktree support is broken. It is because of sbt-release-ci plugin that tried to use JGit < 7.0 which does not support worktrees.